### PR TITLE
tuned-adm: Fix a traceback when run without arguments

### DIFF
--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -94,6 +94,9 @@ if __name__ == "__main__":
 	parser_profile_mode = subparsers.add_parser("profile_mode", help="show current profile selection mode")
 	parser_profile_mode.set_defaults(action="profile_mode")
 
+	if len(sys.argv) < 2:
+		parser.print_usage(file = sys.stderr)
+		sys.exit(1)
 	args = parser.parse_args(sys.argv[1:])
 
 	options = vars(args)


### PR DESCRIPTION
Running tuned-adm without arguments using Python 3 results in
a traceback. This is because in this case parse_args does not
exit with a usage message in Python 3 and the 'action' option
is then undefined. So let's check for this case and print the
usage message ourselves. There may be a better solution to this,
but I wasn't able to come up with anything in a reasonable amount
of time.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>