### PR TITLE
plugin_disk: Fix setting 'readahead_multiply'

### DIFF
--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -305,12 +305,12 @@ class DiskPlugin(hotplug.Plugin):
 				return
 			new_readahead = int(float(multiplier) * old_readahead)
 			self._storage.set(storage_key, old_readahead)
-			self._set_readahead(new_readahead, device)
+			self._set_readahead(new_readahead, device, False)
 		else:
 			old_readahead = self._storage.get(storage_key)
 			if old_readahead is None:
 				return
-			self._set_readahead(old_readahead, device)
+			self._set_readahead(old_readahead, device, False)
 			self._storage.unset(storage_key)
 
 	def _scheduler_quantum_file(self, device):


### PR DESCRIPTION
Provide the correct number of parameters to the '_set_readahead' method.
This fixes a traceback when setting the 'readahead_multiply' option.

I assume the 'sim' parameter to '_set_readahead' means 'simulated' (it
is handled in that sense), so we should set the value to False, because
we are actually enabling/disabling the tunning here.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>