### PR TITLE
plugin_scsi_host: Mark _device_is_supported as a classmethod

### DIFF
--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -28,6 +28,7 @@ class DiskPlugin(hotplug.Plugin):
 		self._assigned_devices = set()
 		self._free_devices = self._devices.copy()
 
+	@classmethod
 	def _device_is_supported(cls, device):
 		return  device.device_type == "scsi_host"
 


### PR DESCRIPTION
This fixes a pylint error.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>