### PR TITLE
bootloader: Don't abort patching if grub.cfg is empty

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -164,7 +164,7 @@ class BootloaderPlugin(base.Plugin):
 			grub2_cfg = self._cmd.read_file(f)
 			if len(grub2_cfg) <= 0:
 				log.info("cannot patch %s" % f)
-				return False
+				continue
 			log.debug("adding boot command line parameters to '%s'" % f)
 			grub2_cfg_new = grub2_cfg
 			patch_initial = False


### PR DESCRIPTION
Previously, if the grub.cfg patching code ran into a grub.cfg file that was empty, all subsequent grub.cfg files would get skipped and would not be patched. This behaviour doesn't make much sense to me. We should skip empty grub.cfg files and patch all the non-empty ones.

Resolves: rhbz#1622646