### PR TITLE
recommend.conf: Describe syspurpose_role and chassis_type

### DIFF
--- a/recommend.conf
+++ b/recommend.conf
@@ -10,12 +10,16 @@
 # KEYWORD22=RE22
 
 # KEYWORD can be:
-# virt    - for RE to match output of virt-what
-# system  - for RE to match content of /etc/system-release-cpe
-# process - for RE to match running processes. It can have arbitrary suffix, all
-#           process* lines have to match for the PROFILE to match (i.e. the AND operator)
-# /FILE   - for RE to match content of the FILE, e.g.: '/etc/passwd=.+'. If file doesn't
-#           exist, its RE will not match.
+# virt            - for RE to match output of virt-what
+# system          - for RE to match content of /etc/system-release-cpe
+# process         - for RE to match running processes. It can have arbitrary
+#                   suffix, all process* lines have to match for the PROFILE
+#                   to match (i.e. the AND operator)
+# /FILE           - for RE to match content of the FILE, e.g.:
+#                   '/etc/passwd=.+'. If file doesn't exist, its RE will not
+#                   match.
+# chassis_type    - for RE to match the chassis type as reported by dmidecode
+# syspurpose_role - for RE to match the system role as reported by syspurpose
 
 # All REs for all KEYWORDs have to match for PROFILE to match (i.e. the AND operator).
 # If 'virt' or 'system' is not specified, it matches for every string.


### PR DESCRIPTION
Describe syspurpose_role and chassis_type in the documentation in
recommend.conf

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>