### PR TITLE
scheduler: Keep polling file objects alive long enough

### DIFF
--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -448,7 +448,11 @@ class SchedulerPlugin(base.Plugin):
 	def _thread_code(self, instance):
 		r = self._cmd.re_lookup_compile(instance._sched_lookup)
 		poll = select.poll()
-		for fd in instance._evlist.get_pollfd():
+		# Store the file objects in a local variable so that they don't
+		# go out of scope too soon. This is a workaround for
+		# python3-perf bug rhbz#1659445.
+		fds = instance._evlist.get_pollfd()
+		for fd in fds:
 			poll.register(fd)
 		while not instance._terminate.is_set():
 			# timeout to poll in milliseconds


### PR DESCRIPTION
Make sure the file objects returned by evlist.get_pollfd()
don't go out of scope and get destroyed too soon. This is
a workaround for python3-perf rhbz#1659445.

Resolves: rhbz#1659140

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>