### PR TITLE
Raise NotImplementedError instead of NotImplemented

### DIFF
--- a/tuned-gui.py
+++ b/tuned-gui.py
@@ -844,7 +844,7 @@ class Base(object):
 			else:
 				self._cmd.execute(['systemctl', 'disable', 'tuned'])
 		else:
-			raise NotImplemented
+			raise NotImplementedError()
 
 	def execute_switch_tuned_admin_functions(self, switch, data):
 		self.is_admin = self.switch_tuned_admin_functions.get_active()

--- a/tuned/exports/interfaces.py
+++ b/tuned/exports/interfaces.py
@@ -4,18 +4,18 @@ class ExportableInterface(object):
 class ExporterInterface(object):
 	def export(self, method, in_signature, out_signature):
 		# to be overriden by concrete implementation
-		raise NotImplemented()
+		raise NotImplementedError()
 
 	def signal(self, method, out_signature):
 		# to be overriden by concrete implementation
-		raise NotImplemented()
+		raise NotImplementedError()
 
 	def send_signal(self, signal, *args, **kwargs):
 		# to be overriden by concrete implementation
-		raise NotImplemented()
+		raise NotImplementedError()
 
 	def start(self):
-		raise NotImplemented()
+		raise NotImplementedError()
 
 	def stop(self):
-		raise NotImplemented()
+		raise NotImplementedError()


### PR DESCRIPTION
NotImplemented is not an exception type. This patch makes some pylint
errors go away.