### PR TITLE
Remove obsolete rhts imports from beakerlib tests

### DIFF
--- a/tests/beakerlib/Program-tuned-tried-to-access-dev-mem-between/runtest.sh
+++ b/tests/beakerlib/Program-tuned-tried-to-access-dev-mem-between/runtest.sh
@@ -26,7 +26,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Include Beaker environment
-. /usr/bin/rhts-environment.sh || exit 1
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="tuned"

--- a/tests/beakerlib/Tuned-takes-too-long-to-reload-start-when-ulimit/runtest.sh
+++ b/tests/beakerlib/Tuned-takes-too-long-to-reload-start-when-ulimit/runtest.sh
@@ -26,7 +26,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Include Beaker environment
-. /usr/bin/rhts-environment.sh || exit 1
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="tuned"

--- a/tests/beakerlib/tuned-adm-functionality/runtest.sh
+++ b/tests/beakerlib/tuned-adm-functionality/runtest.sh
@@ -27,8 +27,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Include Beaker environment
-. /usr/bin/rhts-environment.sh
-. /usr/share/beakerlib/beakerlib.sh
+. /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="tuned"
 LOG_FILE="profile.log"


### PR DESCRIPTION
I would recommend to get rid of the old rhts imports as well.