### PR TITLE
Make copy of instance's devices before executing changes to system

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -6,6 +6,7 @@ import collections
 from tuned.utils.commands import commands
 import os
 from subprocess import Popen, PIPE
+import copy
 
 log = tuned.logs.get()
 
@@ -186,19 +187,19 @@ class Plugin(object):
 	# Tuning activation and deactivation.
 	#
 
-	def _run_for_each_device(self, instance, callback):
+	def _run_for_each_device(self, instance, callback, instance_devices):
 		if self._devices_supported:
-			devices = instance.devices
+			devices = instance_devices
 		else:
 			devices = [None, ]
 
 		for device in devices:
 			callback(instance, device)
 
-	def _instance_pre_static(self, instance, enabling):
+	def _instance_pre_static(self, instance, enabling, devices):
 		pass
 
-	def _instance_post_static(self, instance, enabling):
+	def _instance_post_static(self, instance, enabling, devices):
 		pass
 
 	def _call_device_script(self, instance, script, op, devices, full_rollback = False):
@@ -236,6 +237,10 @@ class Plugin(object):
 				ret = False
 		return ret
 
+	def _copy_instance_devices(self, instance):
+		"""Return a copy of instance devices"""
+		return copy.copy(instance.devices)
+
 	def instance_apply_tuning(self, instance):
 		"""
 		Apply static and dynamic tuning if the plugin instance is active.
@@ -243,14 +248,16 @@ class Plugin(object):
 		if not instance.active:
 			return
 
+		current_devices = self._copy_instance_devices(instance)
+
 		if instance.has_static_tuning:
-			self._call_device_script(instance, instance.script_pre, "apply", instance.devices)
-			self._instance_pre_static(instance, True)
-			self._instance_apply_static(instance)
-			self._instance_post_static(instance, True)
-			self._call_device_script(instance, instance.script_post, "apply", instance.devices)
+			self._call_device_script(instance, instance.script_pre, "apply", current_devices)
+			self._instance_pre_static(instance, True, current_devices)
+			self._instance_apply_static(instance, current_devices)
+			self._instance_post_static(instance, True, current_devices)
+			self._call_device_script(instance, instance.script_post, "apply", current_devices)
 		if instance.has_dynamic_tuning and self._global_cfg.get(consts.CFG_DYNAMIC_TUNING, consts.CFG_DEF_DYNAMIC_TUNING):
-			self._run_for_each_device(instance, self._instance_apply_dynamic)
+			self._run_for_each_device(instance, self._instance_apply_dynamic, current_devices)
 
 	def instance_verify_tuning(self, instance, ignore_missing):
 		"""
@@ -259,12 +266,14 @@ class Plugin(object):
 		if not instance.active:
 			return None
 
+		current_devices = self._copy_instance_devices(instance)
+
 		if instance.has_static_tuning:
-			if self._call_device_script(instance, instance.script_pre, "verify", instance.devices) == False:
+			if self._call_device_script(instance, instance.script_pre, "verify", current_devices) == False:
 				return False
-			if self._instance_verify_static(instance, ignore_missing) == False:
+			if self._instance_verify_static(instance, ignore_missing, current_devices) == False:
 				return False
-			if self._call_device_script(instance, instance.script_post, "verify", instance.devices) == False:
+			if self._call_device_script(instance, instance.script_post, "verify", current_devices) == False:
 				return False
 			return True
 		else:
@@ -277,35 +286,37 @@ class Plugin(object):
 		if not instance.active:
 			return
 		if instance.has_dynamic_tuning and self._global_cfg.get(consts.CFG_DYNAMIC_TUNING, consts.CFG_DEF_DYNAMIC_TUNING):
-			self._run_for_each_device(instance, self._instance_update_dynamic)
+			self._run_for_each_device(instance, self._instance_update_dynamic, self._copy_instance_devices(instance))
 
 	def instance_unapply_tuning(self, instance, full_rollback = False):
 		"""
 		Remove all tunings applied by the plugin instance.
 		"""
+		current_devices = self._copy_instance_devices(instance)
+
 		if instance.has_dynamic_tuning and self._global_cfg.get(consts.CFG_DYNAMIC_TUNING, consts.CFG_DEF_DYNAMIC_TUNING):
-			self._run_for_each_device(instance, self._instance_unapply_dynamic)
+			self._run_for_each_device(instance, self._instance_unapply_dynamic, current_devices)
 		if instance.has_static_tuning:
-			self._call_device_script(instance, instance.script_post, "unapply", instance.devices, full_rollback = full_rollback)
-			self._instance_pre_static(instance, False)
-			self._instance_unapply_static(instance, full_rollback)
-			self._instance_post_static(instance, False)
-			self._call_device_script(instance, instance.script_pre, "unapply", instance.devices, full_rollback = full_rollback)
+			self._call_device_script(instance, instance.script_post, "unapply", current_devices, full_rollback = full_rollback)
+			self._instance_pre_static(instance, False, current_devices)
+			self._instance_unapply_static(instance, current_devices, full_rollback)
+			self._instance_post_static(instance, False, current_devices)
+			self._call_device_script(instance, instance.script_pre, "unapply", current_devices, full_rollback = full_rollback)
 
-	def _instance_apply_static(self, instance):
+	def _instance_apply_static(self, instance, devices):
 		self._execute_all_non_device_commands(instance)
-		self._execute_all_device_commands(instance, instance.devices)
+		self._execute_all_device_commands(instance, devices)
 
-	def _instance_verify_static(self, instance, ignore_missing):
+	def _instance_verify_static(self, instance, ignore_missing, devices):
 		ret = True
 		if self._verify_all_non_device_commands(instance, ignore_missing) == False:
 			ret = False
-		if self._verify_all_device_commands(instance, instance.devices, ignore_missing) == False:
+		if self._verify_all_device_commands(instance, devices, ignore_missing) == False:
 			ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		self._cleanup_all_device_commands(instance, instance.devices)
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
+		self._cleanup_all_device_commands(instance, devices)
 		self._cleanup_all_non_device_commands(instance)
 
 	def _instance_apply_dynamic(self, instance, device):

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -103,7 +103,7 @@ class BootloaderPlugin(base.Plugin):
 			log.info("removing initrd image '%s'" % self._initrd_dst_img_val)
 			self._cmd.unlink(self._initrd_dst_img_val)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
 		if full_rollback:
 			log.info("removing grub2 tuning previously added by Tuned")
 			self._remove_grub2_tuning()

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -141,8 +141,8 @@ class CPULatencyPlugin(base.Plugin):
 		self._set_intel_pstate_attr(attr, value)
 		return v
 
-	def _instance_apply_static(self, instance):
-		super(CPULatencyPlugin, self)._instance_apply_static(instance)
+	def _instance_apply_static(self, instance, devices):
+		super(CPULatencyPlugin, self)._instance_apply_static(instance, devices)
 
 		if not instance._first_instance:
 			return
@@ -155,8 +155,8 @@ class CPULatencyPlugin(base.Plugin):
 			self._max_perf_pct_save = self._getset_intel_pstate_attr("max_perf_pct", instance.options["max_perf_pct"])
 			self._no_turbo_save = self._getset_intel_pstate_attr("no_turbo", instance.options["no_turbo"])
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		super(CPULatencyPlugin, self)._instance_unapply_static(instance, full_rollback)
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
+		super(CPULatencyPlugin, self)._instance_unapply_static(instance, devices, full_rollback)
 
 		if instance._first_instance and self._has_intel_pstate:
 			self._set_intel_pstate_attr("min_perf_pct", self._min_perf_pct_save)

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -39,7 +39,7 @@ class DiskPlugin(hotplug.Plugin):
 	@classmethod
 	def _device_is_supported(cls, device):
 		return  device.device_type == "disk" and \
-			device.attributes.get("removable", None) == "0" and \
+			device.attributes.get("removable", None) == b"0" and \
 			(device.parent is None or \
 					device.parent.subsystem in ["scsi", "virtio", "xen"])
 

--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -39,7 +39,7 @@ class ModulesPlugin(base.Plugin):
 			if retcode != 0:
 				log.warn("cannot insert/reinsert module '%s', reboot is required: %s" % (module, out.strip()))
 
-	def _instance_apply_static(self, instance):
+	def _instance_apply_static(self, instance, devices):
 		self._clear_modprobe_file()
 		s = ""
 		retcode = 0
@@ -73,7 +73,7 @@ class ModulesPlugin(base.Plugin):
 	def _unquote_path(self, path):
 		return str(path).replace("/", "")
 
-	def _instance_verify_static(self, instance, ignore_missing):
+	def _instance_verify_static(self, instance, ignore_missing, devices):
 		ret = True
 		# not all modules exports all their parameteters through sysfs, so hardcode check with ignore_missing
 		ignore_missing = True
@@ -100,7 +100,7 @@ class ModulesPlugin(base.Plugin):
 								ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
 		if full_rollback:
 			self._clear_modprobe_file()
 

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -348,8 +348,8 @@ class SchedulerPlugin(base.Plugin):
 		affinity = self._convert_affinity(affinity)
 		return (rule_prio, scheduler, priority, affinity, regex)
 
-	def _instance_apply_static(self, instance):
-		super(SchedulerPlugin, self)._instance_apply_static(instance)
+	def _instance_apply_static(self, instance, devices):
+		super(SchedulerPlugin, self)._instance_apply_static(instance, devices)
 		try:
 			ps = self.get_processes()
 		except (OSError, IOError) as e:
@@ -410,8 +410,8 @@ class SchedulerPlugin(base.Plugin):
 		self._scheduler_original = {}
 		self._storage.unset(self._scheduler_storage_key)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		super(SchedulerPlugin, self)._instance_unapply_static(instance, full_rollback)
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
+		super(SchedulerPlugin, self)._instance_unapply_static(instance, devices, full_rollback)
 		if self._daemon and instance._runtime_tuning:
 			instance._terminate.set()
 			instance._thread.join()

--- a/tuned/plugins/plugin_script.py
+++ b/tuned/plugins/plugin_script.py
@@ -53,13 +53,13 @@ class ScriptPlugin(base.Plugin):
 				return False
 		return True
 
-	def _instance_apply_static(self, instance):
-		super(ScriptPlugin, self)._instance_apply_static(instance)
+	def _instance_apply_static(self, instance, devices):
+		super(ScriptPlugin, self)._instance_apply_static(instance, devices)
 		self._call_scripts(instance._scripts, ["start"])
 
-	def _instance_verify_static(self, instance, ignore_missing):
+	def _instance_verify_static(self, instance, ignore_missing, devices):
 		ret = True
-		if super(ScriptPlugin, self)._instance_verify_static(instance, ignore_missing) == False:
+		if super(ScriptPlugin, self)._instance_verify_static(instance, ignore_missing, devices) == False:
 			ret = False
 		args = ["verify"]
 		if ignore_missing:
@@ -71,9 +71,9 @@ class ScriptPlugin(base.Plugin):
 			ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices,full_rollback = False):
 		args = ["stop"]
 		if full_rollback:
 			args = args + ["full_rollback"]
 		self._call_scripts(reversed(instance._scripts), args)
-		super(ScriptPlugin, self)._instance_unapply_static(instance, full_rollback)
+		super(ScriptPlugin, self)._instance_unapply_static(instance, devices, full_rollback)

--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -28,7 +28,7 @@ class SysctlPlugin(base.Plugin):
 		instance._sysctl_original = self._storage.get(storage_key, {})
 		if len(instance._sysctl_original) > 0:
 			log.info("recovering old sysctl settings from previous run")
-			self._instance_unapply_static(instance)
+			self._instance_unapply_static(instance, self._copy_instance_devices(instance))
 			instance._sysctl_original = {}
 			self._storage.unset(storage_key)
 
@@ -38,7 +38,7 @@ class SysctlPlugin(base.Plugin):
 		storage_key = self._storage_key(instance.name)
 		self._storage.unset(storage_key)
 
-	def _instance_apply_static(self, instance):
+	def _instance_apply_static(self, instance, devices):
 		for option, value in list(instance._sysctl.items()):
 			original_value = self._read_sysctl(option)
 			if original_value != None:
@@ -52,7 +52,7 @@ class SysctlPlugin(base.Plugin):
 			log.info("reapplying system sysctl")
 			self._cmd.execute(["sysctl", "--system"])
 
-	def _instance_verify_static(self, instance, ignore_missing):
+	def _instance_verify_static(self, instance, ignore_missing, devices):
 		ret = True
 		# override, so always skip missing
 		ignore_missing = True
@@ -64,7 +64,7 @@ class SysctlPlugin(base.Plugin):
 					ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
 		for option, value in list(instance._sysctl_original.items()):
 			self._write_sysctl(option, value)
 

--- a/tuned/plugins/plugin_sysfs.py
+++ b/tuned/plugins/plugin_sysfs.py
@@ -31,7 +31,7 @@ class SysfsPlugin(base.Plugin):
 	def _instance_cleanup(self, instance):
 		pass
 
-	def _instance_apply_static(self, instance):
+	def _instance_apply_static(self, instance, devices):
 		for key, value in list(instance._sysfs.items()):
 			v = self._variables.expand(value)
 			for f in glob.iglob(key):
@@ -41,7 +41,7 @@ class SysfsPlugin(base.Plugin):
 				else:
 					log.error("rejecting write to '%s' (not inside /sys)" % f)
 
-	def _instance_verify_static(self, instance, ignore_missing):
+	def _instance_verify_static(self, instance, ignore_missing, devices):
 		ret = True
 		for key, value in list(instance._sysfs.items()):
 			v = self._variables.expand(value)
@@ -52,7 +52,7 @@ class SysfsPlugin(base.Plugin):
 						ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
 		for key, value in list(instance._sysfs_original.items()):
 			self._write_sysfs(key, value)
 

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -95,7 +95,7 @@ class SystemdPlugin(base.Plugin):
 				conf = self._add_keyval(conf, consts.SYSTEMD_CPUAFFINITY_VAR, cpu_affinity_saved)
 			self._write_systemd_system_conf(conf)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, devices, full_rollback = False):
 		if full_rollback:
 			log.info("removing '%s' systemd tuning previously added by Tuned" % consts.SYSTEMD_CPUAFFINITY_VAR)
 			self._remove_systemd_tuning()


### PR DESCRIPTION
- these changes will protect tuned's execution thread from errors
caused by changes of instance's devices list while execution
thread iterates over them
- fixes problem with bad recognition of disk caused
by use of python3
- Resolve: rhbz#1592743