### PR TITLE
sysctl: Ignore non-existent settings from system sysctl configs

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -133,7 +133,7 @@ def _apply_sysctl_config_line(path, lineno, line):
 				% (path, lineno))
 		return
 	value = value.strip()
-	_write_sysctl(option, value)
+	_write_sysctl(option, value, ignore_missing = True)
 
 def _get_sysctl_path(option):
 	return "/proc/sys/%s" % option.replace(".", "/")
@@ -161,7 +161,7 @@ def _read_sysctl(option):
 					% (option, str(e)))
 		return None
 
-def _write_sysctl(option, value):
+def _write_sysctl(option, value, ignore_missing = False):
 	path = _get_sysctl_path(option)
 	if os.path.basename(path) in DEPRECATED_SYSCTL_OPTIONS:
 		log.error("Refusing to set deprecated sysctl option %s"
@@ -175,7 +175,8 @@ def _write_sysctl(option, value):
 		return True
 	except (OSError, IOError) as e:
 		if e.errno == errno.ENOENT:
-			log.error("Failed to set sysctl parameter '%s' to '%s', the parameter does not exist"
+			log_func = log.debug if ignore_missing else log.error
+			log_func("Failed to set sysctl parameter '%s' to '%s', the parameter does not exist"
 					% (option, value))
 		else:
 			log.error("Failed to set sysctl parameter '%s' to '%s': %s"


### PR DESCRIPTION
Ignore non-existent sysctl settings from the system configuration files
(/etc/sysctl.conf, etc.). Logging errors about these settings hurts user
experience, if the non-existent settings are in fact real settings that
are just temporarily unavailable. For example, the following settings
(from /usr/lib/sysctl.d/00-system.conf on RHEL-7) are not available until
the br_netfilter module is loaded. However once that module is loaded,
it is often desirable to set these, so having them in a RHEL-provided
configuration file makes sense.

net.bridge.bridge-nf-call-ip6tables = 0
net.bridge.bridge-nf-call-iptables = 0
net.bridge.bridge-nf-call-arptables = 0

This change restores the old behaviour before the recent rewrite of the
sysctl plugin away from using the 'sysctl' program (running
'sysctl --system' ignores missing settings).

Resolves: rhbz#1714595

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>