### PR TITLE
added new profile for k8s-container

### DIFF
--- a/profiles/k8s-container/00-tuned-pre-udev.sh
+++ b/profiles/k8s-container/00-tuned-pre-udev.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+cpumask="$(getargs tuned.non_isolcpus)"
+
+file=/sys/devices/virtual/workqueue/cpumask
+
+log()
+{
+  echo "tuned: $@" >> /dev/kmsg
+}
+
+if [ -n "$cpumask" ]; then
+  log "setting workqueue CPU mask to $cpumask"
+  if ! echo $cpumask > $file 2>/dev/null; then
+    log "ERROR: could not write workqueue CPU mask"
+  fi
+fi

--- a/profiles/k8s-container/k8s-container-variables.conf
+++ b/profiles/k8s-container/k8s-container-variables.conf
@@ -1,0 +1,6 @@
+# Examples:
+# isolated_cores=2,4-7
+# isolated_cores=2-23
+#
+# To disable the kernel load balancing in certain isolated CPUs:
+# no_balance_cores=5-10

--- a/profiles/k8s-container/script.sh
+++ b/profiles/k8s-container/script.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+. /usr/lib/tuned/functions
+
+no_balance_cpus_file=$STORAGE/no-balance-cpus.txt
+
+change_sd_balance_bit()
+{
+    local set_bit=$1
+    local flags_cur=
+    local file=
+    local cpu=
+
+    for cpu in $(cat $no_balance_cpus_file); do
+        for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
+            flags_cur=$(cat $file)
+            if [ $set_bit -eq 1 ]; then
+                flags_cur=$((flags_cur | 0x1))
+            else
+                flags_cur=$((flags_cur & 0xfffe))
+            fi
+            echo $flags_cur > $file
+        done
+    done
+}
+
+disable_balance_domains()
+{
+    change_sd_balance_bit 0
+}
+
+enable_balance_domains()
+{
+    change_sd_balance_bit 1
+}
+
+start() {
+    mkdir -p "${TUNED_tmpdir}/etc/systemd"
+    mkdir -p "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev"
+    cp /etc/systemd/system.conf "${TUNED_tmpdir}/etc/systemd/"
+    cp 00-tuned-pre-udev.sh "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev/"
+    irqbalance_banned_cpus_setup "$TUNED_isolated_cpumask"
+
+    echo "$TUNED_no_balance_cores_expanded" | sed 's/,/ /g' > $no_balance_cpus_file
+    disable_balance_domains
+    return "$?"
+}
+
+stop() {
+    if [ "$1" = "full_rollback" ]
+    then
+        irqbalance_banned_cpus_clear
+    fi
+    enable_balance_domains
+    return "$?"
+}
+
+process $@

--- a/profiles/k8s-container/tuned.conf
+++ b/profiles/k8s-container/tuned.conf
@@ -1,0 +1,57 @@
+# tuned configuration
+#
+
+[main]
+summary=Optimize for CPU partitioning
+include=network-latency
+
+[variables]
+# User is responsible for updating variables.conf with variable content such as isolated_cores=X-Y
+include=/etc/tuned/k8s-container-variables.conf
+
+isolated_cores_assert_check = \\${isolated_cores}
+# Fail if isolated_cores are not set
+assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
+
+# tmpdir
+tmpdir=${f:strip:${f:exec:/usr/bin/mktemp:-d}}
+# Non-isolated cores cpumask including offline cores
+isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
+isolated_cpumask=${f:cpulist2hex:${isolated_cores_expanded}}
+not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
+not_isolated_cores_online_expanded=${f:cpulist_online:${not_isolated_cores_expanded}}
+not_isolated_cpumask=${f:cpulist2hex:${not_isolated_cores_expanded}}
+no_balance_cores_expanded=${f:cpulist_unpack:${no_balance_cores}}
+
+# Fail if isolated_cores contains CPUs which are not online
+assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
+
+[sysctl]
+kernel.hung_task_timeout_secs = 600
+kernel.nmi_watchdog = 0
+vm.stat_interval = 10
+kernel.timer_migration = 1
+
+[sysfs]
+/sys/bus/workqueue/devices/writeback/cpumask = ${not_isolated_cpumask}
+/sys/devices/virtual/workqueue/cpumask = ${not_isolated_cpumask}
+/sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
+
+[systemd]
+cpu_affinity=${not_isolated_cores_expanded}
+
+[script]
+priority=5
+script=${i:PROFILE_DIR}/script.sh
+
+[scheduler]
+isolated_cores=${isolated_cores}
+ps_blacklist=.*pmd.*;.*PMD.*;^DPDK
+
+[bootloader]
+priority=10
+initrd_remove_dir=True
+initrd_dst_img=tuned-initrd.img
+initrd_add_dir=${tmpdir}
+cmdline_cpu_part=+rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup


### PR DESCRIPTION
This new profile is targeted for Kubernetes/openshift worker nodes running non real time RHEL. It's based off the existing cpu-partitioning profile, with kvm and ksm related setup removed. Also, "nohz" and "nohz_full" are removed due to this BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1760644
