### PR TITLE
Unapply bootcmdline settings even when grub.cfg does not exits.

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -93,10 +93,10 @@ class BootloaderPlugin(base.Plugin):
 		return self._cmd.add_modify_option_in_file(consts.BOOT_CMDLINE_FILE, d)
 
 	def _remove_grub2_tuning(self):
+		self._patch_bootcmdline({consts.BOOT_CMDLINE_TUNED_VAR : "", consts.BOOT_CMDLINE_INITRD_ADD_VAR : ""})
 		if not self._grub2_cfg_file_names:
 			log.info("cannot find grub.cfg to patch")
 			return
-		self._patch_bootcmdline({consts.BOOT_CMDLINE_TUNED_VAR : "", consts.BOOT_CMDLINE_INITRD_ADD_VAR : ""})
 		for f in self._grub2_cfg_file_names:
 			self._cmd.add_modify_option_in_file(f, {"set\s+" + consts.GRUB2_TUNED_VAR : "", "set\s+" + consts.GRUB2_TUNED_INITRD_VAR : ""}, add = False)
 		if self._initrd_dst_img_val is not None:


### PR DESCRIPTION
Currently when `grub.cfg` file is not found, the [bootloader] plugin still modifies `/etc/tuned/bootcmdline` file.  However, during rollbacks, the settings applied to that file are not rolled back.  This becomes a problem in (containerized) environments when `grub.cfg` file does not exist.  This patch will make the behaviour more consistent and unapply the settings in `/etc/tuned/bootcmdline` even when no `grub.cfg` is found.
