### PR TITLE
Change desktop menu category for tuned-gui from System to Settings;HardwareSettings

### DIFF
--- a/tuned-gui.desktop
+++ b/tuned-gui.desktop
@@ -6,5 +6,5 @@ Exec=/usr/sbin/tuned-gui
 Icon=tuned
 Terminal=false
 Type=Application
-Categories=System;
+Categories=Settings;HardwareSettings;
 Version=1.0


### PR DESCRIPTION
I want to propose to change the menu entry category from System to Settings;HardwareSettings.

While updating the tuned package for openSUSE, the build checker complained that the used menu category 'System' is not sufficient enough.
After digging into https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#System
the right category seems to be Settings;HardwareSettings.

To make the appearance of tuned-gui the same for every distribution I thought pushing this upstream would be a good idea!