### PR TITLE
Don't modify the BLS snippets on s390x

### DIFF
--- a/92-tuned.install
+++ b/92-tuned.install
@@ -19,20 +19,15 @@ LOADER_ENTRIES="$BOOT_ROOT/loader/entries"
 
 [ "$COMMAND" = "add" ] || exit 0
 
-# Workaround for rhbz#1657858
+# The zipl bootloader doesn't support variables
 ARCH=`uname -m`
-[ "${ARCH:0:4}" = "s390" ]
-HANDLE_INITRD="$?"
+[ "${ARCH:0:4}" = "s390" ] && exit 0
 
 pushd "$LOADER_ENTRIES" &> /dev/null
 for f in `basename "$MACHINE_ID"`-*.conf; do
   if [ -f "$f" -a "${f: -12}" != "-rescue.conf" ]; then
     grep -q '^\s*options\s\+.*\$tuned_params' "$f" || sed -i '/^\s*options\s\+/ s/\(.*\)/\1 \$tuned_params/' "$f"
-    if [ "$HANDLE_INITRD" = "1" ]; then
-      grep -q '^\s*initrd\s\+.*\$tuned_initrd' "$f" || sed -i '/^\s*initrd\s\+/ s/\(.*\)/\1 \$tuned_initrd/' "$f"
-    else
-      sed -i '/^\s*initrd\s\+.*\$tuned_initrd/ s/\s\+\$tuned_initrd\b//g' "$f"
-    fi
+    grep -q '^\s*initrd\s\+.*\$tuned_initrd' "$f" || sed -i '/^\s*initrd\s\+/ s/\(.*\)/\1 \$tuned_initrd/' "$f"
   fi
 done
 popd &> /dev/null


### PR DESCRIPTION
Currently the 92-tuned.install kernel-install plugin adds the tuned params
to the BLS config files in s390x machines. But the zipl bootloader doesn't
support for environment variables, which leads to cmdlines like following:

root=/dev/mapper/rhel-root crashkernel=auto rd.dasd=0.0.541f rd.dasd=0.0.551f
rd.dasd=0.0.561f rd.dasd=0.0.571f rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap
cio_ignore=all,!condev rd.znet=qeth,0.0.0600,0.0.0601,0.0.0602,layer2=1,portno=0
$tuned_params BOOT_IMAGE=0

Don't modify the BLS snippets ince the zipl bootloader doesn't support the
variables and just exit the script in the s390x case.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>