### PR TITLE
Fix race between DBus exporter startup and applying a profile

### DIFF
--- a/tuned/exports/dbus_exporter.py
+++ b/tuned/exports/dbus_exporter.py
@@ -133,6 +133,9 @@ class DBusExporter(interfaces.ExporterInterface):
 			self._construct_dbus_object_class()
 
 		self.stop()
+		bus = dbus.SystemBus()
+		bus_name = dbus.service.BusName(self._bus_name, bus)
+		self._bus_object = self._dbus_object_cls(bus, self._object_name, bus_name)
 		self._thread = threading.Thread(target=self._thread_code)
 		self._thread.start()
 
@@ -143,10 +146,6 @@ class DBusExporter(interfaces.ExporterInterface):
 			self._thread = None
 
 	def _thread_code(self):
-		bus = dbus.SystemBus()
-		bus_name = dbus.service.BusName(self._bus_name, bus)
-		self._bus_object = self._dbus_object_cls(bus, self._object_name, bus_name)
-
 		self._main_loop.run()
 		del self._bus_object
 		self._bus_object = None


### PR DESCRIPTION
Previously if the profile was applied before all methods and
signals were exported on DBus, the daemon thread (_thread_code()
in daemon.py) could crash after attempting to emit a signal on DBus
announcing that a profile was applied.

A regular user is unlikely to run into the race in practice, but it
frequently happens when applying an empty profile for testing purposes.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>