### PR TITLE
profiles: renamed sst profile to intel-sst

### DIFF
--- a/man/tuned-profiles.7
+++ b/man/tuned-profiles.7
@@ -122,9 +122,11 @@ Profile optimized for virtual hosts based on throughput\-performance profile.
 It additionally enables more aggressive writeback of dirty pages.
 
 .TP
-.BI "sst"
+.BI "intel-sst"
 Profile optimized for systems with user-defined Intel Speed Select Technology
-configurations.
+configurations. This profile is intended to be used as an overlay on other
+profiles (e.g. cpu\-partitioning profile), example:
+.B tuned\-adm profile cpu\-partitioning intel-sst
 
 .SH "FILES"
 .nf

--- a/profiles/intel-sst/tuned.conf
+++ b/profiles/intel-sst/tuned.conf
@@ -2,4 +2,4 @@
 summary=Configure for Intel Speed Select Base Frequency
 
 [bootloader]
-cmdline_sst=-intel_pstate=disable
+cmdline_intel_sst=-intel_pstate=disable


### PR DESCRIPTION
Also updated intel-sst profile manual page describing its usage.

Related: rhbz#1743879

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>