### PR TITLE
Make python not write bytecode files when unit tests are run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ clean: clean-html
 	rm -rf $(VERSIONED_NAME) rpm-build-dir
 
 test:
-	$(PYTHON) -m unittest discover tests/unit
+	$(PYTHON) -B -m unittest discover tests/unit
 
 lint:
 	$(PYLINT) -E -f parseable tuned *.py tests/unit


### PR DESCRIPTION
Previously, when unit tests were run, python would leave behind files with bytecompiled modules. It's not useful, it just clutters the repository. And it could potentially lead to problems - it seems to have lead to some problem for me earlier today when running git bisect to find out when `make test` started failing.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>