### PR TITLE
tuned-gui: Sort plugins based on their name

### DIFF
--- a/tuned-gui.py
+++ b/tuned-gui.py
@@ -278,7 +278,8 @@ class Base(object):
 		self.treestore_profiles = Gtk.ListStore(GObject.TYPE_STRING,
 				GObject.TYPE_STRING)
 		self.treestore_plugins = Gtk.ListStore(GObject.TYPE_STRING)
-		for plugin in sorted(self.plugin_loader.plugins):
+		for plugin in sorted(self.plugin_loader.plugins,
+				key = lambda plugin: plugin.name):
 			self.treestore_plugins.append([plugin.name])
 		self.combobox_plugins = \
 			self.builder.get_object('comboboxPlugins')


### PR DESCRIPTION
Previously the sorting was done by comparing the objects themselves,
which is not what we want and it doesn't work in Python 3 - TypeError
is raised, e.g:
TypeError: '<' not supported between instances of 'BootloaderPlugin' and 'MountsPlugin'

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>