### PR TITLE
functions: Return an ordered cpu list in cpulist_online

### DIFF
--- a/tuned/profiles/functions/function_cpulist_online.py
+++ b/tuned/profiles/functions/function_cpulist_online.py
@@ -19,4 +19,4 @@ class cpulist_online(base.Function):
 			return None
 		cpus = self._cmd.cpulist_unpack(",".join(args))
 		online = self._cmd.cpulist_unpack(self._cmd.read_file("/sys/devices/system/cpu/online"))
-		return ",".join(str(v) for v in set(cpus).intersection(set(online)))
+		return ",".join(str(v) for v in cpus if v in online)


### PR DESCRIPTION
cpulist_unpack, which is used in the function, returns an ordered cpu
list, however by converting it to a set, the order is lost. Rewrite the
operation in a way that preserves the order.

Resolves: rhbz#1706171

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>