### PR TITLE
Allow override of detected architecture

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -39,3 +39,13 @@ log_file_count = 2
 
 # Log file max size
 log_file_max_size = 1MB
+
+# Preset system uname string for architecture specific tuning.
+# It can be used to force tuning for specific architecture.
+# If commented, "uname" will be called to fill its content.
+# uname_string = x86_64
+
+# Preset system cpuinfo string for architecture specific tuning.
+# It can be used to force tuning for specific architecture.
+# If commented, "/proc/cpuinfo" will be read to fill its content.
+# cpuinfo_string = Intel

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -71,6 +71,8 @@ CFG_RECOMMEND_COMMAND = "recommend_command"
 CFG_REAPPLY_SYSCTL = "reapply_sysctl"
 CFG_DEFAULT_INSTANCE_PRIORITY = "default_instance_priority"
 CFG_UDEV_BUFFER_SIZE = "udev_buffer_size"
+CFG_UNAME_STRING = "uname_string"
+CFG_CPUINFO_STRING = "cpuinfo_string"
 
 # no_daemon mode
 CFG_DEF_DAEMON = True

--- a/tuned/daemon/application.py
+++ b/tuned/daemon/application.py
@@ -41,7 +41,7 @@ class Application(object):
 		def_instance_priority = int(self.config.get(consts.CFG_DEFAULT_INSTANCE_PRIORITY, consts.CFG_DEF_DEFAULT_INSTANCE_PRIORITY))
 		unit_manager = units.Manager(
 				plugins_repository, monitors_repository,
-				def_instance_priority, hardware_inventory)
+				def_instance_priority, hardware_inventory, self.config)
 
 		profile_factory = profiles.Factory()
 		profile_merger = profiles.Merger()


### PR DESCRIPTION
There should be a way for administrators and testers to force loading of
architecture specific tuning. For example, if there is some specific tuning
for some platforms with specific CPUIDs and the vendor will release new
compatible platform with the new CPUID, there needs to be a way for
administrator to use the tuning on the new platform without waiting for the
Tuned profile update or without the need to customize the profile.

This commit adds two main config options:
uname_string
cpuinfo_string

If unset (commented), which is the default, runtime detection will be used,
i.e. 'uname' will be called and '/proc/cpuinfo' will be read. If set,
content of the variables will be used instead of the runtime detection.

For example by setting:
uname_string = aarch64

It's possible to pretend that Tuned is running on the 64-bit ARM.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>