### PR TITLE
Perform command cleanup in reversed order

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -502,12 +502,12 @@ class Plugin(object):
 		return self._verify_value(command["name"], new_value, current_value, ignore_missing)
 
 	def _cleanup_all_non_device_commands(self, instance):
-		for command in filter(lambda command: not command["per_device"], self._commands.values()):
+		for command in reversed(filter(lambda command: not command["per_device"], self._commands.values())):
 			if (instance.options.get(command["name"], None) is not None) or (command["name"] in self._options_used_by_dynamic):
 				self._cleanup_non_device_command(instance, command)
 
 	def _cleanup_all_device_commands(self, instance, devices):
-		for command in filter(lambda command: command["per_device"], self._commands.values()):
+		for command in reversed(filter(lambda command: command["per_device"], self._commands.values())):
 			if (instance.options.get(command["name"], None) is not None) or (command["name"] in self._options_used_by_dynamic):
 				for device in devices:
 					self._cleanup_device_command(instance, command, device)


### PR DESCRIPTION
Clean up device and non-device commands it reversed order, compared to
the order in which they were applied. It makes more sense that way to me.

Related: rhbz#1246176

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>