### PR TITLE
.packit.yaml: Use fedora-all and centos-stream targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,19 +3,17 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
     - epel-8-x86_64
+    - centos-stream-x86_64
   trigger: pull_request
 - job: tests
   trigger: pull_request
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
     - epel-8-x86_64
+    - centos-stream-x86_64
 specfile_path: tuned.spec
 synced_files:
 - tuned.spec


### PR DESCRIPTION
Hi,

according https://packit.dev/docs/configuration/ packit now supports fedora-all alias and centos-stream for targets.
I tested it on this fake pull request https://github.com/zdohnal/tuned/pull/2 - tests were started for all branched non-EOL (F31+F32) Fedoras, rawhide, epel-8 and centos stream.

Please let me know if I should change something else, otherwise would you mind adding the change to the project?

Thank you in advance!