### PR TITLE
tuned-adm: Print only CONSOLE log messages by default

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -115,7 +115,7 @@ ACTIVE_PROFILE_MANUAL = "manual"
 
 LOG_LEVEL_CONSOLE = 60
 LOG_LEVEL_CONSOLE_NAME = "CONSOLE"
-CAPTURE_LOG_LEVEL = "error"
+CAPTURE_LOG_LEVEL = "console"
 CAPTURE_LOG_LEVELS = {
 		"debug": logging.DEBUG,
 		"info": logging.INFO,


### PR DESCRIPTION
Print only log messages with log level CONSOLE by default in tuned-adm.
If we had the log level set to ERROR, people might be surprised they
suddenly get a lot of errors. The errors will probably in most cases
be harmless, e.g. a tuning is not supported on the user's system. We
should first make the logging consistent so that messages about
unsupported tunings are logged as WARN instead. Then we change tuned-adm
to print messages with level ERROR as well.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>