### PR TITLE
Improve logging of tuned-adm recommend

### DIFF
--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -67,7 +67,7 @@ class ProfileRecommender:
 						value = r"^$"
 					if option == "virt":
 						if not re.match(value,
-								self._commands.execute("virt-what")[1], re.S):
+								self._commands.execute(["virt-what"])[1], re.S):
 							match = False
 					elif option == "system":
 						if not re.match(value,


### PR DESCRIPTION
Hi,
recently we've noticed mutliple error messages warning user about running virt-what without root privileges. This pull request makes from these multiple messages one which says exactly what is wrong.
Problem occured when executing:
$ tuned-adm recommend