### PR TITLE
Fix plugin cleanup

### DIFF
--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -71,6 +71,9 @@ class Manager(object):
 		for instance in self._instances:
 			log.debug("destroying instance %s" % instance.name)
 			instance.plugin.destroy_instance(instance)
+		for plugin in self._plugins:
+			log.debug("cleaning plugin '%s'" % plugin.name)
+			plugin.cleanup()
 
 		del self._plugins[:]
 		del self._instances[:]


### PR DESCRIPTION
The plugins were not getting cleaned up properly, so e.g. after
a profile switch instances of the Plugin class would get piled up.

This fixes commit 363d74815a.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>