### PR TITLE
misc: Lower logging level for some errors

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -158,7 +158,7 @@ class Plugin(object):
 		else:
 			udev_devices = self._get_device_objects(devices)
 			if udev_devices is None:
-				log.error("Plugin '%s' does not support the 'devices_udev_regex' option", self.name)
+				log.warn("Plugin '%s' does not support the 'devices_udev_regex' option", self.name)
 				return set()
 			udev_devices = self._device_matcher_udev.match_list(instance.devices_udev_regex, udev_devices)
 			return set([x.sys_name for x in udev_devices])

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -133,7 +133,7 @@ class CPULatencyPlugin(base.Plugin):
 			try:
 				self._cpu_latency_fd = os.open(consts.PATH_CPU_DMA_LATENCY, os.O_WRONLY)
 			except OSError:
-				log.error("Unable to open '%s', disabling PM_QoS control" % consts.PATH_CPU_DMA_LATENCY)
+				log.info("Unable to open '%s', disabling PM_QoS control" % consts.PATH_CPU_DMA_LATENCY)
 				self._has_pm_qos = False
 			self._latency = None
 

--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -49,12 +49,15 @@ class ModulesPlugin(base.Plugin):
 			module = self._variables.expand(option)
 			v = self._variables.expand(value)
 			if not skip_check:
-				retcode, out = self._cmd.execute(["modinfo", module])
+				# modinfo could fail as expected when module is not
+				# there. Capture the error instead of printing an
+				# ERROR every time even it's a very valid case
+				retcode, out, err = self._cmd.execute(["modinfo", module], return_err=True)
 				if retcode < 0:
 					skip_check = True
-					log.warn("'modinfo' command not found, not checking kernel modules")
+					log.info("'modinfo' command not found, not checking kernel modules")
 				elif retcode > 0:
-					log.error("kernel module '%s' not found, skipping it" % module)
+					log.info("kernel module '%s' not found, skipping it" % module)
 			if skip_check or retcode == 0:
 				if len(v) > 1 and v[0:2] == "+r":
 					v = re.sub(r"^\s*\+r\s*,?\s*", "", v)

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -318,15 +318,15 @@ class SchedulerPlugin(base.Plugin):
 	def _convert_sched_params(self, str_scheduler, str_priority):
 		scheduler = self._dict_schedcfg2num.get(str_scheduler)
 		if scheduler is None and str_scheduler != "*":
-			log.error("Invalid scheduler: %s. Scheduler and priority will be ignored."
-					% str_scheduler)
+			log.warn("Invalid scheduler: %s. Scheduler and priority will be ignored."
+					 % str_scheduler)
 			return (None, None)
 		else:
 			try:
 				priority = int(str_priority)
 			except ValueError:
-				log.error("Invalid priority: %s. Scheduler and priority will be ignored."
-							% str_priority)
+				log.warn("Invalid priority: %s. Scheduler and priority will be ignored."
+						 % str_priority)
 				return (None, None)
 		return (scheduler, priority)
 
@@ -336,8 +336,8 @@ class SchedulerPlugin(base.Plugin):
 		else:
 			affinity = self._cmd.hex2cpulist(str_affinity)
 			if not affinity:
-				log.error("Invalid affinity: %s. It will be ignored."
-						% str_affinity)
+				log.warn("Invalid affinity: %s. It will be ignored."
+						 % str_affinity)
 				affinity = None
 		return affinity
 
@@ -584,8 +584,10 @@ class SchedulerPlugin(base.Plugin):
 				log.debug("Setting SMP affinity of IRQ %s is not supported"
 						% irq)
 			else:
-				log.error("Failed to set SMP affinity of IRQ %s to '%s': %s"
-						% (irq, affinity_hex, e))
+				# managed IRQs would have smp_affinity file as RO, so
+				# it could be fine
+				log.warn("Failed to set SMP affinity of IRQ %s to '%s': %s"
+						 % (irq, affinity_hex, e))
 			return False
 
 	def _set_default_irq_affinity(self, affinity):

--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -51,8 +51,8 @@ class SysctlPlugin(base.Plugin):
 		for option, value in list(instance._sysctl.items()):
 			original_value = _read_sysctl(option)
 			if original_value is None:
-				log.error("sysctl option %s will not be set, failed to read the original value."
-						% option)
+				log.warn("sysctl option %s will not be set, failed to read the original value."
+						 % option)
 			else:
 				instance._sysctl_original[option] = original_value
 				new_value = self._variables.expand(
@@ -154,8 +154,8 @@ def _read_sysctl(option):
 		return value
 	except (OSError, IOError) as e:
 		if e.errno == errno.ENOENT:
-			log.error("Failed to read sysctl parameter '%s', the parameter does not exist"
-					% option)
+			log.warn("Failed to read sysctl parameter '%s', the parameter does not exist"
+					 % option)
 		else:
 			log.error("Failed to read sysctl parameter '%s': %s"
 					% (option, str(e)))

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -80,6 +80,8 @@ class VideoPlugin(base.Plugin):
 	@command_get("radeon_powersave")
 	def _get_radeon_powersave(self, device, ignore_missing = False):
 		sys_files = self._radeon_powersave_files(device)
+		if not os.path.exists(sys_files["method"]):
+			return None
 		method = self._cmd.read_file(sys_files["method"], no_error=ignore_missing).strip()
 		if method == "profile":
 			return self._cmd.read_file(sys_files["profile"]).strip()


### PR DESCRIPTION
There're some errors that do not affect tuned from running, even some
of them are quite natural and all these ERRORs are misleading to
newcomers of tuned when they read the logs.  Examples:

https://github.com/redhat-performance/tuned/issues/192

This patch tries to lower quite a few of these cases to use either
warn() or even info() for these errors so the real errors could be
more obvious to users.

One case in _get_radeon_powersave() is special, I simply checked the
file existance before read_file().

Signed-off-by: Peter Xu <peterx@redhat.com>