### PR TITLE
Replaced python-dmidecode with reading sysfs dmi and dmidecode tool.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,9 +10,4 @@ Python files are modified to use Python3. If you want tuned to use Python2
 instead, set PYTHON to the full path of Python2. Example:
     make PYTHON=/usr/bin/python2 install
 
-tuned requires some Python packages in order to run.
-Those packages are listed in 'requirements.txt'.
-
-Use: 'pip3 install -r requirements.txt' (or 'pip install -r requirements.txt' for Python2) to install them.
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-dmidecode

--- a/tuned.spec
+++ b/tuned.spec
@@ -70,14 +70,14 @@ Requires: %{_py}-schedutils, %{_py}-linux-procfs, %{_py}-perf
 BuildRequires: python3-dbus, python3-gobject-base
 Requires: python3-dbus, python3-gobject-base
 %if 0%{?fedora} > 22 || 0%{?rhel} > 7
-Recommends: python3-dmidecode
+Recommends: dmidecode
 %endif
 %else
 # BuildRequires for 'make test'
 BuildRequires: dbus-python, pygobject3-base
 Requires: dbus-python, pygobject3-base
 %if 0%{?fedora} > 22 || 0%{?rhel} > 7
-Recommends: python-dmidecode
+Recommends: dmidecode
 %endif
 %endif
 Requires: virt-what, ethtool, gawk, hdparm

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -5,7 +5,6 @@ from tuned.exceptions import TunedException
 import threading
 import tuned.consts as consts
 from tuned.utils.commands import commands
-from tuned.utils.profile_recommender import ProfileRecommender
 
 __all__ = ["Controller"]
 
@@ -257,7 +256,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 	def recommend_profile(self, caller = None):
 		if caller == "":
 			return ""
-		return ProfileRecommender().recommend(hardcoded = not self._global_config.get_bool(consts.CFG_RECOMMEND_COMMAND, consts.CFG_DEF_RECOMMEND_COMMAND))
+		return self._daemon.profile_recommender.recommend()
 
 	@exports.export("", "b")
 	def verify_profile(self, caller = None):

--- a/tuned/daemon/daemon.py
+++ b/tuned/daemon/daemon.py
@@ -40,6 +40,7 @@ class Daemon(object):
 			log.info("dynamic tuning is enabled (can be overridden by plugins)")
 			log.info("using update interval of %d second(s) (%d times of the sleep interval)" % (self._sleep_cycles * self._sleep_interval, self._sleep_cycles))
 
+		self._profile_recommender = ProfileRecommender(is_hardcoded = not self._recommend_command)
 		self._unit_manager = unit_manager
 		self._profile_loader = profile_loader
 		self._init_threads()
@@ -168,6 +169,10 @@ class Daemon(object):
 		return self._post_loaded_profile if self._profile else None
 
 	@property
+	def profile_recommender(self):
+		return self._profile_recommender
+
+	@property
 	def profile_loader(self):
 		return self._profile_loader
 
@@ -263,7 +268,7 @@ class Daemon(object):
 
 	def _get_recommended_profile(self):
 		log.info("Running in automatic mode, checking what profile is recommended for your configuration.")
-		profile = ProfileRecommender().recommend(hardcoded = not self._recommend_command)
+		profile = self._profile_recommender.recommend()
 		log.info("Using '%s' profile" % profile)
 		return profile
 


### PR DESCRIPTION
Fixes #232
sysfs exports virtual dmi device structs which provides chassis type in numeric form, it should be available in all RHEL6+, so I used it as primary source (not much overhead).
If for some reasons it couldn't be read, dmidecode output will be parsed instead. Removed any references to python-dmidecode module.
chassis type is gathered only once, and only one intance of ProfileRecommender will be created (in daemon).

Signed-off-by: Michal Bajer <outSH@users.noreply.github.com>