### PR TITLE
virtual-host: Fix setting force_latency

### DIFF
--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -16,5 +16,6 @@ vm.dirty_background_ratio = 5
 # (system default is 500000, i.e. 0.5 ms)
 kernel.sched_migration_cost_ns = 5000000
 
+[cpu]
 # Setting C3 state sleep mode/power savings
 force_latency=70


### PR DESCRIPTION
The force_latency parameter belongs to the cpu plugin, so that's the
section it needs to be in.

Fixes #132
Resolves: rhbz#1569375

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>