### PR TITLE
[Docs] Tweak the terminology around Tuned and its components

### DIFF
--- a/doc/manual/README.adoc
+++ b/doc/manual/README.adoc
@@ -16,3 +16,18 @@ This generates the `master.html` file, which you can open with your web browser.
 
 The `master.adoc` file is the main entry point for the documentation. It _includes_ (or, imports, loads) _assembly_ files from the `assemblies/` directory, which represent user stories. These assembly files then include _modules_ located in `modules/performance/`. Modules are reusable sections of content representing a concept, a procedure, or a reference.
 
+== Naming conventions
+
+Use the following naming conventions when referring to Tuned and its components in the documentation:
+
+* "the *Tuned* application", referring to the complete set of software, including executables, profiles, scripts, documentation, artwork, etc. Written as `the \*Tuned* application` in AsciiDoc, because application names are in bold text.
+
+* "the Tuned project", referring to the developers and contributors, the web pages, repositories, planning, etc.
+
+* "the `tuned` service", referring to the `tuned.service` systemd unit and the `tuned` executable
+
+* "the `tuned-adm` utility", referring to the `tuned-adm` executable
+
+* "the `tuned` and `tuned-adm` commands", referring to the text typed into the terminal to run components of Tuned
+
+This is consistent with other naming schemes. For example, consider "the Firefox application" vs. "the `firefox` command".

--- a/doc/manual/assemblies/assembly_getting-started-with-tuned.adoc
+++ b/doc/manual/assemblies/assembly_getting-started-with-tuned.adoc
@@ -5,7 +5,7 @@
 
 :context: getting-started-with-tuned
 
-As a system administrator, you can use the *Tuned* service to optimize the performance profile of your system for a variety of use cases.
+As a system administrator, you can use the *Tuned* application to optimize the performance profile of your system for a variety of use cases.
 
 // [id='prerequisites-{context}']
 // == Prerequisites

--- a/doc/manual/master.adoc
+++ b/doc/manual/master.adoc
@@ -19,7 +19,7 @@ include::meta/attributes.adoc[]
 
 // Abstract (Preamble):
 
-This documentation explains how to use the *Tuned* service to monitor and optimize the throughput, latency, and power consumption of your system in different scenarios.
+This documentation explains how to use the *Tuned* application to monitor and optimize the throughput, latency, and power consumption of your system in different scenarios.
 
 // The following is copied from the standard Red Hat legal notice
 // as used in all Red Hat documentation.

--- a/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
+++ b/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
@@ -1,7 +1,7 @@
 [id="installing-and-enabling-tuned_{context}"]
 = Installing and enabling Tuned
 
-This procedure installs and enables the *Tuned* service, installs *Tuned* profiles, and presets a default *Tuned* profile for your system.
+This procedure installs and enables the *Tuned* application, installs *Tuned* profiles, and presets a default *Tuned* profile for your system.
 
 // [discrete]
 // == Prerequisites

--- a/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
@@ -1,7 +1,7 @@
 [id="built-in-functions-available-in-tuned-profiles_{context}"]
 = Built-in functions available in Tuned profiles
 
-The following built-in functions are available in all Tuned profiles:
+The following built-in functions are available in all *Tuned* profiles:
 
 `PROFILE_DIR`::
 Returns the directory path where the profile and the `tuned.conf` file are located.


### PR DESCRIPTION
As pointed out in [RHBZ#1680386](https://bugzilla.redhat.com/show_bug.cgi?id=1680386), our documentation wasn't completely consistent in how it classified and referred to the components of Tuned.

This PR fixes the inconsistencies and establishes naming conventions as described in the manual's readme: https://github.com/mrksu/tuned/blob/fix-terminology/doc/manual/README.adoc#naming-conventions