### PR TITLE
Check for root privileges by inspecting the effective UID

### DIFF
--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -7,7 +7,7 @@ from configobj import ConfigObj, ConfigObjError
 
 have_dmidecode = False
 try:
-	if (os.getuid() == 0 and platform.machine() in ["i386", "i486", "i586", "i686", "x86_64"]):
+	if (os.geteuid() == 0 and platform.machine() in ["i386", "i486", "i586", "i686", "x86_64"]):
 		import dmidecode
 		have_dmidecode = True
 except:


### PR DESCRIPTION
The effective UID is what matters when it comes to the ability to
perform privileged actions, not the real UID.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>