### PR TITLE
profiles: Make sure variables are defined before use

### DIFF
--- a/profiles/cpu-partitioning/tuned.conf
+++ b/profiles/cpu-partitioning/tuned.conf
@@ -10,6 +10,10 @@ include=network-latency
 include=/etc/tuned/cpu-partitioning-variables.conf
 
 isolated_cores_assert_check = \\${isolated_cores}
+# Make sure isolated_cores is defined before any of the variables that
+# use it (such as assert1) are defined, so that child profiles can set
+# isolated_cores directly in the profile (tuned.conf)
+isolated_cores = ${isolated_cores}
 # Fail if isolated_cores are not set
 assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
 
@@ -22,6 +26,10 @@ not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
 isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
 not_isolated_cores_online_expanded=${f:cpulist_online:${not_isolated_cores_expanded}}
 not_isolated_cpumask=${f:cpulist2hex:${not_isolated_cores_expanded}}
+# Make sure no_balance_cores is defined before
+# no_balance_cores_expanded is defined, so that child profiles can set
+# no_balance_cores directly in the profile (tuned.conf)
+no_balance_cores=${no_balance_cores}
 no_balance_cores_expanded=${f:cpulist_unpack:${no_balance_cores}}
 
 # Fail if isolated_cores contains CPUs which are not online

--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -12,6 +12,10 @@ include = network-latency
 include = /etc/tuned/realtime-variables.conf
 
 isolated_cores_assert_check = \\${isolated_cores}
+# Make sure isolated_cores is defined before any of the variables that
+# use it (such as assert1) are defined, so that child profiles can set
+# isolated_cores directly in the profile (tuned.conf)
+isolated_cores = ${isolated_cores}
 # Fail if isolated_cores are not set
 assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
 


### PR DESCRIPTION
Make sure the isolated_cores and no_balance_cores variables are defined before any of the variables that use them are defined. This enforces a certain ordering of variable expansions so that child profiles can set the variables directly in the profile (tuned.conf), e.g.:

[main]
include=cpu-partitioning

[variables]
isolated_cores=3

Resolves: rhbz#1781664

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>