### PR TITLE
Remove the '_devices' attribute in plugins

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -129,18 +129,15 @@ class Plugin(object):
 	#
 
 	def _init_devices(self):
-		self._devices = None
+		self._devices_supported = False
 		self._assigned_devices = set()
 		self._free_devices = set()
-
-	def _devices_supported(self):
-		return self._devices is not None
 
 	def _get_matching_devices(self, instance, devices):
 		return set(self._device_matcher.match_list(instance.devices_expression, devices))
 
 	def assign_free_devices(self, instance):
-		if not self._devices_supported():
+		if not self._devices_supported:
 			return
 
 		log.debug("assigning devices to instance %s" % instance.name)
@@ -158,10 +155,10 @@ class Plugin(object):
 			self._free_devices -= to_assign
 
 	def release_devices(self, instance):
-		if not self._devices_supported():
+		if not self._devices_supported:
 			return
 
-		to_release = instance.devices & self._devices
+		to_release = instance.devices & self._assigned_devices
 
 		instance.active = False
 		instance.devices.clear()
@@ -173,7 +170,7 @@ class Plugin(object):
 	#
 
 	def _run_for_each_device(self, instance, callback):
-		if self._devices_supported():
+		if self._devices_supported:
 			devices = instance.devices
 		else:
 			devices = [None, ]

--- a/tuned/plugins/hotplug.py
+++ b/tuned/plugins/hotplug.py
@@ -33,10 +33,8 @@ class Plugin(base.Plugin):
 
 	def _add_device(self, device):
 		device_name = device.sys_name
-		if device_name in self._devices:
+		if device_name in (self._assigned_devices | self._free_devices):
 			return
-
-		self._devices.add(device_name)
 
 		for instance_name, instance in self._instances.items():
 			if self._device_matcher.match(instance.devices_expression, device_name):
@@ -51,7 +49,7 @@ class Plugin(base.Plugin):
 
 	def _remove_device(self, device):
 		device_name = device.sys_name
-		if device_name not in self._devices:
+		if device_name not in (self._assigned_devices | self._free_devices):
 			return
 
 		for instance in self._instances.values():
@@ -63,8 +61,6 @@ class Plugin(base.Plugin):
 				break
 		else:
 			self._free_devices.remove(device_name)
-
-		self._devices.remove(device_name)
 
 	def _added_device_apply_tuning(self, instance, device_name):
 		self._execute_all_device_commands(instance, [device_name])

--- a/tuned/plugins/plugin_audio.py
+++ b/tuned/plugins/plugin_audio.py
@@ -19,15 +19,14 @@ class AudioPlugin(base.Plugin):
 	"""
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
 		self._assigned_devices = set()
+		self._free_devices = set()
 
 		for device in self._hardware_inventory.get_devices("sound").match_sys_name("card*"):
 			module_name = self._device_module_name(device)
 			if module_name in ["snd_hda_intel", "snd_ac97_codec"]:
-				self._devices.add(module_name)
-
-		self._free_devices = self._devices.copy()
+				self._free_devices.add(module_name)
 
 	def _instance_init(self, instance):
 		instance._has_static_tuning = True

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -32,13 +32,13 @@ class CPULatencyPlugin(base.Plugin):
 		self._cmd = commands()
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		# current list of devices
 		for device in self._hardware_inventory.get_devices("cpu"):
-			self._devices.add(device.sys_name)
+			self._free_devices.add(device.sys_name)
 
 		self._assigned_devices = set()
-		self._free_devices = self._devices.copy()
 
 	@classmethod
 	def _get_config_options(self):

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -25,13 +25,13 @@ class DiskPlugin(hotplug.Plugin):
 		self._cmd = commands()
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		for device in self._hardware_inventory.get_devices("block"):
 			if self._device_is_supported(device):
-				self._devices.add(device.sys_name)
+				self._free_devices.add(device.sys_name)
 
 		self._assigned_devices = set()
-		self._free_devices = self._devices.copy()
 
 	@classmethod
 	def _device_is_supported(cls, device):

--- a/tuned/plugins/plugin_mounts.py
+++ b/tuned/plugins/plugin_mounts.py
@@ -49,9 +49,9 @@ class MountsPlugin(base.Plugin):
 
 	def _init_devices(self):
 		self._generate_mountpoint_topology()
-		self._devices = set(self._mountpoint_topology.keys())
+		self._devices_supported = True
+		self._free_devices = set(self._mountpoint_topology.keys())
 		self._assigned_devices = set()
-		self._free_devices = self._devices.copy()
 
 	@classmethod
 	def _get_config_options(self):

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -22,16 +22,16 @@ class NetTuningPlugin(base.Plugin):
 		self._cmd = commands()
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		self._assigned_devices = set()
 
 		re_not_virtual = re.compile('(?!.*/virtual/.*)')
 		for device in self._hardware_inventory.get_devices("net"):
 			if re_not_virtual.match(device.device_path):
-				self._devices.add(device.sys_name)
+				self._free_devices.add(device.sys_name)
 
-		self._free_devices = self._devices.copy()
-		log.debug("devices: %s" % str(self._devices));
+		log.debug("devices: %s" % str(self._free_devices));
 
 	def _instance_init(self, instance):
 		instance._has_static_tuning = True

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -20,13 +20,13 @@ class DiskPlugin(hotplug.Plugin):
 		self._cmd = commands()
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		for device in self._hardware_inventory.get_devices("scsi"):
 			if self._device_is_supported(device):
-				self._devices.add(device.sys_name)
+				self._free_devices.add(device.sys_name)
 
 		self._assigned_devices = set()
-		self._free_devices = self._devices.copy()
 
 	@classmethod
 	def _device_is_supported(cls, device):

--- a/tuned/plugins/plugin_usb.py
+++ b/tuned/plugins/plugin_usb.py
@@ -12,13 +12,13 @@ class USBPlugin(base.Plugin):
 	"""
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		self._assigned_devices = set()
 
 		for device in self._hardware_inventory.get_devices("usb").match_property("DEVTYPE", "usb_device"):
-			self._devices.add(device.sys_name)
+			self._free_devices.add(device.sys_name)
 
-		self._free_devices = self._devices.copy()
 		self._cmd = commands()
 
 	@classmethod

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -12,14 +12,14 @@ class VideoPlugin(base.Plugin):
 	"""
 
 	def _init_devices(self):
-		self._devices = set()
+		self._devices_supported = True
+		self._free_devices = set()
 		self._assigned_devices = set()
 
 		# FIXME: this is a blind shot, needs testing
 		for device in self._hardware_inventory.get_devices("drm").match_sys_name("card*").match_property("DEVTYPE", "drm_minor"):
-			self._devices.add(device.sys_name)
+			self._free_devices.add(device.sys_name)
 
-		self._free_devices = self._devices.copy()
 		self._cmd = commands()
 
 	@classmethod


### PR DESCRIPTION
The _device attribute should always be the same as the union of
_assigned_devices and _free_devices, therefore it's redundant.
Its existence in my opinion brings only confusion and a potential
source of inconsistencies.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>