### PR TITLE
Fix a bare 'except' statement

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -90,7 +90,7 @@ def _apply_system_sysctl():
 	for d in SYSCTL_CONFIG_DIRS:
 		try:
 			flist = os.listdir(d)
-		except:
+		except OSError:
 			continue
 		for fname in flist:
 			if not fname.endswith(".conf"):


### PR DESCRIPTION
A bare 'except' statement can catch (and hide) all sorts of errors,
including NameError. Fix it to catch only the errors we really expect.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>