### PR TITLE
Enable isolate_managed_irq to be defined in child profiles.

### DIFF
--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -29,6 +29,10 @@ isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
 assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
 
 # Assembly managed_irq
+# Make sure isolate_managed_irq is defined before any of the variables that
+# use it (such as managed_irq) are defined, so that child profiles can set
+# isolate_managed_irq directly in the profile (tuned.conf)
+isolate_managed_irq = ${isolate_managed_irq}
 managed_irq=${f:regex_search_ternary:${isolate_managed_irq}:\b[y,Y,1,t,T]\b:managed_irq,domain,:}
 
 [sysctl]


### PR DESCRIPTION
This fixes the unability to use `isolate_managed_irq` from child profiles.
