### PR TITLE
fix NF/FI macros in manpages

### DIFF
--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -72,7 +72,7 @@ performance or balanced profile if unsure.
 Unload tunings.
 
 .SH "FILES"
-.NF
+.nf
 /etc/tuned/*
 /usr/lib/tuned/*
 
@@ -89,7 +89,7 @@ Unload tunings.
 .BR tuned\-profiles\-nfv\-guest (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>
 Jan Kaluža <jkaluza@redhat.com>
 Jan Včelák <jvcelak@redhat.com>

--- a/man/tuned-main.conf.5
+++ b/man/tuned-main.conf.5
@@ -79,7 +79,7 @@ in order defined by their priorities, i.e. unit with the lowest number is
 processed as the first.
 
 .SH EXAMPLE
-.NF
+.nf
   no_daemon = 0
   dynamic_tuning = 1
   sleep_interval = 1
@@ -87,7 +87,7 @@ processed as the first.
   recommend_command = 0
   reapply_sysctl = 1
   default_instance_priority = 0
-.FI
+.fi
 
 .SH FILES
 .I /etc/tuned/tuned\-main.conf

--- a/man/tuned-profiles-atomic.7
+++ b/man/tuned-profiles-atomic.7
@@ -42,7 +42,7 @@ profile. It additionally increases SELinux AVC cache, PID limit and tunes
 netfilter connections tracking.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -59,5 +59,5 @@ netfilter connections tracking.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-compat.7
+++ b/man/tuned-profiles-compat.7
@@ -75,7 +75,7 @@ disables disk barriers. Disk readahead values are increased. CPU governor is
 set to performance.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -92,7 +92,7 @@ set to performance.
 .BR tuned\-profiles\-nfv\-guest (7)
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>
 Jan Kaluža <jkaluza@redhat.com>
 Jan Včelák <jvcelak@redhat.com>

--- a/man/tuned-profiles-cpu-partitioning.7
+++ b/man/tuned-profiles-cpu-partitioning.7
@@ -33,7 +33,7 @@ The following profiles is provided:
 Profile optimized for CPU partitioning.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -50,5 +50,5 @@ Profile optimized for CPU partitioning.
 .BR tuned\-profiles\-nfv\-guest (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-nfv-guest.7
+++ b/man/tuned-profiles-nfv-guest.7
@@ -33,7 +33,7 @@ The following profile is provided:
 Profile optimized for virtual guests based on realtime profile.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -50,5 +50,5 @@ Profile optimized for virtual guests based on realtime profile.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-nfv-host.7
+++ b/man/tuned-profiles-nfv-host.7
@@ -33,7 +33,7 @@ The following profile is provided:
 Profile optimized for virtual hosts based on realtime profile.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -50,5 +50,5 @@ Profile optimized for virtual hosts based on realtime profile.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-oracle.7
+++ b/man/tuned-profiles-oracle.7
@@ -35,7 +35,7 @@ It additionaly disables transparent huge pages and modifies some other
 performance related kernel parameters.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -52,5 +52,5 @@ performance related kernel parameters.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-realtime.7
+++ b/man/tuned-profiles-realtime.7
@@ -33,7 +33,7 @@ The following profiles are provided:
 Profile optimized for realtime.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -50,5 +50,5 @@ Profile optimized for realtime.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-sap-hana.7
+++ b/man/tuned-profiles-sap-hana.7
@@ -44,7 +44,7 @@ regarding semaphores. It decreases virtual memory swappiness and disables large
 recieve offload for the network adapter.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -61,5 +61,5 @@ recieve offload for the network adapter.
 .BR tuned\-profiles\-cpu-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles-sap.7
+++ b/man/tuned-profiles-sap.7
@@ -36,7 +36,7 @@ settings regarding shared memory, semaphores and maximum number of memory map
 areas a process may have.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -53,5 +53,5 @@ areas a process may have.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned-profiles.7
+++ b/man/tuned-profiles.7
@@ -112,7 +112,7 @@ Profile optimized for virtual hosts based on throughput\-performance profile.
 It additionally enables more aggresive writeback of dirty pages.
 
 .SH "FILES"
-.NF
+.nf
 .I /etc/tuned/*
 .I /usr/lib/tuned/*
 
@@ -129,7 +129,7 @@ It additionally enables more aggresive writeback of dirty pages.
 .BR tuned\-profiles\-cpu\-partitioning (7)
 .BR tuned\-profiles\-compat (7)
 .SH AUTHOR
-.NF
+.nf
 Jaroslav Škarvada <jskarvad@redhat.com>
 Jan Kaluža <jkaluza@redhat.com>
 Jan Včelák <jvcelak@redhat.com>

--- a/man/tuned.8
+++ b/man/tuned.8
@@ -60,7 +60,7 @@ This is intended for debugging purposes.
 .BI  \-v "\fR, \fP" \-\-version
 Show version information.
 .SH "FILES"
-.NF
+.nf
 /etc/tuned
 /usr/share/doc/tuned/README
 .SH "SEE ALSO"
@@ -68,7 +68,7 @@ Show version information.
 tuned.conf(5)
 tuned\-adm(8)
 .SH AUTHOR
-.NF
+.nf
 Jan Kaluža <jkaluza@redhat.com>
 Jan Včelák <jvcelak@redhat.com>
 Jaroslav Škarvada <jskarvad@redhat.com>

--- a/man/tuned.conf.5
+++ b/man/tuned.conf.5
@@ -50,7 +50,7 @@ last replaces all options defined by the previosly defined plugin.
 Plugins can also have plugin related options.
 
 .SH "EXAMPLE"
-.NF
+.nf
 [main]
 # Includes plugins defined in "included" profile.
 include=included
@@ -71,7 +71,7 @@ net.core.wmem_default = 262144
 [my_script]
 type=script
 script=profile.sh
-.FI
+.fi
 
 .SH "SEE ALSO"
 .LP


### PR DESCRIPTION
the macros are called .nf and .fi, not .NF and .FI

Test:

    % LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80  man --warnings \
      -E UTF-8 -l -Tutf8 -Z <file> >/dev/null
    53: warning: macro `NF' not defined
    74: warning: macro `FI' not defined

Spotted by rpmlint and lintian.