### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+Contributing to Tuned
+=====================
+
+Submitting patches
+------------------
+
+All patches should be based on the most recent revision of Tuned, which is
+available on [GitHub](https://github.com/redhat-performance/tuned).
+
+Patches should be created using `git` and the commit message should generally
+consist of three parts:
+1. The first line, which briefly describes the change that you are making.
+2. A detailed description of the change. This should include information
+   about the purpose of the change, i.e. why you are making the change in
+   the first place. For example, if your patch addresses a bug, give
+   a description of the bug and a way to reproduce it, if possible. If your
+   patch adds a new feature, describe how it can be used and what it can be
+   used for.
+
+   Think about the impact that your change can have on the users. If your
+   patch changes the behavior in a user-visible way, you should mention it
+   and justify why the change should be made anyway.
+
+   You should also describe any non-trivial design decisions that were made
+   in making of the patch. Write down any gotchas that could be useful for
+   future readers of the code, any hints that could be useful to determine
+   why the change was made in a particular way.
+
+   You can also provide links, for example links to any documentation that
+   could be useful for reviewers of the patch, or links to discussions about
+   a bug that your patch addresses. If your patch resolves a bug in the Red Hat
+   Bugzilla, you can link to it using the following tag:
+
+   `Resolves: rhbz#1592743`
+
+   If your patch addresses an issue in the GitHub repository, you can use
+   the following notation:
+
+   `Fixes #95`
+3. Your sign-off. Every commit needs to have a `Signed-off-by` tag at the end
+   of the commit message, indicating that the contributor of the patch agrees
+   with the [Developer Certificate of Origin](/DCO). The tag should have the
+   following format and it must include the real name and email address of
+   the contributor:
+
+   `Signed-off-by: John Doe <jdoe@somewhere.com>`
+
+   If you use `git commit -s`, `git` will add the tag for you.
+
+Every patch should represent a single logical change. On the one hand, each
+patch should be complete enough so that after applying it, the Tuned repository
+remains in a consistent state and Tuned remains, to the best of the
+contributor's knowledge, completely functional (a corollary of this is that
+when making fixes to your pull request on GitHub, you should include the fixes
+in the commits where they logically belong rather than appending new commits).
+
+On the other hand, a patch should not make multiple changes which could be
+separated into individual ones.
+
+Patches can either be submitted in the form of pull requests to the GitHub
+repository, sent to the power-management (at) lists.fedoraproject.org mailing
+list, or sent directly to the maintainers of the Tuned project.
+
+These guidelines were inspired by the [contribution guidelines of the Linux
+Kernel](https://www.kernel.org/doc/html/latest/process/submitting-patches.html).
+You can find more rationale for Tuned's guidelines in that document.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README
+++ b/README
@@ -74,6 +74,10 @@ You can also join #fedora-power IRC channel on Freenode.
 Web page:
 https://tuned-project.org/
 
+Contributing
+------------
+See the file CONTRIBUTING.md for guidelines for contributing.
+
 License
 -------
 
@@ -94,6 +98,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 Full text of the license is enclosed in COPYING file.
+
+The Developer Certificate of Origin, distributed in the file 'DCO' is licensed
+differently, see the file for the text of the license.
 
 
 The icon:


### PR DESCRIPTION
This is an attempt to formalize the process of contributing to Tuned
and formulate what is expected from contributors. From now on, all
contributors are expected to follow the guidelines.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>