### PR TITLE
Improve logging

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -457,9 +457,9 @@ class Plugin(object):
 				log.warn("cannot compare new value '%s' with current value '%s' by operator '%s', using '%s' directly as new value" % (val, current_value, op, new_value))
 		return new_value
 
-	def _get_current_value(self, command, device = None):
+	def _get_current_value(self, command, device = None, ignore_missing=False):
 		if device is not None:
-			return command["get"](device)
+			return command["get"](device, ignore_missing=ignore_missing)
 		else:
 			return command["get"]()
 
@@ -529,7 +529,7 @@ class Plugin(object):
 	def _verify_device_command(self, instance, command, device, new_value, ignore_missing):
 		if command["custom"] is not None:
 			return command["custom"](True, new_value, device, True, ignore_missing)
-		current_value = self._get_current_value(command, device)
+		current_value = self._get_current_value(command, device, ignore_missing=ignore_missing)
 		new_value = self._process_assignment_modifiers(new_value, current_value)
 		if new_value is None:
 			return None

--- a/tuned/plugins/plugin_audio.py
+++ b/tuned/plugins/plugin_audio.py
@@ -70,9 +70,9 @@ class AudioPlugin(base.Plugin):
 			return None
 
 	@command_get("timeout")
-	def _get_timeout(self, device):
+	def _get_timeout(self, device, ignore_missing=False):
 		sys_file = self._timeout_path(device)
-		value = cmd.read_file(sys_file)
+		value = cmd.read_file(sys_file, no_error=ignore_missing)
 		if len(value) > 0:
 			return value
 		return None
@@ -88,7 +88,7 @@ class AudioPlugin(base.Plugin):
 		return None
 
 	@command_get("reset_controller")
-	def _get_reset_controller(self, device):
+	def _get_reset_controller(self, device, ignore_missing=False):
 		sys_file = self._reset_controller_path(device)
 		if os.path.exists(sys_file):
 			value = cmd.read_file(sys_file)

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -205,11 +205,11 @@ class CPULatencyPlugin(base.Plugin):
 		return str(governor)
 
 	@command_get("governor")
-	def _get_governor(self, device):
+	def _get_governor(self, device, ignore_missing=False):
 		governor = None
 		if not self._check_cpu_can_change_governor(device):
 			return None
-		data = self._cmd.read_file("/sys/devices/system/cpu/%s/cpufreq/scaling_governor" % device).strip()
+		data = self._cmd.read_file("/sys/devices/system/cpu/%s/cpufreq/scaling_governor" % device, no_error=ignore_missing).strip()
 		if len(data) > 0:
 			governor = data
 
@@ -249,8 +249,8 @@ class CPULatencyPlugin(base.Plugin):
 		return val
 
 	@command_get("sampling_down_factor")
-	def _get_sampling_down_factor(self, device):
-		governor = self._get_governor(device)
+	def _get_sampling_down_factor(self, device, ignore_missing=False):
+		governor = self._get_governor(device, ignore_missing=ignore_missing)
 		if governor is None:
 			return None
 		path = self._sampling_down_factor_path(governor)
@@ -286,7 +286,7 @@ class CPULatencyPlugin(base.Plugin):
 		return {0:"performance", 6:"normal", 15:"powersave"}.get(self._try_parse_num(s), s)
 
 	@command_get("energy_perf_bias")
-	def _get_energy_perf_bias(self, device):
+	def _get_energy_perf_bias(self, device, ignore_missing=False):
 		energy_perf_bias = None
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -237,11 +237,11 @@ class DiskPlugin(hotplug.Plugin):
 		return value
 
 	@command_get("elevator")
-	def _get_elevator(self, device):
+	def _get_elevator(self, device, ignore_missing=False):
 		sys_file = self._elevator_file(device)
 		# example of scheduler file content:
 		# noop deadline [cfq]
-		return self._cmd.get_active_option(self._cmd.read_file(sys_file))
+		return self._cmd.get_active_option(self._cmd.read_file(sys_file, no_error=ignore_missing))
 
 	@command_set("apm", per_device=True)
 	def _set_apm(self, value, device, sim):
@@ -254,7 +254,7 @@ class DiskPlugin(hotplug.Plugin):
 			return None
 
 	@command_get("apm")
-	def _get_apm(self, device):
+	def _get_apm(self, device, ignore_missing=False):
 		value = None
 		err = False
 		(rc, out) = self._cmd.execute(["hdparm", "-B", "/dev/" + device], no_errors = [errno.ENOENT])
@@ -284,7 +284,7 @@ class DiskPlugin(hotplug.Plugin):
 			return None
 
 	@command_get("spindown")
-	def _get_spindown(self, device):
+	def _get_spindown(self, device, ignore_missing=False):
 		# There's no way how to get current/old spindown value, hardcoding vendor specific 253
 		return 253
 
@@ -308,9 +308,9 @@ class DiskPlugin(hotplug.Plugin):
 		return val
 
 	@command_get("readahead")
-	def _get_readahead(self, device):
+	def _get_readahead(self, device, ignore_missing=False):
 		sys_file = self._readahead_file(device)
-		value = self._cmd.read_file(sys_file).strip()
+		value = self._cmd.read_file(sys_file, no_error=ignore_missing).strip()
 		if len(value) == 0:
 			return None
 		return int(value)
@@ -345,10 +345,11 @@ class DiskPlugin(hotplug.Plugin):
 		return value
 
 	@command_get("scheduler_quantum")
-	def _get_scheduler_quantum(self, device):
+	def _get_scheduler_quantum(self, device, ignore_missing=False):
 		sys_file = self._scheduler_quantum_file(device)
-		value = self._cmd.read_file(sys_file).strip()
+		value = self._cmd.read_file(sys_file, no_error=ignore_missing).strip()
 		if len(value) == 0:
-			log.info("disk_scheduler_quantum option is not supported by this HW")
+			if not ignore_missing:
+				log.info("disk_scheduler_quantum option is not supported by this HW")
 			return None
 		return int(value)

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -227,7 +227,7 @@ class NetTuningPlugin(base.Plugin):
 		return value
 
 	@command_get("wake_on_lan")
-	def _get_wake_on_lan(self, device):
+	def _get_wake_on_lan(self, device, ignore_missing=False):
 		value = None
 		try:
 			m = re.match(r".*Wake-on:\s*([" + WOL_VALUES + "]+).*", self._cmd.execute(["ethtool", device])[1], re.S)

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -81,7 +81,7 @@ class SCSIHostPlugin(hotplug.Plugin):
 		return policy
 
 	@command_get("alpm")
-	def _get_alpm(self, device):
+	def _get_alpm(self, device, ignore_missing=False):
 		policy_file = self._get_alpm_policy_file(device)
 		policy = self._cmd.read_file(policy_file, no_error = True).strip()
 		return policy if policy != "" else None

--- a/tuned/plugins/plugin_usb.py
+++ b/tuned/plugins/plugin_usb.py
@@ -53,6 +53,6 @@ class USBPlugin(base.Plugin):
 		return val
 
 	@command_get("autosuspend")
-	def _get_autosuspend(self, device):
+	def _get_autosuspend(self, device, ignore_missing=False):
 		sys_file = self._autosuspend_sysfile(device)
-		return self._cmd.read_file(sys_file).strip()
+		return self._cmd.read_file(sys_file, no_error=ignore_missing).strip()

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -68,9 +68,9 @@ class VideoPlugin(base.Plugin):
 
 
 	@command_get("radeon_powersave")
-	def _get_radeon_powersave(self, device):
+	def _get_radeon_powersave(self, device, ignore_missing=False):
 		sys_files = self._radeon_powersave_files(device)
-		method = self._cmd.read_file(sys_files["method"]).strip()
+		method = self._cmd.read_file(sys_files["method"], no_error=ignore_missing).strip()
 		if method == "profile":
 			return self._cmd.read_file(sys_files["profile"]).strip()
 		elif method == "dynpm":


### PR DESCRIPTION
Note: With commit 66d4843 you get tons of warnings in the logs when the isolated_cores parameter is set, such as the following:
tuned.plugins.plugin_scheduler: Affinity of PID 9534 is not changeable.
tuned.plugins.plugin_scheduler: Affinity of PID 522 is not changeable.

It seems all the PIDs it's complaining about are kernel threads. Maybe we could change the behaviour so that:
* Tuned doesn't complain about not being able to change affinity of kernel threads, and/or
* Log only one message after the migration is completed saying that _some_ tasks could not be migrated