### PR TITLE
Makefile: Drop a workaround for a pylint bug and run pylint on tests too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,6 @@ test:
 	$(PYTHON) -m unittest discover tests
 
 lint:
-	$(PYLINT) -E -f parseable tuned *.py
+	$(PYLINT) -E -f parseable tuned *.py tests
 
 .PHONY: clean archive srpm tag test lint

--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,6 @@ test:
 	$(PYTHON) -m unittest discover tests
 
 lint:
-	# --ignore commands.py is a workaround for
-	# https://bugzilla.redhat.com/show_bug.cgi?id=1613466
-	$(PYLINT) --ignore commands.py -E -f parseable tuned *.py
+	$(PYLINT) -E -f parseable tuned *.py
 
 .PHONY: clean archive srpm tag test lint

--- a/tests/plugins/test_base.py
+++ b/tests/plugins/test_base.py
@@ -1,4 +1,7 @@
-from collections import Mapping
+try:
+	from collections.abc import Mapping
+except ImportError:
+	from collections import Mapping
 import tempfile
 import unittest2
 import flexmock


### PR DESCRIPTION
The bug is no longer reproducible with
python3-pylint-2.1.1-2.fc29.noarch.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>