### PR TITLE
Apply irqbalance service tuning for realtime-virtual-{host|guest} profiles

### DIFF
--- a/profiles/cpu-partitioning/script.sh
+++ b/profiles/cpu-partitioning/script.sh
@@ -39,8 +39,7 @@ start() {
     mkdir -p "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev"
     cp /etc/systemd/system.conf "${TUNED_tmpdir}/etc/systemd/"
     cp 00-tuned-pre-udev.sh "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev/"
-    sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance
-    echo "IRQBALANCE_BANNED_CPUS=$TUNED_isolated_cpumask" >>/etc/sysconfig/irqbalance
+    irqbalance_banned_cpus_setup "$TUNED_isolated_cpumask"
     setup_kvm_mod_low_latency
     disable_ksm
 
@@ -52,7 +51,7 @@ start() {
 stop() {
     if [ "$1" = "full_rollback" ]
     then
-        sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance
+        irqbalance_banned_cpus_clear
         teardown_kvm_mod_low_latency
         enable_ksm
     fi

--- a/profiles/functions
+++ b/profiles/functions
@@ -473,6 +473,17 @@ restore_logs_syncing() {
 	mv -Z $RSYSLOG_SAVE $RSYSLOG_CFG || mv $RSYSLOG_SAVE $RSYSLOG_CFG
 }
 
+irqbalance_banned_cpus_clear() {
+    sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance
+}
+
+irqbalance_banned_cpus_setup() {
+    irqbalance_banned_cpus_clear
+    if [ -n "$1" ]; then
+        echo "IRQBALANCE_BANNED_CPUS=$1" >> /etc/sysconfig/irqbalance
+    fi
+}
+
 #
 # HARDWARE SPECIFIC tuning
 #

--- a/profiles/realtime/script.sh
+++ b/profiles/realtime/script.sh
@@ -3,10 +3,12 @@
 . /usr/lib/tuned/functions
 
 start() {
+    irqbalance_banned_cpus_setup "$TUNED_isolated_cpumask"
     return 0
 }
 
 stop() {
+    irqbalance_banned_cpus_clear
     return 0
 }
 

--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -18,6 +18,7 @@ assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isola
 # Non-isolated cores cpumask including offline cores
 not_isolated_cpumask = ${f:cpulist2hex_invert:${isolated_cores}}
 isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
+isolated_cpumask=${f:cpulist2hex:${isolated_cores_expanded}}
 isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
 
 # Fail if isolated_cores contains CPUs which are not online

--- a/tuned/plugins/plugin_script.py
+++ b/tuned/plugins/plugin_script.py
@@ -31,6 +31,7 @@ class ScriptPlugin(base.Plugin):
 		pass
 
 	def _call_scripts(self, scripts, arguments):
+		ret = True
 		for script in scripts:
 			environ = os.environ
 			environ.update(self._variables.get_env())
@@ -47,11 +48,11 @@ class ScriptPlugin(base.Plugin):
 					log.error("script '%s' error output: '%s'" % (script, err[:-1]))
 				if proc.returncode:
 					log.error("script '%s' returned error code: %d" % (script, proc.returncode))
-					return False
+					ret = False
 			except (OSError,IOError) as e:
 				log.error("script '%s' error: %s" % (script, e))
-				return False
-		return True
+				ret = False
+		return ret
 
 	def _instance_apply_static(self, instance):
 		super(ScriptPlugin, self)._instance_apply_static(instance)


### PR DESCRIPTION
The two realtime profiles needs to do cpu isolation just like cpu-partitioning profiles.  Do proper configuration for irqbalance service for them just like the cpu-partioning profile otherwise irqbalance might collapse with tuned on configuring system IRQs.