### PR TITLE
Fix logging to file in the current directory

### DIFF
--- a/tuned/logs.py
+++ b/tuned/logs.py
@@ -74,6 +74,8 @@ class TunedLogger(logging.getLoggerClass()):
 			return
 
 		log_directory = os.path.dirname(filename)
+		if log_directory == '':
+			log_directory = '.'
 		if not os.path.exists(log_directory):
 			os.makedirs(log_directory)
 


### PR DESCRIPTION
Previously if you ran 'tuned -l log', it would crash with:
OSError: [Errno 2] No such file or directory: ''
This patch fixes the bug.