### PR TITLE
Added profile for HPC compute workloads

### DIFF
--- a/profiles/hpc-compute/tuned.conf
+++ b/profiles/hpc-compute/tuned.conf
@@ -4,9 +4,25 @@
 
 [main]
 summary=Optimize for HPC compute workloads
-include=throughput-performance
+description=Configures virtual memory, CPU governors, and network settings for HPC compute workloads.
+include=latency-performance
+
+[vm]
+transparent_hugepages=always
+
+[disk]
+readahead=>4096
 
 [sysctl]
+# Forces hugepages to be allocated on non-hotpluggable memory
+vm.hugepages_treat_as_movable=0
+vm.min_free_kbytes=135168
+vm.zone_reclaim_mode=1
+
+# Most HPC applications have NUMA knowledge. Disabling automatic NUMA
+# balancing prevents unwanted memory unmapping. 
+kernel.numa_balancing=0
+
 # Busy polling helps reduce latency in the network receive path
 # by allowing socket layer code to poll the receive queue of a
 # network device, and disabling network interrupts.
@@ -22,16 +38,8 @@ net.core.busy_poll=50
 # on client and server connections.
 net.ipv4.tcp_fastopen=3
 
-# Most HPC applications have NUMA knowledge. Disabling automatic NUMA
-# balancing prevents unwanted memory unmapping. 
-kernel.numa_balancing=0
-
 # The total time the scheduler will consider a migrated process
 # "cache hot" and thus less likely to be re-migrated
 # (system default is 500000, i.e. 0.5 ms)
 kernel.sched_migration_cost_ns=5000000
 
-[vm]
-# Most HPC applications can take advantage of large page sizes.
-# This setting ensures that THP is forced on.
-transparent_hugepages=always

--- a/profiles/hpc-compute/tuned.conf
+++ b/profiles/hpc-compute/tuned.conf
@@ -28,11 +28,6 @@ vm.min_free_kbytes=135168
 vm.zone_reclaim_mode=1
 kernel.numa_balancing=0
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=5000000
-
 # Busy polling helps reduce latency in the network receive path
 # by allowing socket layer code to poll the receive queue of a
 # network device, and disabling network interrupts.

--- a/profiles/hpc-compute/tuned.conf
+++ b/profiles/hpc-compute/tuned.conf
@@ -8,20 +8,30 @@ description=Configures virtual memory, CPU governors, and network settings for H
 include=latency-performance
 
 [vm]
+# Most HPC application can take advantage of hugepages. Force them to on.
 transparent_hugepages=always
 
 [disk]
+# Increase the readahead value to support large, contiguous, files.
 readahead=>4096
 
 [sysctl]
 # Forces hugepages to be allocated on non-hotpluggable memory
 vm.hugepages_treat_as_movable=0
-vm.min_free_kbytes=135168
-vm.zone_reclaim_mode=1
 
-# Most HPC applications have NUMA knowledge. Disabling automatic NUMA
-# balancing prevents unwanted memory unmapping. 
+# Keep a reasonable amount of memory free to support large mem requests
+vm.min_free_kbytes=135168
+
+# Most HPC applications are NUMA aware. Enabling zone reclaim ensures
+# memory is reclaimed and reallocated from local pages. Disabling
+# automatic NUMA balancing prevents unwanted memory unmapping.
+vm.zone_reclaim_mode=1
 kernel.numa_balancing=0
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+kernel.sched_migration_cost_ns=5000000
 
 # Busy polling helps reduce latency in the network receive path
 # by allowing socket layer code to poll the receive queue of a
@@ -38,8 +48,4 @@ net.core.busy_poll=50
 # on client and server connections.
 net.ipv4.tcp_fastopen=3
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=5000000
 

--- a/profiles/hpc-compute/tuned.conf
+++ b/profiles/hpc-compute/tuned.conf
@@ -1,0 +1,37 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize for HPC compute workloads
+include=throughput-performance
+
+[sysctl]
+# Busy polling helps reduce latency in the network receive path
+# by allowing socket layer code to poll the receive queue of a
+# network device, and disabling network interrupts.
+# busy_read value greater than 0 enables busy polling. Recommended
+# net.core.busy_read value is 50.
+# busy_poll value greater than 0 enables polling globally. 
+# Recommended net.core.busy_poll value is 50 
+net.core.busy_read=50
+net.core.busy_poll=50
+
+# TCP fast open reduces network latency by enabling data exchange
+# during the sender's initial TCP SYN. The value 3 enables fast open
+# on client and server connections.
+net.ipv4.tcp_fastopen=3
+
+# Most HPC applications have NUMA knowledge. Disabling automatic NUMA
+# balancing prevents unwanted memory unmapping. 
+kernel.numa_balancing=0
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+kernel.sched_migration_cost_ns=5000000
+
+[vm]
+# Most HPC applications can take advantage of large page sizes.
+# This setting ensures that THP is forced on.
+transparent_hugepages=always


### PR DESCRIPTION
Added a profile for common HPC workloads. It sets basic VM policies common to compute nodes and enables a few network settings that optimize for large, contiguous, file operations.