### PR TITLE
Implement instance priority

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -26,3 +26,6 @@ recommend_command = 1
 # If enabled these sysctls will be re-appliead after Tuned sysctls are
 # applied, i.e. Tuned sysctls will not override system sysctls.
 reapply_sysctl = 1
+
+# Default priority assigned to instances
+default_instance_priority = 0

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -56,6 +56,7 @@ CFG_SLEEP_INTERVAL = "sleep_interval"
 CFG_UPDATE_INTERVAL = "update_interval"
 CFG_RECOMMEND_COMMAND = "recommend_command"
 CFG_REAPPLY_SYSCTL = "reapply_sysctl"
+CFG_DEFAULT_INSTANCE_PRIORITY = "default_instance_priority"
 
 # no_daemon mode
 CFG_DEF_DAEMON = True
@@ -69,6 +70,8 @@ CFG_DEF_UPDATE_INTERVAL = 10
 CFG_DEF_RECOMMEND_COMMAND = True
 # reapply system sysctl
 CFG_DEF_REAPPLY_SYSCTL = True
+# default instance priority
+CFG_DEF_DEFAULT_INSTANCE_PRIORITY = 0
 
 PATH_CPU_DMA_LATENCY = "/dev/cpu_dma_latency"
 

--- a/tuned/daemon/application.py
+++ b/tuned/daemon/application.py
@@ -34,7 +34,8 @@ class Application(object):
 			log.info("dynamic tuning is globally disabled")
 
 		plugins_repository = plugins.Repository(monitors_repository, storage_factory, hardware_inventory, device_matcher, plugin_instance_factory, self.config, self.variables)
-		unit_manager = units.Manager(plugins_repository, monitors_repository)
+		def_instance_priority = int(self.config.get(consts.CFG_DEFAULT_INSTANCE_PRIORITY, consts.CFG_DEF_DEFAULT_INSTANCE_PRIORITY))
+		unit_manager = units.Manager(plugins_repository, monitors_repository, def_instance_priority)
 
 		profile_factory = profiles.Factory()
 		profile_merger = profiles.Merger()

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -102,11 +102,10 @@ class Plugin(object):
 		self._destroy_instance(instance)
 		del self._instances[instance.name]
 
-	def initialize_instances(self):
-		"""Initialize all created instances."""
-		for (instance_name, instance) in self._instances.items():
-			log.debug("initializing instance %s (%s)" % (instance_name, self.name))
-			self._instance_init(instance)
+	def initialize_instance(self, instance):
+		"""Initialize an instance."""
+		log.debug("initializing instance %s (%s)" % (instance.name, self.name))
+		self._instance_init(instance)
 
 	def destroy_instances(self):
 		"""Destroy all instances."""
@@ -140,21 +139,20 @@ class Plugin(object):
 	def _get_matching_devices(self, instance, devices):
 		return set(self._device_matcher.match_list(instance.devices_expression, devices))
 
-	def assign_free_devices(self):
+	def assign_free_devices(self, instance):
 		if not self._devices_supported():
 			return
 
-		log.debug("assigning devices to all instances")
-		for instance_name, instance in reversed(self._instances.items()):
-			to_assign = self._get_matching_devices(instance, self._free_devices)
-			instance.active = len(to_assign) > 0
-			if not instance.active:
-				log.warn("instance %s: no matching devices available" % instance_name)
-			else:
-				log.info("instance %s: assigning devices %s" % (instance_name, ", ".join(to_assign)))
-				instance.devices.update(to_assign) # cannot use |=
-				self._assigned_devices |= to_assign
-				self._free_devices -= to_assign
+		log.debug("assigning devices to instance %s" % instance.name)
+		to_assign = self._get_matching_devices(instance, self._free_devices)
+		instance.active = len(to_assign) > 0
+		if not instance.active:
+			log.warn("instance %s: no matching devices available" % instance.name)
+		else:
+			log.info("instance %s: assigning devices %s" % (instance.name, ", ".join(to_assign)))
+			instance.devices.update(to_assign) # cannot use |=
+			self._assigned_devices |= to_assign
+			self._free_devices -= to_assign
 
 	def release_devices(self, instance):
 		if not self._devices_supported():

--- a/tuned/plugins/instance/instance.py
+++ b/tuned/plugins/instance/instance.py
@@ -16,6 +16,10 @@ class Instance(object):
 	# properties
 
 	@property
+	def plugin(self):
+		return self._plugin
+
+	@property
 	def name(self):
 		return self._name
 


### PR DESCRIPTION
Resolves: rhbz#1246172

Allow specifying order in which individual plugin instances are to be
executed.

Each instance can be given the 'instance_priority' option
in the profile configuration. The value must be an integer (it can be
negative). If no priority is specified, it is inherited from the parent
profile, or set to the default instance priority, if no parent profile
specifies the priority for that instance.

The default instance priority is by default zero, but it can be set to
a different value using the 'default_instance_priority' option in the
global configuration file.

Creating plugin instances, assigning devices to instances, initializing
instances, applying, updating and verifying tuning are all done in order
from lowest numerical instance priority to highest. Unapplying tuning and
destroying instances is done in reversed order.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>