### PR TITLE
log: add two options(log_file_count and log_file_maxbytes) in the mai…

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -32,3 +32,9 @@ default_instance_priority = 0
 
 # Udev buffer size
 udev_buffer_size = 1MB
+
+# Log file count
+log_file_count = 2
+
+# Log file max size
+log_file_max_size = 100KB

--- a/tuned.py
+++ b/tuned.py
@@ -55,13 +55,15 @@ if __name__ == "__main__":
 		log.setLevel("DEBUG")
 
 	try:
+		maxBytes = config.get_size("log_file_max_size", consts.LOG_FILE_MAXBYTES)
+		backupCount = config.get("log_file_count", consts.LOG_FILE_COUNT)
 		if args.daemon:
 			if args.log is None:
 				args.log = consts.LOG_FILE
-			log.switch_to_file(args.log)
+			log.switch_to_file(args.log, maxBytes, backupCount)
 		else:
 			if args.log is not None:
-				log.switch_to_file(args.log)
+				log.switch_to_file(args.log, maxBytes, backupCount)
 
 		app = tuned.daemon.Application(args.profile, config)
 

--- a/tuned/logs.py
+++ b/tuned/logs.py
@@ -104,8 +104,10 @@ class TunedLogger(logging.getLoggerClass()):
 		self.remove_all_handlers()
 		self.addHandler(self._console_handler)
 
-	def switch_to_file(self, filename = consts.LOG_FILE):
-		self._setup_file_handler(filename)
+	def switch_to_file(self, filename = consts.LOG_FILE, 
+			   maxBytes = consts.LOG_FILE_MAXBYTES,
+			   backupCount = consts.LOG_FILE_COUNT):
+		self._setup_file_handler(filename, maxBytes, backupCount)
 		self.remove_all_handlers()
 		self.addHandler(self._file_handler)
 
@@ -123,7 +125,7 @@ class TunedLogger(logging.getLoggerClass()):
 		cls._console_handler.setFormatter(cls._formatter)
 
 	@classmethod
-	def _setup_file_handler(cls, filename):
+	def _setup_file_handler(cls, filename, maxBytes, backupCount):
 		if cls._file_handler is not None:
 			return
 
@@ -134,7 +136,7 @@ class TunedLogger(logging.getLoggerClass()):
 			os.makedirs(log_directory)
 
 		cls._file_handler = logging.handlers.RotatingFileHandler(
-			filename, maxBytes = consts.LOG_FILE_MAXBYTES, backupCount = consts.LOG_FILE_COUNT)
+			filename, maxBytes = maxBytes, backupCount = backupCount)
 		cls._file_handler.setFormatter(cls._formatter)
 
 logging.addLevelName(consts.LOG_LEVEL_CONSOLE, consts.LOG_LEVEL_CONSOLE_NAME)


### PR DESCRIPTION
…n config file

Currently the logrotation is not configurable. On system with large
amount of cpus a tuned start creates a lot of entries and older log
entries are lost.