### PR TITLE
conservative governor may be compiled as module and needs explicit lo…

### DIFF
--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -5,6 +5,9 @@
 [main]
 summary=General non-specialized tuned profile
 
+[modules]
+cpufreq_conservative=+r
+
 [cpu]
 governor=conservative
 energy_perf_bias=normal


### PR DESCRIPTION
…ading

Tested on an AMD machine with acpi-cpufreq kernel driver providing
ondemand, conservative,... governors.

Without this line, one gets:
tuned.plugins.plugin_cpu: ignoring governor 'conservative' on cpu 'cpu7', it
is not supported

when switching to balanced profile.
With this line you see:
tuned.plugins.plugin_cpu: setting governor 'ondemand' on cpu 'cpu2'

Be careful: Order matters!
tuned seem to read profile config file line by line or section by section
and directly tries to apply things.

If order of these lines are exchanged:
[modules]
cpufreq_conservative=+r

[cpu]
governor=conservative

you fall back to previous error again. Therefore the newly introduced
[modules] section is not put at the end, but nearly at top.