### PR TITLE
Start dbus exports after a profile is applied

### DIFF
--- a/tuned/daemon/application.py
+++ b/tuned/daemon/application.py
@@ -185,13 +185,7 @@ class Application(object):
 		# override global config if ran from command line with daemon option (-d)
 		if daemon:
 			self.config.set(consts.CFG_DAEMON, True)
-		if self.config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON):
-			exports.start()
-		else:
-			log.warn("Using one shot no deamon mode, most of the functionality will be not available, it can be changed in global config")
 		result = self._controller.run()
-		if self.config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON):
-			exports.stop()
 
 		if self._pid_file is not None:
 			self._delete_pid_file()

--- a/tuned/exports/__init__.py
+++ b/tuned/exports/__init__.py
@@ -35,3 +35,7 @@ def start():
 def stop():
 	ctl = controller.ExportsController.get_instance()
 	return ctl.stop()
+
+def wait_for_exports_running(timeout):
+	ctl = controller.ExportsController.get_instance()
+	return ctl.wait_for_exports_running(timeout)

--- a/tuned/patterns.py
+++ b/tuned/patterns.py
@@ -1,9 +1,12 @@
+from threading import Lock
+
 class Singleton(object):
 	"""
 	Singleton design pattern.
 	"""
 
 	_instance = None
+	_lock = Lock()
 
 	def __init__(self):
 		if self.__class__ is Singleton:
@@ -12,6 +15,10 @@ class Singleton(object):
 	@classmethod
 	def get_instance(cls):
 		"""Get the class instance."""
+		if cls._instance is not None:
+			return cls._instance
+		cls._lock.acquire()
 		if cls._instance is None:
 			cls._instance = cls()
+		cls._lock.release()
 		return cls._instance


### PR DESCRIPTION
So this was my initial idea of what the patch might look like. But maybe we could remove the timeout, so that it waits indefinitely for a profile to be applied / for exports? It would be better for debugging - things wouldn't time out when stepping through the code. We would still keep the log messages 'Waiting for ...', so that the user knows what's going on, in case things are taking too long.