### PR TITLE
cpu-partitioning: Disable kernel.timer_migration

### DIFF
--- a/profiles/cpu-partitioning/tuned.conf
+++ b/profiles/cpu-partitioning/tuned.conf
@@ -39,7 +39,7 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 kernel.hung_task_timeout_secs = 600
 kernel.nmi_watchdog = 0
 vm.stat_interval = 10
-kernel.timer_migration = 1
+kernel.timer_migration = 0
 
 [sysfs]
 /sys/bus/workqueue/devices/writeback/cpumask = ${not_isolated_cpumask}


### PR DESCRIPTION
Reportedly, it's no longer needed.

Resolves: rhbz#1797629