### PR TITLE
Make python-dmidecode a weak dependency

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -57,10 +57,10 @@ Requires: %{_py}-schedutils, %{_py}-linux-procfs, %{_py}-perf
 # requires for packages with inconsistent python2/3 names
 %if %{with python3}
 Requires: python3-dbus, python3-gobject-base
-Requires: python3-dmidecode
+Recommends: python3-dmidecode
 %else
 Requires: dbus-python, pygobject3-base
-Requires: python-dmidecode
+Recommends: python-dmidecode
 %endif
 Requires: virt-what, ethtool, gawk, hdparm
 Requires: util-linux, dbus, polkit

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -9,7 +9,11 @@ import re
 import procfs
 from subprocess import *
 from tuned.exceptions import TunedException
-import dmidecode
+try:
+	import dmidecode
+	have_dmidecode = True
+except:
+	have_dmidecode = False
 try:
 	import syspurpose.files
 	have_syspurpose = True
@@ -420,12 +424,15 @@ class commands:
 						if len(ps.find_by_regex(re.compile(value))) == 0:
 							match = False
 					elif option == "chassis_type":
-						for chassis in dmidecode.chassis().values():
-							chassis_type = chassis["data"]["Type"].decode("ascii")
-							if re.match(value, chassis_type, re.IGNORECASE):
-								break
+						if have_dmidecode:
+							for chassis in dmidecode.chassis().values():
+								chassis_type = chassis["data"]["Type"].decode("ascii")
+								if re.match(value, chassis_type, re.IGNORECASE):
+									break
+							else:
+								match = False
 						else:
-							match = False
+							log.debug("Ignoring 'chassis_type' in '%s', dmidecode is not available." % fname)
 					elif option == "syspurpose_role":
 						if have_syspurpose:
 							s = syspurpose.files.SyspurposeStore(


### PR DESCRIPTION
It's only available on x86_64.

Resolves: rhbz#1565598

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>