### PR TITLE
cpu: Don't log error in execute() if EPB is not supported

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -60,7 +60,8 @@ class CPULatencyPlugin(base.Plugin):
 
 	def _check_energy_perf_bias(self):
 		self._has_energy_perf_bias = False
-		retcode = self._cmd.execute(["x86_energy_perf_policy", "-r"], no_errors = [errno.ENOENT])[0]
+		retcode_unsupported = 1
+		retcode = self._cmd.execute(["x86_energy_perf_policy", "-r"], no_errors = [errno.ENOENT, retcode_unsupported])[0]
 		if retcode == 0:
 			self._has_energy_perf_bias = True
 		elif retcode < 0:


### PR DESCRIPTION
Don't log error in commands.execute() if MSR_IA32_ENERGY_PERF_BIAS
is not supported. A message with level WARN is already logged
afterwards:

WARNING  tuned.plugins.plugin_cpu: your CPU doesn't support
         MSR_IA32_ENERGY_PERF_BIAS, ignoring CPU energy performance bias

Resolves: rhbz#1443182

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>