### PR TITLE
sysctl: Make reapply_sysctl ignore configs from /usr

### DIFF
--- a/man/tuned-main.conf.5
+++ b/man/tuned-main.conf.5
@@ -61,14 +61,14 @@ applicable if \fBdaemon\fR is enabled. By default it's set to \fBTrue\fR.
 
 .TP
 .BI reapply_sysctl= BOOL
-This controls whether to reapply sysctl settings from the \fI/etc/sysctl.conf\fR,
-\fI/etc/sysctl.d/*.conf\fR, \fI/usr/lib/sysctl.d/*.conf\fR,
-\fI/usr/local/lib/sysctl.d/*.conf\fR, \fI/lib/sysctl.d/*.conf\fR,
-\fI/run/sysctl.d/*.conf\fR, i.e. all locations supported by
-\fBsysctl --system\fR after Tuned sysctl settings are applied, i.e. if
-set to \fBTrue\fR or \fB1\fR Tuned sysctl settings will not override system
-sysctl settings. If set to \fBFalse\fR or \fB0\fR Tuned sysctl settings will
-override system sysctl settings. By default it's set to \fBTrue\fR.
+This controls whether to reapply sysctl settings from \fI/run/sysctl.d/*.conf\fR,
+\fI/etc/sysctl.d/*.conf\fR and \fI/etc/sysctl.conf\fR after Tuned sysctl
+settings are applied. These are locations supported by \fBsysctl --system\fR,
+excluding those that contain sysctl configuration files provided by system packages.
+So if \fBreapply_sysctl\fR is set to \fBTrue\fR or \fB1\fR, Tuned sysctl settings
+will not override user-provided system sysctl settings. If set to \fBFalse\fR or
+\fB0\fR, Tuned sysctl settings will override system sysctl settings. By default
+it's set to \fBTrue\fR.
 
 .TP
 .BI default_instance_priority= INT

--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -22,9 +22,10 @@ update_interval = 10
 # one hardcoded profile (by default "balanced").
 recommend_command = 1
 
-# Whether to reapply sysctl from the e.g /etc/sysctl.conf, /etc/sysctl.d, ...
-# If enabled these sysctls will be re-appliead after Tuned sysctls are
-# applied, i.e. Tuned sysctls will not override system sysctls.
+# Whether to reapply sysctl from /run/sysctl.d/, /etc/sysctl.d/ and
+# /etc/sysctl.conf.  If enabled, these sysctls will be re-appliead
+# after Tuned sysctls are applied, i.e. Tuned sysctls will not
+# override user-provided system sysctls.
 reapply_sysctl = 1
 
 # Default priority assigned to instances

--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -12,10 +12,7 @@ log = tuned.logs.get()
 
 DEPRECATED_SYSCTL_OPTIONS = [ "base_reachable_time", "retrans_time" ]
 SYSCTL_CONFIG_DIRS = [ "/run/sysctl.d",
-		"/etc/sysctl.d",
-		"/usr/local/lib/sysctl.d",
-		"/usr/lib/sysctl.d",
-		"/lib/sysctl.d" ]
+		"/etc/sysctl.d" ]
 
 class SysctlPlugin(base.Plugin):
 	"""


### PR DESCRIPTION
The reapply_sysctl functionality was originally added to address rhbz#1302953, which was about Tuned overriding sysctl config files from /etc, which was deemed undesirable. The bug said nothing about sysctl config files from /usr/lib/sysctl.d, /lib/sysctl.d or /usr/local/lib/sysctl.d.

Having sysctl configs from /usr override Tuned profiles causes problems (rhbz#1759597). Also, it seems reasonable for Tuned profiles to override sysctl configs from /usr - a Tuned profile is often explicitly chosen by the user, whereas sysctl configs from /usr are provided by system packages whether the user wants them or not.

Also, in RHEL-6, tuned used to ignore sysctl config files from /usr, as far as I can tell.

Resolves rhbz#1759597

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>