### PR TITLE
cpu: Update checking if EPB is supported

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -93,8 +93,11 @@ class CPULatencyPlugin(base.Plugin):
 	def _check_energy_perf_bias(self):
 		self._has_energy_perf_bias = False
 		retcode_unsupported = 1
-		retcode = self._cmd.execute(["x86_energy_perf_policy", "-r"], no_errors = [errno.ENOENT, retcode_unsupported])[0]
-		if retcode == 0:
+		retcode, out = self._cmd.execute(["x86_energy_perf_policy", "-r"], no_errors = [errno.ENOENT, retcode_unsupported])
+		# With recent versions of the tool, a zero exit code is
+		# returned even if EPB is not supported. The output is empty
+		# in that case, however.
+		if retcode == 0 and out != "":
 			self._has_energy_perf_bias = True
 		elif retcode < 0:
 			log.warning("unable to run x86_energy_perf_policy tool, ignoring CPU energy performance bias, is the tool installed?")


### PR DESCRIPTION
Update checking if EPB is supported so that it works with recent versions of the x86_energy_perf_policy tool. Newer versions of x86_energy_perf_policy, unlike older versions, exit with a zero exit code even if the CPU doesn't support EPB. Newer versions of the tool give no ouput on stdout if EPB is not supported, so check for that.

In the future, we might like to determine if EPB is supported by searching /proc/cpuinfo for specific CPU flags. However the solution described in the previous paragraph should work just fine for now.

Resolves: rhbz#1690929

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>