### PR TITLE
Implement udev-based device matching

### DIFF
--- a/tuned/daemon/application.py
+++ b/tuned/daemon/application.py
@@ -24,6 +24,7 @@ class Application(object):
 		monitors_repository = monitors.Repository()
 		hardware_inventory = hardware.Inventory()
 		device_matcher = hardware.DeviceMatcher()
+		device_matcher_udev = hardware.DeviceMatcherUdev()
 		plugin_instance_factory = plugins.instance.Factory()
 		self.variables = profiles.variables.Variables()
 
@@ -33,7 +34,8 @@ class Application(object):
 		else:
 			log.info("dynamic tuning is globally disabled")
 
-		plugins_repository = plugins.Repository(monitors_repository, storage_factory, hardware_inventory, device_matcher, plugin_instance_factory, self.config, self.variables)
+		plugins_repository = plugins.Repository(monitors_repository, storage_factory, hardware_inventory,\
+			device_matcher, device_matcher_udev, plugin_instance_factory, self.config, self.variables)
 		def_instance_priority = int(self.config.get(consts.CFG_DEFAULT_INSTANCE_PRIORITY, consts.CFG_DEF_DEFAULT_INSTANCE_PRIORITY))
 		unit_manager = units.Manager(plugins_repository, monitors_repository, def_instance_priority)
 

--- a/tuned/gtk/gui_plugin_loader.py
+++ b/tuned/gtk/gui_plugin_loader.py
@@ -71,6 +71,7 @@ class GuiPluginLoader(PluginLoader):
         monitors_repository = monitors.Repository()
         hardware_inventory = hardware.Inventory()
         device_matcher = hardware.DeviceMatcher()
+        device_matcher_udev = hardware.DeviceMatcherUdev()
         plugin_instance_factory = plugins.instance.Factory()
 
         self.repo = repository.Repository(
@@ -78,6 +79,7 @@ class GuiPluginLoader(PluginLoader):
             storage_factory,
             hardware_inventory,
             device_matcher,
+            device_matcher_udev,
             plugin_instance_factory,
             None,
             None

--- a/tuned/hardware/__init__.py
+++ b/tuned/hardware/__init__.py
@@ -1,2 +1,3 @@
 from inventory import *
 from device_matcher import *
+from device_matcher_udev import *

--- a/tuned/hardware/device_matcher_udev.py
+++ b/tuned/hardware/device_matcher_udev.py
@@ -1,0 +1,18 @@
+import device_matcher
+import re
+
+__all__ = ["DeviceMatcherUdev"]
+
+class DeviceMatcherUdev(device_matcher.DeviceMatcher):
+	def match(self, regex, device):
+		"""
+		Match a device against the udev regex in tuning profiles.
+
+		device is a pyudev.Device object
+		"""
+
+		properties = ''
+		for key, val in device.items():
+			properties += key + '=' + val + '\n'
+
+		return re.search(regex, properties, re.MULTILINE) is not None

--- a/tuned/hardware/inventory.py
+++ b/tuned/hardware/inventory.py
@@ -28,6 +28,10 @@ class Inventory(object):
 
 		self._subscriptions = {}
 
+	def get_device(self, subsystem, sys_name):
+		"""Get a pyudev.Device object for the sys_name (e.g. 'sda')."""
+		return pyudev.Devices.from_name(self._udev_context, subsystem, sys_name)
+
 	def get_devices(self, subsystem):
 		"""Get list of devices on a given subsystem."""
 		return self._udev_context.list_devices(subsystem=subsystem)

--- a/tuned/plugins/instance/instance.py
+++ b/tuned/plugins/instance/instance.py
@@ -2,10 +2,11 @@ class Instance(object):
 	"""
 	"""
 
-	def __init__(self, plugin, name, devices_expression, options):
+	def __init__(self, plugin, name, devices_expression, devices_udev_regex, options):
 		self._plugin = plugin
 		self._name = name
 		self._devices_expression = devices_expression
+		self._devices_udev_regex = devices_udev_regex
 		self._options = options
 
 		self._active = True
@@ -39,6 +40,10 @@ class Instance(object):
 	@property
 	def devices(self):
 		return self._devices
+
+	@property
+	def devices_udev_regex(self):
+		return self._devices_udev_regex
 
 	@property
 	def options(self):

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -40,6 +40,9 @@ class CPULatencyPlugin(base.Plugin):
 
 		self._assigned_devices = set()
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("cpu", x), devices)
+
 	@classmethod
 	def _get_config_options(self):
 		return {

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -33,6 +33,9 @@ class DiskPlugin(hotplug.Plugin):
 
 		self._assigned_devices = set()
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("block", x), devices)
+
 	@classmethod
 	def _device_is_supported(cls, device):
 		return  device.device_type == "disk" and \

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -33,6 +33,9 @@ class NetTuningPlugin(base.Plugin):
 
 		log.debug("devices: %s" % str(self._free_devices));
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("net", x), devices)
+
 	def _instance_init(self, instance):
 		instance._has_static_tuning = True
 		instance._has_dynamic_tuning = True

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -28,6 +28,9 @@ class DiskPlugin(hotplug.Plugin):
 
 		self._assigned_devices = set()
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("scsi", x), devices)
+
 	@classmethod
 	def _device_is_supported(cls, device):
 		return  device.device_type == "scsi_host"

--- a/tuned/plugins/plugin_usb.py
+++ b/tuned/plugins/plugin_usb.py
@@ -21,6 +21,9 @@ class USBPlugin(base.Plugin):
 
 		self._cmd = commands()
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("usb", x), devices)
+
 	@classmethod
 	def _get_config_options(self):
 		return {

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -22,6 +22,9 @@ class VideoPlugin(base.Plugin):
 
 		self._cmd = commands()
 
+	def _get_device_objects(self, devices):
+		return map(lambda x: self._hardware_inventory.get_device("drm", x), devices)
+
 	@classmethod
 	def _get_config_options(self):
 		return {

--- a/tuned/plugins/repository.py
+++ b/tuned/plugins/repository.py
@@ -8,13 +8,14 @@ __all__ = ["Repository"]
 
 class Repository(PluginLoader):
 
-	def __init__(self, monitor_repository, storage_factory, hardware_inventory, device_matcher, plugin_instance_factory, global_cfg, variables):
+	def __init__(self, monitor_repository, storage_factory, hardware_inventory, device_matcher, device_matcher_udev, plugin_instance_factory, global_cfg, variables):
 		super(self.__class__, self).__init__()
 		self._plugins = set()
 		self._monitor_repository = monitor_repository
 		self._storage_factory = storage_factory
 		self._hardware_inventory = hardware_inventory
 		self._device_matcher = device_matcher
+		self._device_matcher_udev = device_matcher_udev
 		self._plugin_instance_factory = plugin_instance_factory
 		self._global_cfg = global_cfg
 		self._variables = variables
@@ -32,7 +33,7 @@ class Repository(PluginLoader):
 		log.debug("creating plugin %s" % plugin_name)
 		plugin_cls = self.load_plugin(plugin_name)
 		plugin_instance = plugin_cls(self._monitor_repository, self._storage_factory, self._hardware_inventory, self._device_matcher,\
-			self._plugin_instance_factory, self._global_cfg, self._variables)
+			self._device_matcher_udev, self._plugin_instance_factory, self._global_cfg, self._variables)
 		self._plugins.add(plugin_instance)
 		return plugin_instance
 

--- a/tuned/profiles/merger.py
+++ b/tuned/profiles/merger.py
@@ -32,6 +32,8 @@ class Merger(object):
 				profile_a.units[unit_name].type = unit.type
 				profile_a.units[unit_name].enabled = unit.enabled
 				profile_a.units[unit_name].devices = unit.devices
+				if unit.devices_udev_regex != None:
+					profile_a.units[unit_name].devices_udev_regex = unit.devices_udev_regex
 				if unit_name == "script" and profile_a.units[unit_name].options.get("script", None) is not None:
 					script = profile_a.units[unit_name].options.get("script", None)
 					profile_a.units[unit_name].options.update(unit.options)

--- a/tuned/profiles/unit.py
+++ b/tuned/profiles/unit.py
@@ -3,7 +3,7 @@ class Unit(object):
 	Unit description.
 	"""
 
-	__slots__ = [ "_name", "_type", "_enabled", "_replace", "_devices", "_options" ]
+	__slots__ = [ "_name", "_type", "_enabled", "_replace", "_devices", "_devices_udev_regex", "_options" ]
 
 	def __init__(self, name, config):
 		self._name = name
@@ -11,6 +11,7 @@ class Unit(object):
 		self._enabled = config.pop("enabled", True) in [True, "true", 1]
 		self._replace = config.pop("replace", False) in [True, "true", 1]
 		self._devices = config.pop("devices", "*")
+		self._devices_udev_regex = config.pop("devices_udev_regex", None)
 		self._options = dict(config)
 
 	@property
@@ -44,6 +45,14 @@ class Unit(object):
 	@devices.setter
 	def devices(self, value):
 		self._devices = value
+
+	@property
+	def devices_udev_regex(self):
+		return self._devices_udev_regex
+
+	@devices_udev_regex.setter
+	def devices_udev_regex(self, value):
+		self._devices_udev_regex = value
 
 	@property
 	def options(self):

--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -62,7 +62,7 @@ class Manager(object):
 			if plugin is None:
 				continue
 			log.debug("creating '%s' (%s)" % (instance_info.name, instance_info.type))
-			new_instance = plugin.create_instance(instance_info.name, instance_info.devices, instance_info.options)
+			new_instance = plugin.create_instance(instance_info.name, instance_info.devices, instance_info.devices_udev_regex, instance_info.options)
 			plugin.assign_free_devices(new_instance)
 			plugin.initialize_instance(new_instance)
 			self._instances.append(new_instance)


### PR DESCRIPTION
A new option 'devices_udev_regex' can be used in profile
configuration to specify devices to which a plugin instance
should be applied.

The option can contain a python regular expression, as specified
in https://docs.python.org/2/library/re.html#regular-expression-syntax.
The expression is effectively matched against the output of
udevadm info --query=property -n <device_path>

If the option 'devices_udev_regex' is specified, the 'devices' option
is ignored. If it is not specified, then the matching is done the same
way as previously, i.e. against 'devices'.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>