### PR TITLE
Remove unnecessary shebang from gtk python modules.

### DIFF
--- a/tuned/gtk/gui_plugin_loader.py
+++ b/tuned/gtk/gui_plugin_loader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2008-2014 Red Hat, Inc.

--- a/tuned/gtk/gui_profile_loader.py
+++ b/tuned/gtk/gui_profile_loader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2008-2014 Red Hat, Inc.

--- a/tuned/gtk/managerException.py
+++ b/tuned/gtk/managerException.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2008-2014 Red Hat, Inc.


### PR DESCRIPTION
Currently the modules in tuned/gtk/* include shebangs. Since these modules are not intended for executing remove them.

This will also silence rpmlint warnings.