### PR TITLE
Use python3 interpreter by default

### DIFF
--- a/experiments/kwin-stop/xlib-example.py
+++ b/experiments/kwin-stop/xlib-example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 
 from __future__ import print_function
 import os

--- a/experiments/powertop2tuned.py
+++ b/experiments/powertop2tuned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008-2013 Red Hat, Inc.

--- a/libexec/defirqaffinity.py
+++ b/libexec/defirqaffinity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Helper script for realtime profiles provided by RT
 

--- a/libexec/pmqos-static.py
+++ b/libexec/pmqos-static.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # pmqos-static.py: Simple daemon for setting static PM QoS values. It is a part
 #                  of 'tuned' and it should not be called manually.

--- a/systemtap/varnetload
+++ b/systemtap/varnetload
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 #
 # varnetload: A python script to create reproducable sustained network traffic
 

--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 #
 # tuned: daemon for monitoring and adaptive tuning of system devices
 #

--- a/tuned-gui.py
+++ b/tuned-gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2014 Red Hat, Inc.

--- a/tuned.py
+++ b/tuned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 #
 # tuned: daemon for monitoring and adaptive tuning of system devices
 #


### PR DESCRIPTION
This may ease development, because development environment will
be probably already on python3.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>