### PR TITLE
Disable KSM only once, re-enable it only on full rollback

### DIFF
--- a/profiles/cpu-partitioning/script.sh
+++ b/profiles/cpu-partitioning/script.sh
@@ -54,8 +54,8 @@ stop() {
     then
         sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance
         teardown_kvm_mod_low_latency
+        enable_ksm
     fi
-    enable_ksm
     enable_balance_domains
     return "$?"
 }

--- a/profiles/functions
+++ b/profiles/functions
@@ -531,20 +531,30 @@ teardown_kvm_mod_low_latency()
 
 KSM_SERVICES="ksm ksmtuned"
 KSM_RUN_PATH=/sys/kernel/mm/ksm/run
+KSM_MASK_FILE="${STORAGE_PERSISTENT}/ksm-masked"
 
 disable_ksm()
 {
-	systemctl -q --runtime --now mask $KSM_SERVICES
-
-	if [ -f $KSM_RUN_PATH ]; then
+	if [ ! -f $KSM_MASK_FILE ]; then
+		# Always create $KSM_MASK_FILE, since we don't want to
+		# run any systemctl commands during boot
+		if ! touch $KSM_MASK_FILE; then
+			die "failed to create $KSM_MASK_FILE"
+		fi
+		systemctl --now --quiet mask $KSM_SERVICES
 		# Unmerge all shared pages
-		echo 2 > $KSM_RUN_PATH
+		test -f $KSM_RUN_PATH && echo 2 > $KSM_RUN_PATH
 	fi
 }
 
+# Should only be called when full_rollback == true
 enable_ksm()
 {
-	systemctl -q unmask $KSM_SERVICES
+	if [ -f $KSM_MASK_FILE ]; then
+		if systemctl --quiet unmask $KSM_SERVICES; then
+			rm -f $KSM_MASK_FILE
+		fi
+	fi
 }
 
 die() {

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -104,8 +104,10 @@ start() {
 }
 
 stop() {
-    [ "$1" = "full_rollback" ] && teardown_kvm_mod_low_latency
-    enable_ksm
+    if [ "$1" = "full_rollback" ]; then
+        teardown_kvm_mod_low_latency
+        enable_ksm
+    fi
     systemctl stop rt-entsk
     return "$?"
 }


### PR DESCRIPTION
Disabling the ksm and ksmtuned services during boot seems to cause
problems, so do it only once when the profile is first applied and
reenable the services only when full rollback is required.

Resolves: rhbz#1622239

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>