### PR TITLE
port realtime virtual host profile to Fedora

### DIFF
--- a/profiles/realtime-virtual-host/run-tscdeadline-latency.sh
+++ b/profiles/realtime-virtual-host/run-tscdeadline-latency.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-QEMU=/usr/libexec/qemu-kvm
+QEMU=$(type -P qemu-kvm || echo /usr/libexec/qemu-kvm)
 
 if [ ! -f /sys/module/kvm/parameters/lapic_timer_advance_ns ]; then
         echo "/sys/module/kvm/parameters/lapic_timer_advance_ns not found"
@@ -14,7 +14,7 @@ for i in `seq 1000 500 7000`; do
 	chrt -f 1 taskset -c $1 $QEMU -enable-kvm -device pc-testdev \
 		-device isa-debug-exit,iobase=0xf4,iosize=0x4 \
 		-display none -serial stdio -device pci-testdev \
-		-kernel /usr/share/qemu-kvm/tscdeadline_latency.flat  \
+		-kernel /usr/share/tuned/tscdeadline_latency.flat  \
 		-cpu host | grep latency | cut -f 2 -d ":" > $dir/out
 
 	A=0

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -26,7 +26,7 @@ start() {
 
 
     if [ -f $ltanfile -a ! -f ./lapic_timer_adv_ns ]; then
-        if [ -f /usr/share/qemu-kvm/tscdeadline_latency.flat ]; then
+        if [ -f /usr/share/tuned/tscdeadline_latency.flat ]; then
              tempdir=`mktemp -d`
              isolatedcpu=`echo "$TUNED_isolated_cores_expanded" | cut -f 1 -d ","`
              sh ./run-tscdeadline-latency.sh $isolatedcpu > $tempdir/lat.out


### PR DESCRIPTION
RHEL ships tscdeadline_latency.flat as part of the qemu-kvm-tools package, but Fedora does not. In addition, the script that runs it refers to /usr/libexec/qemu-kvm that doesn't exist in Fedora (where qemu-kvm is simply on the path).

The solution is to package the benchmark in tuned, and once we do this we can look it in /usr/share/tuned instead of /usr/share/qemu-kvm.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>