### PR TITLE
Add 'lint' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,6 @@ test:
 	python -m unittest discover tests
 
 lint:
-	$(eval tmpfile := $(shell mktemp))
-	find . \( -path ./experiments -o -path ./tests \) -prune \
-		-or -name '*.py' \
-		\( -exec bash -c "pylint -E {} > $(tmpfile) 2> /dev/null" \; \
-		-or \( -print -exec cat $(tmpfile) \; \) \)
-	rm -f $(tmpfile)
+	pylint -E tuned *.py
 
 .PHONY: clean archive srpm tag test lint

--- a/Makefile
+++ b/Makefile
@@ -182,4 +182,12 @@ clean:
 test:
 	python -m unittest discover tests
 
-.PHONY: clean archive srpm tag test
+lint:
+	$(eval tmpfile := $(shell mktemp))
+	find . \( -path ./experiments -o -path ./tests \) -prune \
+		-or -name '*.py' \
+		\( -exec bash -c "pylint -E {} > $(tmpfile) 2> /dev/null" \; \
+		-or \( -print -exec cat $(tmpfile) \; \) \)
+	rm -f $(tmpfile)
+
+.PHONY: clean archive srpm tag test lint


### PR DESCRIPTION
The target executes pylint on all *.py files, except for those in the ./tests and ./experiments subdirectories. The tests subdirectory is out-dated (lots and lots of errors) and the experiments subdirectory doesn't seem like a place you'd want to check everytime you make a change. What do you think?