### PR TITLE
Remove usage of unittest2, use unittest from the standard library

### DIFF
--- a/tests/unit/exports/test_controller.py
+++ b/tests/unit/exports/test_controller.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 from unittest.mock import Mock
 
 from tuned.exports.controller import ExportsController
 import tuned.exports as exports
 
-class ControllerTestCase(unittest2.TestCase):
+class ControllerTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls._controller = ExportsController()

--- a/tests/unit/hardware/test_device_matcher.py
+++ b/tests/unit/hardware/test_device_matcher.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 from tuned.hardware.device_matcher import DeviceMatcher
 
-class DeviceMatcherTestCase(unittest2.TestCase):
+class DeviceMatcherTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls.matcher = DeviceMatcher()

--- a/tests/unit/hardware/test_device_matcher_udev.py
+++ b/tests/unit/hardware/test_device_matcher_udev.py
@@ -1,9 +1,9 @@
-import unittest2
+import unittest
 import pyudev
 
 from tuned.hardware.device_matcher_udev import DeviceMatcherUdev
 
-class DeviceMatcherUdevTestCase(unittest2.TestCase):
+class DeviceMatcherUdevTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls.udev_context = pyudev.Context()

--- a/tests/unit/hardware/test_inventory.py
+++ b/tests/unit/hardware/test_inventory.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 from unittest.mock import Mock
 import pyudev
 
@@ -6,7 +6,7 @@ from tuned.hardware.inventory import Inventory
 
 subsystem_name = "test subsystem"
 
-class InventoryTestCase(unittest2.TestCase):
+class InventoryTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls._context = pyudev.Context()
@@ -25,7 +25,10 @@ class InventoryTestCase(unittest2.TestCase):
 	def test_get_devices(self):
 		device_list1 = self._context.list_devices(subsystem = "tty")
 		device_list2 = self._inventory.get_devices("tty")
-		self.assertItemsEqual(device_list1,device_list2)
+		try:
+			self.assertCountEqual(device_list1,device_list2)
+		except AttributeError:  # Python 2
+			self.assertItemsEqual(device_list1,device_list2)
 
 	def test_subscribe(self):
 		self._inventory.subscribe(self._dummy,subsystem_name,

--- a/tests/unit/monitors/test_base.py
+++ b/tests/unit/monitors/test_base.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import tuned.monitors.base
 
 class MockMonitor(tuned.monitors.base.Monitor):
@@ -12,7 +12,7 @@ class MockMonitor(tuned.monitors.base.Monitor):
 			cls._load.setdefault(device, 0)
 			cls._load[device] += 1
 
-class MonitorBaseClassTestCase(unittest2.TestCase):
+class MonitorBaseClassTestCase(unittest.TestCase):
 	def test_fail_base_class_init(self):
 		with self.assertRaises(NotImplementedError):
 			tuned.monitors.base.Monitor()

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
 	from collections import Mapping
 import tempfile
-import unittest2
+import unittest
 
 from tuned.monitors.repository import Repository
 import tuned.plugins.decorators as decorators
@@ -26,7 +26,7 @@ plugin_instance_factory = plugins.instance.Factory()
 storage_provider = storage.PickleProvider()
 storage_factory = storage.Factory(storage_provider)
 
-class PluginBaseTestCase(unittest2.TestCase):
+class PluginBaseTestCase(unittest.TestCase):
 	def setUp(self):
 		self._plugin = DummyPlugin(monitors_repository,storage_factory,\
 			hardware_inventory,device_matcher,device_matcher_udev,\

--- a/tests/unit/profiles/test_loader.py
+++ b/tests/unit/profiles/test_loader.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import tempfile
 import shutil
 import os
@@ -6,7 +6,7 @@ import os
 import tuned.profiles as profiles
 from tuned.profiles.exceptions import InvalidProfileException
 
-class LoaderTestCase(unittest2.TestCase):
+class LoaderTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls._test_dir = tempfile.mkdtemp()

--- a/tests/unit/profiles/test_locator.py
+++ b/tests/unit/profiles/test_locator.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import os
 import shutil
 import tempfile
 from tuned.profiles.locator import Locator
 
-class LocatorTestCase(unittest2.TestCase):
+class LocatorTestCase(unittest.TestCase):
 	def setUp(self):
 		self.locator = Locator(self._tmp_load_dirs)
 

--- a/tests/unit/profiles/test_merger.py
+++ b/tests/unit/profiles/test_merger.py
@@ -1,9 +1,9 @@
-import unittest2
+import unittest
 from tuned.profiles.merger import Merger
 from tuned.profiles.profile import Profile
 from collections import OrderedDict
 
-class MergerTestCase(unittest2.TestCase):
+class MergerTestCase(unittest.TestCase):
 	def test_merge_without_replace(self):
 		merger = Merger()
 		config1 = OrderedDict([

--- a/tests/unit/profiles/test_profile.py
+++ b/tests/unit/profiles/test_profile.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import tuned.profiles
 import collections
 
@@ -6,7 +6,7 @@ class MockProfile(tuned.profiles.profile.Profile):
 	def _create_unit(self, name, config):
 		return (name, config)
 
-class ProfileTestCase(unittest2.TestCase):
+class ProfileTestCase(unittest.TestCase):
 
 	def test_init(self):
 		MockProfile("test", {})

--- a/tests/unit/profiles/test_unit.py
+++ b/tests/unit/profiles/test_unit.py
@@ -1,7 +1,7 @@
-import unittest2
+import unittest
 from tuned.profiles import Unit
 
-class UnitTestCase(unittest2.TestCase):
+class UnitTestCase(unittest.TestCase):
 
 	def test_default_options(self):
 		unit = Unit("sample", {})

--- a/tests/unit/utils/test_commands.py
+++ b/tests/unit/utils/test_commands.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import tempfile
 import shutil
 import re
@@ -9,7 +9,7 @@ import tuned.consts as consts
 from tuned.exceptions import TunedException
 import tuned.utils.commands
 
-class CommandsTestCase(unittest2.TestCase):
+class CommandsTestCase(unittest.TestCase):
 	def setUp(self):
 		self._commands = commands()
 		self._test_dir = tempfile.mkdtemp()

--- a/tests/unit/utils/test_global_config.py
+++ b/tests/unit/utils/test_global_config.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import tempfile
 import shutil
 import os
@@ -6,7 +6,7 @@ import os
 import tuned.consts as consts
 import tuned.utils.global_config as global_config
 
-class GlobalConfigTestCase(unittest2.TestCase):
+class GlobalConfigTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		cls.test_dir = tempfile.mkdtemp()

--- a/tuned.spec
+++ b/tuned.spec
@@ -60,7 +60,7 @@ Requires(preun): systemd
 Requires(postun): systemd
 BuildRequires: %{_py}, %{_py}-devel
 # BuildRequires for 'make test'
-BuildRequires: %{_py}-unittest2, %{_py}-configobj, %{_py}-mock
+BuildRequires: %{_py}-configobj
 BuildRequires: %{_py}-decorator, %{_py}-pyudev
 Requires: %{_py}-decorator, %{_py}-pyudev, %{_py}-configobj
 Requires: %{_py}-schedutils, %{_py}-linux-procfs, %{_py}-perf


### PR DESCRIPTION
Fixes https://github.com/redhat-performance/tuned/issues/241

Fedora is removing the unittest2 package: https://bugzilla.redhat.com/show_bug.cgi?id=1794222

tuned is not targeting Python 2.6: https://github.com/redhat-performance/tuned/issues/241#issuecomment-588320175

One thing not present in Python 2.7 is `assertItemsEqual()` -- renamed to `assertCountEqual()`.

Related, `mock` was also listed as a requirement in the spec file,
but all the imports are from `unittest.mock`, hence removed.