### PR TITLE
List available profiles on 'tuned-adm profile'

### DIFF
--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -24,7 +24,7 @@
 tuned\-adm - commandline tool for switching between different tuning profiles
 .SH SYNOPSIS
 .B tuned\-adm 
-.RB [ list " | " active " | " "profile \fI<profile>\fP" " | " off " | " verify " | " recommend ]
+.RB [ list " | " active " | " "profile \fI[profile]\fP" " | " off " | " verify " | " recommend ]
 
 .SH DESCRIPTION
 This command line utility allows you to switch between user definable tuning
@@ -47,9 +47,10 @@ List all available profiles.
 Show current active profile.
 
 .TP
-.BI "profile " PROFILE
-Switches to the given profilename. If none is given or no valid one is given
-the command gracefully exits without performing any operation.
+.BI "profile " [PROFILE]
+Switches to the given profilename. If none is given then all available profiles
+are listed. If the profile given is not valid the command gracefully exits without
+performing any operation.
 
 .TP
 .B verify

--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -55,9 +55,9 @@ if __name__ == "__main__":
 	parser_off = subparsers.add_parser("off", help="switch off all tunings")
 	parser_off.set_defaults(action="off")
 
-	parser_profile = subparsers.add_parser("profile", help="switch to a given profile")
+	parser_profile = subparsers.add_parser("profile", help="switch to a given profile, or list available profiles if no profile is given")
 	parser_profile.set_defaults(action="profile")
-	parser_profile.add_argument("profiles", metavar="profile", type=str, nargs="+", help="profile name")
+	parser_profile.add_argument("profiles", metavar="profile", type=str, nargs="*", help="profile name")
 
 	parser_profile_info = subparsers.add_parser("profile_info", help="show information/description of given profile or current profile if no profile is specified")
 	parser_profile_info.set_defaults(action="profile_info")

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -183,6 +183,8 @@ class Admin(object):
 		return False
 
 	def _action_dbus_profile(self, profiles):
+		if len(profiles) == 0:
+			return self._action_dbus_list()
 		profile_name = " ".join(profiles)
 		if profile_name == "":
 			return False
@@ -196,6 +198,8 @@ class Admin(object):
 		return self._profile_print_status(ret, msg)
 
 	def _action_profile(self, profiles):
+		if len(profiles) == 0:
+			return self._action_list()
 		profile_name = " ".join(profiles)
 		if profile_name == "":
 			return False


### PR DESCRIPTION
List available profiles when 'tuned-adm profile' is run
without a profile name.

Resolves: rhbz#988433

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>