### PR TITLE
oracle: Turn off NUMA balancing

### DIFF
--- a/profiles/oracle/tuned.conf
+++ b/profiles/oracle/tuned.conf
@@ -24,6 +24,7 @@ net.core.rmem_max = 4194304
 net.core.wmem_default = 262144
 net.core.wmem_max = 1048576
 kernel.panic_on_oops = 1
+kernel.numa_balancing = 0
 
 [vm]
 transparent_hugepages=never


### PR DESCRIPTION
Turn off NUMA balancing, according to feedback from the performance team.

Resolves: rhbz#1782233

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>