### PR TITLE
plugin_disk: Mark _device_is_supported as a classmethod

### DIFF
--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -33,6 +33,7 @@ class DiskPlugin(hotplug.Plugin):
 		self._assigned_devices = set()
 		self._free_devices = self._devices.copy()
 
+	@classmethod
 	def _device_is_supported(cls, device):
 		return  device.device_type == "disk" and \
 			device.attributes.get("removable", None) == "0" and \


### PR DESCRIPTION
This fixes a pylint error.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>