### PR TITLE
tuned-adm: Fix a traceback when run without action specified

### DIFF
--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -94,16 +94,17 @@ if __name__ == "__main__":
 	parser_profile_mode = subparsers.add_parser("profile_mode", help="show current profile selection mode")
 	parser_profile_mode.set_defaults(action="profile_mode")
 
-	if len(sys.argv) < 2:
-		parser.print_usage(file = sys.stderr)
-		sys.exit(1)
 	args = parser.parse_args(sys.argv[1:])
 
 	options = vars(args)
 	debug = options.pop("debug")
 	asynco = options.pop("async")
 	timeout = options.pop("timeout")
-	action_name = options.pop("action")
+	try:
+		action_name = options.pop("action")
+	except KeyError:
+		parser.print_usage(file = sys.stderr)
+		sys.exit(1)
 	log_level = options.pop("loglevel")
 	result = False
 


### PR DESCRIPTION
The previous fix was not sufficient, tuned-adm still tracebacks
in cases when options are specified, but an action is not, e.g.:
$ python3 ./tuned-adm.py -a
Traceback (most recent call last):
  File "./tuned-adm.py", line 106, in <module>
    action_name = options.pop("action")
KeyError: 'action'

The object returned by ArgumentParser.add_subparsers recognizes
a 'required' attribute (at least in Python 3), which is probably
meant to allow to make specifying an action required, but I wasn't
able to make it work properly, I get errors such as
Traceback (most recent call last):
  File "./tuned-adm.py", line 98, in <module>
    args = parser.parse_args(sys.argv[1:])
  File "/usr/lib64/python3.6/argparse.py", line 1730, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib64/python3.6/argparse.py", line 1762, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib64/python3.6/argparse.py", line 1997, in _parse_known_args
    ', '.join(required_actions))
TypeError: sequence item 0: expected str instance, NoneType found

which I think is not expected. The error is raised here:
https://github.com/python/cpython/blob/6ceab46a602c6653356d67d7479391fba0b35697/Lib/argparse.py#L2001

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>