### PR TITLE
plugin_net: Fix invocation of execute()

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -269,7 +269,7 @@ class NetTuningPlugin(base.Plugin):
 		if not sim:
 			log.debug("setting %s: %s" % ("coalesce" if coalesce else "features", str(d)))
 			# ignore ethtool return code 80, it means parameter is already set
-			self._cmd.execute(["ethtool", "-C" if coalesce else "-K", device] + self._cmd.dict2list(d), [80])
+			self._cmd.execute(["ethtool", "-C" if coalesce else "-K", device] + self._cmd.dict2list(d), no_errors = [80])
 		return d
 
 	def _custom_parameters(self, coalesce, start, value, device, verify):


### PR DESCRIPTION
Fix an invocation of execute() after its API changed.

Reproducer:
Run tuned with the following profile, and you'll see error messages
'tuned.utils.commands: Executing ethtool error: ethtool: bad command line argument(s)'
in the log. Replace 'enp0s25' with your ethernet interface:

[net]
devices=enp0s25
coalesce=rx-usecs 4

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>