### PR TITLE
plugin_video: Prefix DPM states with 'dpm-'

### DIFF
--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -13,7 +13,7 @@ energy_perf_bias=normal
 timeout=10
 
 [video]
-radeon_powersave=balanced, auto
+radeon_powersave=dpm-balanced, auto
 
 [disk]
 # Comma separated list of devices, all devices if commented out.

--- a/profiles/desktop-powersave/tuned.conf
+++ b/profiles/desktop-powersave/tuned.conf
@@ -7,7 +7,7 @@ summary=Optmize for the desktop use-case with power saving
 include=server-powersave
 
 [video]
-radeon_powersave=powersave, auto
+radeon_powersave=dpm-battery, auto
 
 [net]
 # Comma separated list of devices, all devices if commented out.

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -17,7 +17,7 @@ energy_perf_bias=powersave
 timeout=10
 
 [video]
-radeon_powersave=powersave, auto
+radeon_powersave=dpm-battery, auto
 
 [disk]
 # Comma separated list of devices, all devices if commented out.

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -65,10 +65,11 @@ class VideoPlugin(base.Plugin):
 					if (self._cmd.write_to_file(sys_files["method"], "dynpm")):
 						return "dynpm"
 			# new DPM profiles, recommended to use if supported
-			elif v in ["battery", "balanced", "performance"]:
+			elif v in ["dpm-battery", "dpm-balanced", "dpm-performance"]:
 				if not sim:
+					state = v[len("dpm-"):]
 					if (self._cmd.write_to_file(sys_files["method"], "dpm") and
-						self._cmd.write_to_file(sys_files["dpm_state"], v)):
+						self._cmd.write_to_file(sys_files["dpm_state"], state)):
 						return v
 			else:
 				if not sim:
@@ -85,6 +86,6 @@ class VideoPlugin(base.Plugin):
 		elif method == "dynpm":
 			return method
 		elif method == "dpm":
-			return self._cmd.read_file(sys_files["dpm_state"]).strip()
+			return "dpm-" + self._cmd.read_file(sys_files["dpm_state"]).strip()
 		else:
 			return None


### PR DESCRIPTION
In the end, I like your version better. It's short and sweet. But let's prefix DPM states with 'dpm-' to prevent future name collisions. Graphics cards manufacturers are very creative, I'm sure they will come up with a completely new power management mechanism soon :).

Also, change the state in powersave profiles to 'battery' - for some strange reason, there's
no such DPM state as 'powersave' and the lowest power consumption state is called 'battery'.