### PR TITLE
Fixed W3C validation errors; added more indentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.1//EN' 'http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd'>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"><head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="generator" content="vi and me :)" />
-<meta http-equiv="X-UA-Compatible" content="IE=9999" />
-<link rel="stylesheet" type="text/css" href="style.css">
-<title>Tuned project</title>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="generator" content="vi and me :)" />
+  <meta http-equiv="X-UA-Compatible" content="IE=9999" />
+  <link rel="stylesheet" type="text/css" href="style.css" />
+  <title>Tuned project</title>
 </head>
+
 <body>
-<map id="download">
-  <area shape="rect" coords="754,90,1032,149" href="https://github.com/redhat-performance/tuned/releases" alt="Download" />
-</map>
-<img alt="Tuned header" src="header1.png" usemap="#download" />
+  <div id="header-container">
+    <map id="download">
+      <area shape="rect" coords="754,90,1032,149" href="https://github.com/redhat-performance/tuned/releases" alt="Download" />
+    </map>
+    <img alt="Tuned header" src="header1.png" usemap="#download" />
+  </div>
 
 <h1>Introduction</h1>
 <p>Tuned is a system tuning service for Linux. It:</p>


### PR DESCRIPTION
The fixes:

- Closed the <link> element with the correct "/>" XHTML syntax.
- Wrapped the header <img> and the associated <map> element in a simple <div>.

Also, I've indented a couple of lines for the structure to be slightly clearer.