### PR TITLE
Use re.DOTALL in the udev device matcher

### DIFF
--- a/tuned/hardware/device_matcher_udev.py
+++ b/tuned/hardware/device_matcher_udev.py
@@ -21,4 +21,4 @@ class DeviceMatcherUdev(device_matcher.DeviceMatcher):
 		for key, val in list(items):
 			properties += key + '=' + val + '\n'
 
-		return re.search(regex, properties, re.MULTILINE) is not None
+		return re.search(regex, properties, re.MULTILINE | re.DOTALL) is not None


### PR DESCRIPTION
In order to allow matching multiple parameter-value pairs in a single regex, we need to use re.DOTALL, because the parameter-value pairs are on separate lines. Consider the following regex:

^ID_MODEL=SD_MMC$.*^ID_MODEL_ID=0316$

Previously it would not much a string such as the following:

ID_MODEL=SD_MMC
ID_MODEL_ENC=SD\x2fMMC\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20
ID_MODEL_ID=0316

Now it does match.

It should be noted that this change is not entirely backwards-compatible. Some user-written regexes can now start to match where they shouldn't. For example the following regex will now match even if 'ID_MODEL_ID' and '0316' are on different lines.

ID_MODEL_ID.*0316

The primary motivation for this change is making the udev matcher behave the same as the cpuinfo matcher that will be written to resolve rhbz#1748965.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>