### PR TITLE
Assign hotplugged devices in priority order too

### DIFF
--- a/tuned/plugins/hotplug.py
+++ b/tuned/plugins/hotplug.py
@@ -38,7 +38,7 @@ class Plugin(base.Plugin):
 
 		self._devices.add(device_name)
 
-		for instance_name, instance in reversed(self._instances.items()):
+		for instance_name, instance in self._instances.items():
 			if self._device_matcher.match(instance.devices_expression, device_name):
 				log.info("instance %s: adding new device %s" % (instance_name, device_name))
 				self._assigned_devices.add(device_name)


### PR DESCRIPTION
Resolves: rhbz#1246172

This fixes commit 363d74815a.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>