### PR TITLE
Revert "Use re.DOTALL in the udev device matcher"

### DIFF
--- a/tuned/hardware/device_matcher_udev.py
+++ b/tuned/hardware/device_matcher_udev.py
@@ -21,4 +21,4 @@ class DeviceMatcherUdev(device_matcher.DeviceMatcher):
 		for key, val in list(items):
 			properties += key + '=' + val + '\n'
 
-		return re.search(regex, properties, re.MULTILINE | re.DOTALL) is not None
+		return re.search(regex, properties, re.MULTILINE) is not None


### PR DESCRIPTION
This reverts commit d0b43e8b74aa9c1ae3ab69abf7fb8ece713b7ddf.

This reverts https://github.com/redhat-performance/tuned/pull/216.

The original change is completely unnecessary. The following regex (mentioned in the commit message of the original commit)

^ID_MODEL=SD_MMC$.*^ID_MODEL_ID=0316$

can be simply changed like this

^ID_MODEL=SD_MMC$(.|\n)*^ID_MODEL_ID=0316$

and it'll match the desired string without re.DOTALL

ID_MODEL=SD_MMC
ID_MODEL_ENC=SD\x2fMMC\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20
ID_MODEL_ID=0316

So it seems completely unnecessary to introduce this user-visible change in behaviour.

Also, the change would in fact make matching strings on a single line harder, because the following regex

^ID_MODEL=.*SD_MMC$

would also match the following multi-line string with re.DOTALL

ID_MODEL=HDD
ID_MODEL_ID=0316
COMMENT=ULTRA_SD_MMC

A big thanks to Jaroslav Škarvada for discovering this.
https://github.com/redhat-performance/tuned/pull/216#issuecomment-557915251

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>