### PR TITLE
Allow running verify_profile_ignore_missing to all users

### DIFF
--- a/com.redhat.tuned.policy
+++ b/com.redhat.tuned.policy
@@ -126,4 +126,14 @@
       <allow_active>yes</allow_active>
     </defaults>
   </action>
+
+  <action id="com.redhat.tuned.verify_profile_ignore_missing">
+    <description>Verify Tuned profile, ignore missing values</description>
+    <message>Authentication is required to verify Tuned profile</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
 </policyconfig>


### PR DESCRIPTION
The policy for running the 'verify_profile_ignore_missing' D-Bus method
was missing, so only root could run it. This commit adds the policy, so
that it is the same as the policy for regular 'verify_profile'.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>