### PR TITLE
Arch specific tuning for Marvell ThunderX and AMD

### DIFF
--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -7,6 +7,7 @@ summary=Broadly applicable tuning that provides excellent performance across a v
 
 [variables]
 thunderx_cpuinfo_regex=CPU part\s+:\s+(0x0?516)|(0x0?af)|(0x0?a[0-3])|(0x0?b8)\b
+amd_cpuinfo_regex=model name\s+:.*\bAMD\b
 
 [cpu]
 governor=performance
@@ -76,4 +77,12 @@ vm.swappiness=10
 type=sysctl
 uname_regex=aarch64
 cpuinfo_regex=${thunderx_cpuinfo_regex}
+kernel.numa_balancing=0
+
+# AMD
+[sysctl.amd]
+type=sysctl
+uname_regex=x86_64
+cpuinfo_regex=${amd_cpuinfo_regex}
+kernel.sched_migration_cost_ns=5000000
 kernel.numa_balancing=0

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -5,10 +5,20 @@
 [main]
 summary=Broadly applicable tuning that provides excellent performance across a variety of common server workloads
 
+[variables]
+thunderx_cpuinfo_regex=CPU part\s+:\s+(0x0?516)|(0x0?af)|(0x0?a[0-3])|(0x0?b8)\b
+
 [cpu]
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+
+# Marvell ThunderX
+[vm.thunderx]
+type=vm
+uname_regex=aarch64
+cpuinfo_regex=${thunderx_cpuinfo_regex}
+transparent_hugepages=never
 
 [disk]
 # The default unit for readahead is KiB.  This can be adjusted to sectors
@@ -60,3 +70,10 @@ vm.dirty_background_ratio = 10
 # 100 tells the kernel to aggressively swap processes out of physical memory
 # and move them to swap cache
 vm.swappiness=10
+
+# Marvell ThunderX
+[sysctl.thunderx]
+type=sysctl
+uname_regex=aarch64
+cpuinfo_regex=${thunderx_cpuinfo_regex}
+kernel.numa_balancing=0


### PR DESCRIPTION
This adds architecture specific tuning for the Marvell ThunderX and AMD.

It works but I can see few problems with this approach:
1. sysctl are reapplied multiple times - it should be harmless, but it's inefficient.
2. if conflicting settings are used in the arch specific instance and in the base instance, both settings will be applied and the last settings will win - this is not optimal, but it shouldn't cause trouble for unloading, because the units are unloaded in the opposite order as they were loaded.
3. if someone wants to override the arch specific tuning she or he has to override the arch specific instance or has to increase the base instance priority to change the processing order (similarly for the case if the arch specific tuning was defined the first).

I think 1 and 2 are fixable, but fix for 3 would probably require redesign and redefinition of the way how Tuned behaves. However, I think it's not blocker and the behaviour could be described in the documentation.
