### PR TITLE
Increase max log file size in the default config file

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -37,4 +37,4 @@ udev_buffer_size = 1MB
 log_file_count = 2
 
 # Log file max size
-log_file_max_size = 100KB
+log_file_max_size = 1MB


### PR DESCRIPTION
100KB is not a lot, it can fill up quickly.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>