### PR TITLE
builtin_functions: fixed check for number of arguments

### DIFF
--- a/tuned/profiles/functions/base.py
+++ b/tuned/profiles/functions/base.py
@@ -24,7 +24,7 @@ class Function(object):
 		if args is None or nargs_max is None:
 			return False
 		la = len(args)
-		return (nargs_max == 0 or nargs_max == la) and (nargs_min is None or nargs_min <= la)
+		return (nargs_max == 0 or nargs_max >= la) and (nargs_min is None or nargs_min <= la)
 
 	def execute(self, args):
 		if self._check_args(args, self._nargs_max, self._nargs_min):

--- a/tuned/profiles/functions/function_assertion.py
+++ b/tuned/profiles/functions/function_assertion.py
@@ -13,8 +13,8 @@ class assertion(base.Function):
 	exception will abort profile loading.
 	"""
 	def __init__(self):
-		# 2 arguments
-		super(assertion, self).__init__("assertion", 3)
+		# 3 arguments
+		super(assertion, self).__init__("assertion", 3, 3)
 
 	def execute(self, args):
 		if not super(assertion, self).execute(args):

--- a/tuned/profiles/functions/function_assertion_non_equal.py
+++ b/tuned/profiles/functions/function_assertion_non_equal.py
@@ -13,8 +13,8 @@ class assertion_non_equal(base.Function):
 	exception will abort profile loading.
 	"""
 	def __init__(self):
-		# 2 arguments
-		super(assertion_non_equal, self).__init__("assertion_non_equal", 3)
+		# 3 arguments
+		super(assertion_non_equal, self).__init__("assertion_non_equal", 3, 3)
 
 	def execute(self, args):
 		if not super(assertion_non_equal, self).execute(args):

--- a/tuned/profiles/functions/function_hex2cpulist.py
+++ b/tuned/profiles/functions/function_hex2cpulist.py
@@ -10,8 +10,8 @@ class hex2cpulist(base.Function):
 	Conversion function: converts hexadecimal CPU mask to CPU list
 	"""
 	def __init__(self):
-		# one argument
-		super(hex2cpulist, self).__init__("hex2cpulist", 1)
+		# 1 argument
+		super(hex2cpulist, self).__init__("hex2cpulist", 1, 1)
 
 	def execute(self, args):
 		if not super(hex2cpulist, self).execute(args):

--- a/tuned/profiles/functions/function_kb2s.py
+++ b/tuned/profiles/functions/function_kb2s.py
@@ -8,8 +8,8 @@ class kb2s(base.Function):
 	Conversion function: kbytes to sectors
 	"""
 	def __init__(self):
-		# one argument
-		super(kb2s, self).__init__("kb2s", 1)
+		# 1 argument
+		super(kb2s, self).__init__("kb2s", 1, 1)
 
 	def execute(self, args):
 		if not super(kb2s, self).execute(args):

--- a/tuned/profiles/functions/function_regex_search_ternary.py
+++ b/tuned/profiles/functions/function_regex_search_ternary.py
@@ -10,7 +10,7 @@ class regex_search_ternary(base.Function):
 	"""
 	def __init__(self):
 		# 4 arguments
-		super(regex_search_ternary, self).__init__("regex_search_ternary", 4)
+		super(regex_search_ternary, self).__init__("regex_search_ternary", 4, 4)
 
 	def execute(self, args):
 		if not super(regex_search_ternary, self).execute(args):

--- a/tuned/profiles/functions/function_s2kb.py
+++ b/tuned/profiles/functions/function_s2kb.py
@@ -8,8 +8,8 @@ class s2kb(base.Function):
 	Conversion function: sectors to kbytes
 	"""
 	def __init__(self):
-		# one argument
-		super(s2kb, self).__init__("s2kb", 1)
+		# 1 argument
+		super(s2kb, self).__init__("s2kb", 1, 1)
 
 	def execute(self, args):
 		if not super(s2kb, self).execute(args):

--- a/tuned/profiles/functions/function_virt_check.py
+++ b/tuned/profiles/functions/function_virt_check.py
@@ -11,7 +11,7 @@ class virt_check(base.Function):
 	"""
 	def __init__(self):
 		# 2 arguments
-		super(virt_check, self).__init__("virt_check", 2)
+		super(virt_check, self).__init__("virt_check", 2, 2)
 
 	def execute(self, args):
 		if not super(virt_check, self).execute(args):


### PR DESCRIPTION
There can be lower number of arguments than the max limit.
Also fixed definition of functions which wrongly used the API.

I.e. it should work this way:
__init__("FUNC", 3, 3)

__init__("FUNC", 4, 3)

__init__("FUNC", 3)

__init__("FUNC", 0, 3)

__init__("FUNC", 0)

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>