### PR TITLE
Fix a hang on SIGHUP when the preset profile does not exist

### DIFF
--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -138,7 +138,11 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			stop_ok = self.stop()
 			if not stop_ok:
 				return False
-			self._daemon.reload_profile_config()
+			try:
+				self._daemon.reload_profile_config()
+			except TunedException as e:
+				log.error("Failed to reload Tuned: %s" % e)
+				return False
 			return self.start()
 
 	def _switch_profile(self, profile_name, manual):

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -132,18 +132,16 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 	def reload(self, caller = None):
 		if caller == "":
 			return False
-		if not self._daemon.is_running():
-			return False
-		else:
+		if self._daemon.is_running():
 			stop_ok = self.stop()
 			if not stop_ok:
 				return False
-			try:
-				self._daemon.reload_profile_config()
-			except TunedException as e:
-				log.error("Failed to reload Tuned: %s" % e)
-				return False
-			return self.start()
+		try:
+			self._daemon.reload_profile_config()
+		except TunedException as e:
+			log.error("Failed to reload Tuned: %s" % e)
+			return False
+		return self.start()
 
 	def _switch_profile(self, profile_name, manual):
 		was_running = self._daemon.is_running()

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -219,7 +219,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 		if self._daemon.is_running():
 			self._daemon.stop()
 		if self._daemon.is_enabled():
-			self._daemon.set_profile(None, None, save_instantly=True)
+			self._daemon.set_profile(None, True, save_instantly=True)
 		return True
 
 	@exports.export("", "b")


### PR DESCRIPTION
Please take a look at the second commit. The `return False` when the daemon is not running has been there for ages, however I'm not sure if it serves a specific purpose. Do you think we can drop it?