### PR TITLE
scheduler: add support for cgroups

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -41,6 +41,13 @@ MACHINE_ID_FILE = "/etc/machine-id"
 KERNEL_UPDATE_HOOK_FILE = "/usr/lib/kernel/install.d/92-tuned.install"
 BLS_ENTRIES_PATH = "/boot/loader/entries"
 
+# scheduler plugin configuration
+# how many times retry to move tasks to parent cgroup on cgroup cleanup
+CGROUP_CLEANUP_TASKS_RETRY = 10
+PROCFS_MOUNT_POINT = "/proc"
+DEF_CGROUP_MOUNT_POINT = "/sys/fs/cgroup/cpuset"
+DEF_CGROUP_MODE = 0o770
+
 # modules plugin configuration
 MODULES_FILE = "/etc/modprobe.d/tuned.conf"
 

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -399,6 +399,9 @@ class commands:
 			m |= pow(2, v)
 		return m
 
+	def cpulist2string(self, l):
+		return ",".join(str(v) for v in l)
+
 	# Do not make balancing on patched Python 2 interpreter (rhbz#1028122).
 	# It means less CPU usage on patchet interpreter. On non-patched interpreter
 	# it is not allowed to sleep longer than 50 ms.


### PR DESCRIPTION
This is an alpha version, expect bugs :) It needs more love :)

This commit adds cgroup v1 support to the scheduler plugin. It seems that
cgroup v1 is the default on RHEL-8. Systemd uses it there, so we have to start
with the cgroup v1. On Fedora, systemd has been switched
to the cgroup v2 (tested on f31), but it's still possible to intermix there
with the cgroup v1. We can add cgroup v2 support later (the logic of the
extended syntax will not change).

This commit extends the syntax the following way:
```
[scheduler]
cgroup_init=1
cgroup_mount_point=/cgroup/cpuset
cgroup=group
cgroup.group1=2
cgroup.group2=0,2

group.ksoftirqd=0:f:2:cgroup.group1:ksoftirqd.*

ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*

isolated_cores=1
```
--
Legend:

'cgroup_init' if set to '1' (or similar boolean) means that Tuned
will create and remove the cgroup mountpoint and all related directories
by itself. If set to '0' (the default) the cgroups needs to be preset
by some different tool or by hand.

'cgroup_mount_point' is where to mount the cgroup FS or where Tuned
expects it to be mounted. If unset '/cgroup/cpuset' is expected.

'cgroup' is the cgroup name used for the 'isolated_cores' functionality.
For example here if the system has 4 CPUs, 'isolated_cores=1' means that
all threads (except of the blacklisted ones by the 'ps_blacklist' regexes)
will be moved to the CPU cores 0,2,3. It will be done the way that cgroup
'group' will be set to use the affinity 0,2-3 (by the 'cpuset.cpus' control
file) and all matching threads will be moved to this cgroup. If 'cgroup'
is unset, classic cpuset affinity will be used to achieve the goal.

'cgroup.CGROUP_NAME' defines affinities for arbitrary cgroups.
Even hierarchic cgroups can be used, but the hieararchy needs to be
specified in the correct order. Also Tuned doesn't do any sanity checks
here (except that it forces the cgroup to be under the mountpoint).
In the example it defines 'group1' with the affinity set to the CPU 2
and 'group2' with the affinity set to CPUs 0, 2.

'group.' its syntax has been extended, so it's now possible to use
e.g. 'cgroup.group1' instead of the hex affinity and the matching
processes will be moved to the 'group1'. It's also possible to use
cgroups which hasn't been defined by the 'cgroup.' option described
above (e.g. cgroups not managed by Tuned).

Resolves: rhbz#1784648

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>