### PR TITLE
Fix checking for None values

### DIFF
--- a/experiments/kwin-stop/xlib-example.py
+++ b/experiments/kwin-stop/xlib-example.py
@@ -32,7 +32,7 @@ def loop():
 						root = dpy.screen(num).root
 						for win in root.get_full_property(dpy.get_atom('_NET_CLIENT_LIST'), 0).value.tolist():
 							window = dpy.create_resource_object('window', win)
-							if window.get_full_property(dpy.get_atom('_NET_WM_STATE'), Xatom.WINDOW) == None:
+							if window.get_full_property(dpy.get_atom('_NET_WM_STATE'), Xatom.WINDOW) is None:
 								continue
 							if dpy.get_atom("_NET_WM_STATE_HIDDEN") in window.get_full_property(dpy.get_atom('_NET_WM_STATE'), 0).value.tolist():
 								if not win in hidden:

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -61,7 +61,7 @@ class SystemdPlugin(base.Plugin):
 
 	def _read_systemd_system_conf(self):
 		systemd_system_conf = self._cmd.read_file(consts.SYSTEMD_SYSTEM_CONF_FILE, err_ret = None)
-		if systemd_system_conf == None:
+		if systemd_system_conf is None:
 			log.error("error reading systemd configuration file")
 			return None
 		return systemd_system_conf

--- a/tuned/profiles/merger.py
+++ b/tuned/profiles/merger.py
@@ -33,7 +33,7 @@ class Merger(object):
 				profile_a.units[unit_name].type = unit.type
 				profile_a.units[unit_name].enabled = unit.enabled
 				profile_a.units[unit_name].devices = unit.devices
-				if unit.devices_udev_regex != None:
+				if unit.devices_udev_regex is not None:
 					profile_a.units[unit_name].devices_udev_regex = unit.devices_udev_regex
 				if unit.script_pre is not None:
 					profile_a.units[unit_name].script_pre = unit.script_pre


### PR DESCRIPTION
In python, 'is None' should be used instead of '== None' to check if
something is None.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>