### PR TITLE
Fix verifying cpumask on systems with more than 32 cores

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -490,8 +490,8 @@ class Plugin(object):
 
 	def _norm_value(self, value):
 		v = self._cmd.unquote(str(value))
-		if re.match(r'\s*(0+,)+[\da-fA-F]*\s*$', v):
-			return re.sub(r'^\s*(0+,)+', "", v)
+		if re.match(r'\s*(0+,?)+([\da-fA-F]*,?)*\s*$', v):
+			return re.sub(r'^\s*(0+,?)+', "", v)
 		return v
 
 	def _verify_value(self, name, new_value, current_value, ignore_missing, device = None):

--- a/tuned/plugins/plugin_sysfs.py
+++ b/tuned/plugins/plugin_sysfs.py
@@ -60,7 +60,7 @@ class SysfsPlugin(base.Plugin):
 		return re.match(r"^/sys/.*", sysfs_file)
 
 	def _read_sysfs(self, sysfs_file):
-		data = self._cmd.read_file(sysfs_file)
+		data = self._cmd.read_file(sysfs_file).strip()
 		if len(data) > 0:
 			return self._cmd.get_active_option(data, False)
 		else:


### PR DESCRIPTION
Previously verifying the value of a cpumask on systems with more than
32 cores always failed. There are two reasons for this:
1. When there are more than 32 cores, string comparison is done on the
   cpu masks. This failed because the value read from sysfs contained
   a line feed and was not stripped.
2. The cpumask value was not properly normalized when the value had multiple
   non-zero comma separated parts, e.g. '00ffffff,80808000'

Resolves: rhbz#1528368