### PR TITLE
Expand variables in the 'devices' option

### DIFF
--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -60,7 +60,13 @@ class Loader(object):
 		if "variables" in final_profile.units:
 			self._variables.add_from_cfg(final_profile.units["variables"].options)
 			del(final_profile.units["variables"])
+		# FIXME hack, do all variable expansions in one place
+		self._expand_vars_in_devices(final_profile)
 		return final_profile
+
+	def _expand_vars_in_devices(self, profile):
+		for unit in profile.units:
+			profile.units[unit].devices = self._variables.expand(profile.units[unit].devices)
 
 	def _load_profile(self, profile_names, profiles, processed_files):
 		for name in profile_names:


### PR DESCRIPTION
Variables in the 'devices' option were not being expanded. This is
bad. It shows that the current variable expansion system is broken.
We need to come up with a consistent, well-defined way of expanding
variables. Preferably it should be done all in one place.

The expansion is probably still not done for options 'type', 'enabled',
'replace', 'devices_udev_regex', 'script_pre' and 'script_post'. Let's
deal with that later, as we don't need it in our profiles right now.

Related: rhbz#1490399

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>