### PR TITLE
logs: actually use SystemRandom source for generating a random string

### DIFF
--- a/tuned/logs.py
+++ b/tuned/logs.py
@@ -30,7 +30,7 @@ def _random_string(length):
 	chars = string.ascii_letters + string.digits
 	res = ""
 	for i in range(length):
-		res += random.choice(chars)
+		res += r.choice(chars)
 	return res
 
 def log_capture_start(log_level):


### PR DESCRIPTION
The returned string was only pseudo random. It is only used for the
log_capture_start() mechanism at the moment. Therefore an attacker might
be able to guess the tokens of other users. Since this data it publicly
available anyways it should not be a big issue, however.