### PR TITLE
drop the encoding keyword from the desktop file

### DIFF
--- a/tuned-gui.desktop
+++ b/tuned-gui.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=tuned-gui
 GenericName=tuned-gui
 Comment=GTK GUI that can control Tuned daemon and provides simple profile editor


### PR DESCRIPTION
it's deprecated:
 https://specifications.freedesktop.org/desktop-entry-spec/1.0/apc.html