### PR TITLE
tuned: Add readahead comment to throughput-performance tuned.conf

### DIFF
--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -11,6 +11,9 @@ energy_perf_bias=performance
 min_perf_pct=100
 
 [disk]
+# The default unit for readahead is KiB.  This can be adjusted to sectors
+# by specifying the relevant suffix, eg. (readahead => 8192 s). There must
+# be at least one space between the number and suffix (if suffix is specified).
 readahead=>4096
 
 [sysctl]


### PR DESCRIPTION
A common source of confusion within tuned is the lack of suffix
on the readahead specification in the throughput-performance
tuned.conf. This confusion is resolved, in general, by comparing
the value, for example, to blockdev or lvdisplay output. Avoid
future end-user confusion by adding a comment to the
throughput-performance tuned.conf file, explaining that the default
is in KiB, and noting the allowance of a sector suffix as well.

Signed-off-by: John Pittman <jpittman@redhat.com>