### PR TITLE
fix disk plugin/plugout problem

### DIFF
--- a/tuned/monitors/base.py
+++ b/tuned/monitors/base.py
@@ -99,13 +99,13 @@ class Monitor(object):
 		self._refresh_updating_devices()
 
 	def add_device(self, device):
-		assert isinstance(device, str)
+		assert (isinstance(device,str) or isinstance(device,unicode))
 		if device in self._available_devices:
 			self._devices.add(device)
 			self._updating_devices.add(device)
 
 	def remove_device(self, device):
-		assert isinstance(device, str)
+		assert (isinstance(device,str) or isinstance(device,unicode))
 		if device in self._devices:
 			self._devices.remove(device)
 			self._updating_devices.remove(device)

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -50,7 +50,7 @@ class DiskPlugin(hotplug.Plugin):
 		self._hardware_inventory.unsubscribe(self)
 
 	def _hardware_events_callback(self, event, device):
-		if self._device_is_supported(device):
+		if self._device_is_supported(device) or event == "remove":
 			super(DiskPlugin, self)._hardware_events_callback(event, device)
 
 	def _added_device_apply_tuning(self, instance, device_name):


### PR DESCRIPTION
when udev sends remove event it does not send any device
attributes with it so _device_is_supported check must be omitted
also when getting devices sys_name ensure it is string object
by using str()
Resolves: rhbz#1595156