### PR TITLE
Adjust FILES section to point to the doc dir  containing the version info

### DIFF
--- a/man/tuned.8
+++ b/man/tuned.8
@@ -59,7 +59,6 @@ Show version information.
 .SH "FILES"
 .nf
 /etc/tuned
-/usr/share/doc/tuned\fR[\fI-version\fR]/README
 .SH "SEE ALSO"
 .LP
 tuned.conf(5)

--- a/man/tuned.8
+++ b/man/tuned.8
@@ -59,7 +59,7 @@ Show version information.
 .SH "FILES"
 .nf
 /etc/tuned
-/usr/share/doc/tuned/README
+/usr/share/doc/tuned\fR[\fI-version\fR]/README
 .SH "SEE ALSO"
 .LP
 tuned.conf(5)


### PR DESCRIPTION
The DOC file specified in the man tuned.8 page may actually be located under the tuned-VERSION of it but there is no indicator that that might be the case.