### PR TITLE
Added drop option allowing dropping options from inherited plugins

### DIFF
--- a/tuned/profiles/merger.py
+++ b/tuned/profiles/merger.py
@@ -43,6 +43,10 @@ class Merger(object):
 					profile_a.units[unit_name].script_pre = unit.script_pre
 				if unit.script_post is not None:
 					profile_a.units[unit_name].script_post = unit.script_post
+				if unit.drop is not None:
+					for option in unit.drop:
+						profile_a.units[unit_name].options.pop(option, None)
+					unit.drop = None
 				if unit_name == "script" and profile_a.units[unit_name].options.get("script", None) is not None:
 					script = profile_a.units[unit_name].options.get("script", None)
 					profile_a.units[unit_name].options.update(unit.options)

--- a/tuned/profiles/unit.py
+++ b/tuned/profiles/unit.py
@@ -1,11 +1,12 @@
 import collections
+import re
 
 class Unit(object):
 	"""
 	Unit description.
 	"""
 
-	__slots__ = [ "_name", "_type", "_enabled", "_replace", "_devices", "_devices_udev_regex", \
+	__slots__ = [ "_name", "_type", "_enabled", "_replace", "_drop", "_devices", "_devices_udev_regex", \
 		"_cpuinfo_regex", "_uname_regex", "_script_pre", "_script_post", "_options" ]
 
 	def __init__(self, name, config):
@@ -13,6 +14,9 @@ class Unit(object):
 		self._type = config.pop("type", self._name)
 		self._enabled = config.pop("enabled", True) in [True, "True", "true", 1, "1"]
 		self._replace = config.pop("replace", False) in [True, "True", "true", 1, "1"]
+		self._drop = config.pop("drop", None)
+		if self._drop is not None:
+			self._drop = re.split(r"\b\s*[,;]\s*", str(self._drop))
 		self._devices = config.pop("devices", "*")
 		self._devices_udev_regex = config.pop("devices_udev_regex", None)
 		self._cpuinfo_regex = config.pop("cpuinfo_regex", None)
@@ -44,6 +48,14 @@ class Unit(object):
 	@property
 	def replace(self):
 		return self._replace
+
+	@property
+	def drop(self):
+		return self._drop
+
+	@drop.setter
+	def drop(self, value):
+		self._drop = value
 
 	@property
 	def devices(self):


### PR DESCRIPTION
Consider the following:
profile_1:
[cpu]
force_latency=10
no_turbo=1

[disk]
readahead=4098

If you want to include it in profile_2 and just drop the force_latency
option now you can write:
[main]
include=profile_1

[cpu]
drop=force_latency

Previously, you had to use the replace option and add all other options
which were used in the inherited profiles like:
[main]
include=profile_1

[cpu]
replace=true
no_turbo=1

There can be named multiple options in the drop. As the delimiter comma
',' or semicolon ';' can be used, spaces are ignored, e.g.:
[cpu]
drop=force_latency, no_turbo

Fixes: #227

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>