### PR TITLE
Added new profile optimize-serial-console

### DIFF
--- a/man/tuned-profiles.7
+++ b/man/tuned-profiles.7
@@ -122,11 +122,19 @@ Profile optimized for virtual hosts based on throughput\-performance profile.
 It additionally enables more aggressive writeback of dirty pages.
 
 .TP
-.BI "intel-sst"
+.BI "intel\-sst"
 Profile optimized for systems with user-defined Intel Speed Select Technology
 configurations. This profile is intended to be used as an overlay on other
 profiles (e.g. cpu\-partitioning profile), example:
-.B tuned\-adm profile cpu\-partitioning intel-sst
+.B tuned\-adm profile cpu\-partitioning intel\-sst
+
+.TP
+.BI "optimize\-serial\-console"
+Profile which tunes down I/O activity to the serial console by reducing the
+printk value. This should make the serial console more responsive.
+This profile is intended to be used as an overlay on other
+profiles (e.g. throughput\-performance profile), example:
+.B tuned\-adm profile throughput\-performance optimize\-serial\-console
 
 .SH "FILES"
 .nf

--- a/profiles/optimize-serial-console/tuned.conf
+++ b/profiles/optimize-serial-console/tuned.conf
@@ -1,0 +1,11 @@
+#
+# tuned configuration
+#
+# This tuned configuration optimizes for serial console performance at the
+# expense of reduced debug information to the console.
+
+[main]
+summary=Optimize for serial console use.
+
+[sysctl]
+kernel.printk="4 4 1 7"


### PR DESCRIPTION
Profile which tunes down I/O activity to the serial console by reducing the
printk value. This should make the serial console more responsive.
This profile is intended to be used as an overlay on other
profiles (e.g. throughput-performance profile), example:
```
# tuned-adm profile throughput-performance optimize-serial-console
```

Also minor fixes to the man page quoting.

Resolves: rhbz#1840689

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>