### PR TITLE
Create log file directory with more limited permissions

### DIFF
--- a/tuned/logs.py
+++ b/tuned/logs.py
@@ -134,6 +134,7 @@ class TunedLogger(logging.getLoggerClass()):
 			log_directory = '.'
 		if not os.path.exists(log_directory):
 			os.makedirs(log_directory)
+			os.chmod(log_directory, 0o750)
 
 		cls._file_handler = logging.handlers.RotatingFileHandler(
 			filename, maxBytes = int(maxBytes), backupCount = int(backupCount))


### PR DESCRIPTION
This patch is originally from:
Matthias Gerstner <matthias.gerstner@suse.com>
If tuned creates /var/log/tuned
permissions are now 750 instead of 755