### PR TITLE
cpu: Fix string comparisons

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -73,9 +73,9 @@ class CPULatencyPlugin(base.Plugin):
                         # "TransmetaCPU", "UMC UMC UMC"
 			cpu = procfs.cpuinfo()
 			vendor = cpu.tags.get("vendor_id")
-			if vendor is "GenuineIntel":
+			if vendor == "GenuineIntel":
 			        self._is_intel = True
-			elif vendor is "AuthenticAMD" or vendor is "HygonGenuine":
+			elif vendor == "AuthenticAMD" or vendor == "HygonGenuine":
 			        self._is_amd = True
 			else:
 				# We always assign Intel, unless we know better


### PR DESCRIPTION
The 'is' operator is used to determine object identity. What we want to do here instead is a value comparison, i.e. the "==" operator.

With the 'is' operator, the conditions would likely never evaluate to true.

This fixes errors such as these (they seem to get produced during byte
compilation; you can trigger them just by running Tuned).
```
/root/tuned/tuned/plugins/plugin_cpu.py:76: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if vendor is "GenuineIntel":
/root/tuned/tuned/plugins/plugin_cpu.py:78: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif vendor is "AuthenticAMD" or vendor is "HygonGenuine":
/root/tuned/tuned/plugins/plugin_cpu.py:78: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif vendor is "AuthenticAMD" or vendor is "HygonGenuine":
```

This fixes commit 29022a0edf651347f432463f359b0f3c42ee5348.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>