### PR TITLE
Make virtual-host identical to latency-performance

### DIFF
--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -4,42 +4,4 @@
 
 [main]
 summary=Optimize for running KVM guests
-
-[cpu]
-force_latency=1
-governor=performance
-energy_perf_bias=performance
-min_perf_pct=100
-
-[sysctl]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns=10000000
-
-# If a workload mostly uses anonymous memory and it hits this limit, the entire
-# working set is buffered for I/O, and any more write buffering would require
-# swapping, so it's time to throttle writes until I/O can catch up.  Workloads
-# that mostly use file mappings may be able to use even higher values.
-#
-# The generator of dirty data starts writeback at this percentage (system default
-# is 20%)
-vm.dirty_ratio=10
-
-# Start background writeback (via writeback threads) at this percentage (system
-# default is 10%)
-vm.dirty_background_ratio=3
-
-# The swappiness parameter controls the tendency of the kernel to move
-# processes out of physical memory and onto the swap disk.
-# 0 tells the kernel to avoid swapping processes out of physical memory
-# for as long as possible
-# 100 tells the kernel to aggressively swap processes out of physical memory
-# and move them to swap cache
-vm.swappiness=10
-
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=5000000
+include=latency-performance

--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -4,4 +4,17 @@
 
 [main]
 summary=Optimize for running KVM guests
-include=latency-performance
+include=throughput-performance
+
+[sysctl]
+# Start background writeback (via writeback threads) at this percentage (system
+# default is 10%)
+vm.dirty_background_ratio = 5
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+kernel.sched_migration_cost_ns = 5000000
+
+# Setting C3 state sleep mode/power savings
+force_latency=70

--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -4,14 +4,42 @@
 
 [main]
 summary=Optimize for running KVM guests
-include=throughput-performance
+
+[cpu]
+force_latency=1
+governor=performance
+energy_perf_bias=performance
+min_perf_pct=100
 
 [sysctl]
+# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+kernel.sched_min_granularity_ns=10000000
+
+# If a workload mostly uses anonymous memory and it hits this limit, the entire
+# working set is buffered for I/O, and any more write buffering would require
+# swapping, so it's time to throttle writes until I/O can catch up.  Workloads
+# that mostly use file mappings may be able to use even higher values.
+#
+# The generator of dirty data starts writeback at this percentage (system default
+# is 20%)
+vm.dirty_ratio=10
+
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-vm.dirty_background_ratio = 5
+vm.dirty_background_ratio=3
+
+# The swappiness parameter controls the tendency of the kernel to move
+# processes out of physical memory and onto the swap disk.
+# 0 tells the kernel to avoid swapping processes out of physical memory
+# for as long as possible
+# 100 tells the kernel to aggressively swap processes out of physical memory
+# and move them to swap cache
+vm.swappiness=10
 
 # The total time the scheduler will consider a migrated process
 # "cache hot" and thus less likely to be re-migrated
 # (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns = 5000000
+kernel.sched_migration_cost_ns=5000000


### PR DESCRIPTION
The default tuned profile for an oVirt cluster is "virtual-host".
Recently, testing at customer sites and performance labs has shown
that "latency-performance" yields better results. This patch makes
virtual-host profile identical to latency-performance. This seems
better than uniting them since this way we maintain the possibility
to tweak them in different ways in the future according to further
findings.

fixes #131 

Change-Id: I1a64fac22364b17de1279a3e1f37a6b7eb0fe61b
Bug-Url: https://bugzilla.redhat.com/1588932
Signed-off-by: Ori_Liel <oliel@redhat.com>