### PR TITLE
Lower permissions for plugin info dbus interfaces

### DIFF
--- a/com.redhat.tuned.policy
+++ b/com.redhat.tuned.policy
@@ -181,8 +181,8 @@
     <description>Get plugins which Tuned daemon can acces</description>
     <message>Authentication is required to get Tuned plugins</message>
     <defaults>
-      <allow_any>yes</allow_any>
-      <allow_inactive>yes</allow_inactive>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
   </action>
@@ -191,8 +191,8 @@
     <description>Get documentation of tuned plugin</description>
     <message>Authentication is required to get documentation of tuned plugin</message>
     <defaults>
-      <allow_any>yes</allow_any>
-      <allow_inactive>yes</allow_inactive>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
   </action>
@@ -201,8 +201,8 @@
     <description>Get hints for parameters of Tuned plugin</description>
     <message>Authentication is required to get hints for parameters of Tuned plugin</message>
     <defaults>
-      <allow_any>yes</allow_any>
-      <allow_inactive>yes</allow_inactive>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
   </action>


### PR DESCRIPTION
As these interfaces allow loading and thus executing code from plugins
the default permission policy is lowered from:
yes:yes:yes
to
auth_admin:auth_admin:yes
So only users logged into the X server are allowed to use this interface
without extra root/admin authentication.

This was found by security review by Matthias Gerstner
<matthias.gerstner@suse.com>

Also see:
https://github.com/redhat-performance/tuned/issues/180