### PR TITLE
Fix verifying sysctl options with tabs

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -76,7 +76,7 @@ class SysctlPlugin(base.Plugin):
 			curr_val = _read_sysctl(option)
 			value = self._process_assignment_modifiers(self._variables.expand(value), curr_val)
 			if value is not None:
-				if self._verify_value(option, self._cmd.remove_ws(value), curr_val, ignore_missing) == False:
+				if self._verify_value(option, self._cmd.remove_ws(value), self._cmd.remove_ws(curr_val), ignore_missing) == False:
 					ret = False
 		return ret
 


### PR DESCRIPTION
sysctl options such as `net.ipv4.tcp_wmem` and `net.ipv4.tcp_rmem` include tabs. When you use `tuned-adm verify`, the changes report back as broken as the whitespaces are different because one side has been sanitized but the other side has not. This pull request will fix that.