### PR TITLE
Introduce ${PROFILE_DIR} variable

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -99,3 +99,12 @@ STR_VERIFY_PROFILE_FAIL = "verify: failed: '%s'"
 
 # timout for tuned-adm operations in seconds
 ADMIN_TIMEOUT = 600
+
+# Constants which can be used in profiles just like regular variables (i.e. ${var_name}).
+# The constant names are reserved, they cannot be redefined in profiles. When adding a new
+# constant, add it to TUNED_RESERVED_CONSTANTS.
+#
+# expands to the directory where the current profile configuration resides
+CONST_PROFILE_DIR = "PROFILE_DIR"
+
+TUNED_RESERVED_CONSTANTS = [CONST_PROFILE_DIR]

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -12,7 +12,6 @@ DEFAULT_STORAGE_FILE = "/run/tuned/save.pickle"
 LOAD_DIRECTORIES = ["/usr/lib/tuned", "/etc/tuned"]
 PERSISTENT_STORAGE_DIR = "/var/lib/tuned"
 PLUGIN_MAIN_UNIT_NAME = "main"
-PLUGIN_WORKDIR_OPTION_NAME = "workdir"
 
 TMP_FILE_SUFFIX = ".tmp"
 # max. number of consecutive errors to give up

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -81,13 +81,13 @@ class Plugin(object):
 	# Interface for manipulation with instances of the plugin.
 	#
 
-	def create_instance(self, name, devices_expression, devices_udev_regex, workdir, options):
+	def create_instance(self, name, devices_expression, devices_udev_regex, options):
 		"""Create new instance of the plugin and seize the devices."""
 		if name in self._instances:
 			raise Exception("Plugin instance with name '%s' already exists." % name)
 
 		effective_options = self._get_effective_options(options)
-		instance = self._instance_factory.create(self, name, devices_expression, devices_udev_regex, workdir, effective_options)
+		instance = self._instance_factory.create(self, name, devices_expression, devices_udev_regex, effective_options)
 		self._instances[name] = instance
 
 		return instance

--- a/tuned/plugins/instance/instance.py
+++ b/tuned/plugins/instance/instance.py
@@ -2,12 +2,11 @@ class Instance(object):
 	"""
 	"""
 
-	def __init__(self, plugin, name, devices_expression, devices_udev_regex, workdir, options):
+	def __init__(self, plugin, name, devices_expression, devices_udev_regex, options):
 		self._plugin = plugin
 		self._name = name
 		self._devices_expression = devices_expression
 		self._devices_udev_regex = devices_udev_regex
-		self._workdir = workdir
 		self._options = options
 
 		self._active = True
@@ -45,10 +44,6 @@ class Instance(object):
 	@property
 	def devices_udev_regex(self):
 		return self._devices_udev_regex
-
-	@property
-	def workdir(self):
-		return self._workdir
 
 	@property
 	def options(self):

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -34,7 +34,6 @@ class BootloaderPlugin(base.Plugin):
 		self._initrd_dst_img_val = None
 		self._cmdline_val = ""
 		self._initrd_val = ""
-		self._workdir = instance.workdir
 		self._grub2_cfg_file_name = self._get_grub2_cfg_file()
 
 	def _instance_cleanup(self, instance):
@@ -185,11 +184,6 @@ class BootloaderPlugin(base.Plugin):
 		self.update_grub2_cfg = True
 		self._initrd_val = "/" + img_name
 
-	def _build_abs_path(self, path):
-		if path is None or len(path) == 0 or path[0] == "/":
-			return path
-		return os.path.normpath(os.path.join(self._workdir, path))
-
 	@command_custom("grub2_cfg_file")
 	def _grub2_cfg_file(self, enabling, value, verify, ignore_missing):
 		# nothing to verify
@@ -228,7 +222,6 @@ class BootloaderPlugin(base.Plugin):
 			self._init_initrd_dst_img(src_img)
 			if src_img == "":
 				return False
-			src_img = self._build_abs_path(src_img)
 			self._install_initrd(src_img)
 
 	@command_custom("initrd_add_dir", per_device = False, priority = 10)
@@ -241,7 +234,6 @@ class BootloaderPlugin(base.Plugin):
 			self._init_initrd_dst_img(src_dir)
 			if src_dir == "":
 				return False
-			src_dir = self._build_abs_path(src_dir)
 			if not os.path.isdir(src_dir):
 				log.error("error: cannot create initrd image, source directory '%s' doesn't exist" % src_dir)
 				return False

--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -75,7 +75,7 @@ class Loader(object):
 			profiles.append(profile)
 
 	def _expand_profile_dir(self, profile_dir, string):
-		return re.sub(r'(?<!\\)\$\{PROFILE_DIR\}', profile_dir, string)
+		return re.sub(r'(?<!\\)\$\{' + re.escape(consts.CONST_PROFILE_DIR) + r'\}', profile_dir, string)
 
 	def _load_config_data(self, file_name):
 		try:

--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -74,6 +74,9 @@ class Loader(object):
 
 			profiles.append(profile)
 
+	def _expand_profile_dir(self, profile_dir, string):
+		return re.sub(r'(?<!\\)\$\{PROFILE_DIR\}', profile_dir, string)
+
 	def _load_config_data(self, file_name):
 		try:
 			config_obj = ConfigObj(file_name, raise_errors = True, list_values = False, interpolation = False)
@@ -93,13 +96,16 @@ class Loader(object):
 				for option in keys:
 					config[section][option] = config_obj[section][option]
 
-		# TODO: HACK, this needs to be solved in a better way (better config parser)
 		dir_name = os.path.dirname(file_name)
+		# TODO: Try to do this in the same place as the expansion of other variables
+		for section in config:
+			for option in config[section]:
+				config[section][option] = self._expand_profile_dir(dir_name, config[section][option])
+
+		# TODO: HACK, this needs to be solved in a better way (better config parser)
 		for unit_name in config:
 			if "script" in config[unit_name] and config[unit_name].get("script", None) is not None:
 				script_path = os.path.join(dir_name, config[unit_name]["script"])
 				config[unit_name]["script"] = [os.path.normpath(script_path)]
-			if config[unit_name].get(consts.PLUGIN_WORKDIR_OPTION_NAME, None) is None:
-				config[unit_name][consts.PLUGIN_WORKDIR_OPTION_NAME] = dir_name
 
 		return config

--- a/tuned/profiles/variables.py
+++ b/tuned/profiles/variables.py
@@ -27,12 +27,18 @@ class Variables():
 	def _check_var(self, variable):
 		return re.match(r'\w+$',variable)
 
+	def _check_var_reserved(self, variable):
+		return variable not in consts.TUNED_RESERVED_CONSTANTS
+
 	def add_variable(self, variable, value):
 		if value is None:
 			return
 		s = str(variable)
 		if not self._check_var(variable):
 			log.error("variable definition '%s' contains unallowed characters" % variable)
+			return
+		if not self._check_var_reserved(s):
+			log.error("Variable '%s' cannot be defined, it is a reserved constant" % s)
 			return
 		v = self.expand(value)
 		# variables referenced by ${VAR}, $ can be escaped by two $,

--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -64,7 +64,7 @@ class Manager(object):
 				continue
 			log.debug("creating '%s' (%s)" % (instance_info.name, instance_info.type))
 			new_instance = plugin.create_instance(instance_info.name, instance_info.devices, instance_info.devices_udev_regex, \
-				instance_info.options.pop(consts.PLUGIN_WORKDIR_OPTION_NAME, "."), instance_info.options)
+				instance_info.options)
 			plugin.assign_free_devices(new_instance)
 			plugin.initialize_instance(new_instance)
 			self._instances.append(new_instance)


### PR DESCRIPTION
See the individual commit messages for more detail.

Perhaps we could rename the new 'PROFILE_DIR' variable to 'TUNED_PROFILE_DIR' or '_PROFILE_DIR' to avoid possible conflicts with user-defined profiles. We could then say in the documentation that variable names starting with the 'TUNED_' or '_' prefix are reserved for future use. What do you think?