### PR TITLE
Add Intel Speed Select Technology (SST) Profile

### DIFF
--- a/man/tuned-profiles.7
+++ b/man/tuned-profiles.7
@@ -115,6 +115,11 @@ settings.
 Profile optimized for virtual hosts based on throughput\-performance profile.
 It additionally enables more aggressive writeback of dirty pages.
 
+.TP
+.BI "sst"
+Profile optimized for systems with user-defined Intel Speed Select Technology
+configurations.
+
 .SH "FILES"
 .nf
 .I /etc/tuned/*

--- a/profiles/sst/tuned.conf
+++ b/profiles/sst/tuned.conf
@@ -1,0 +1,5 @@
+[main]
+summary=Configure for Intel Speed Select Base Frequency
+
+[bootloader]
+cmdline_sst=-intel_pstate=disable


### PR DESCRIPTION
Intel's new Speed Select Technology (SST) is a process power management
technology introduced by Intel that allows for throughput and per-core
performance configurations and optimizations such as allowing for
prioritization of workloads on specific cores by sacrificing performance
on other cores.

Intel has released several CascadeLake processors, commonly referred to
as CascadeLake-N, with this technology and will introduce further SST
related technologies in the next few years.

These new technologies require the disabling of the intel-pstate driver
configuration in tuned as it may interfere with the user chosen per-core
configurations of SST.

Add a new SST profile to tuned for general use.

Resolves:  https://bugzilla.redhat.com/1743879

Signed-off-by: Prarit Bhargava <prarit@redhat.com>
Signed-off-by: Joe Mario <jmario@redhat.com>