### PR TITLE
[For v2.15] Make tuned-adm indicate which profile is post-loaded

### DIFF
--- a/com.redhat.tuned.policy
+++ b/com.redhat.tuned.policy
@@ -27,6 +27,16 @@
     </defaults>
   </action>
 
+  <action id="com.redhat.tuned.post_loaded_profile">
+    <description>Show active post-loaded profile</description>
+    <message>Authentication is required to show active post-loaded profile</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
   <action id="com.redhat.tuned.disable">
     <description>Disable Tuned</description>
     <message>Authentication is required to disable Tuned</message>

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -149,7 +149,12 @@ class Admin(object):
 	def _action_dbus_profile_info(self, profile = ""):
 		if profile == "":
 			profile = self._dbus_get_active_profile()
-		return self._controller.exit(self._print_profile_info(profile, self._controller.profile_info(profile)))
+		if profile:
+			res = self._print_profile_info(profile, self._controller.profile_info(profile))
+		else:
+			print("No current active profile.")
+			res = False
+		return self._controller.exit(res)
 
 	def _action_profile_info(self, profile = ""):
 		if profile == "":

--- a/tuned/admin/dbus_controller.py
+++ b/tuned/admin/dbus_controller.py
@@ -117,6 +117,9 @@ class DBusController(object):
 	def profile_mode(self):
 		return self._call("profile_mode")
 
+	def post_loaded_profile(self):
+		return self._call("post_loaded_profile")
+
 	def switch_profile(self, new_profile):
 		if new_profile == "":
 			return (False, "No profile specified")

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -210,6 +210,12 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 		mode = consts.ACTIVE_PROFILE_MANUAL if manual else consts.ACTIVE_PROFILE_AUTO
 		return mode, ""
 
+	@exports.export("", "s")
+	def post_loaded_profile(self, caller = None):
+		if caller == "":
+			return ""
+		return self._daemon.post_loaded_profile or ""
+
 	@exports.export("", "b")
 	def disable(self, caller = None):
 		if caller == "":

--- a/tuned/daemon/daemon.py
+++ b/tuned/daemon/daemon.py
@@ -162,6 +162,12 @@ class Daemon(object):
 		return self._manual
 
 	@property
+	def post_loaded_profile(self):
+		# Return the profile name only if the profile is active. If
+		# the profile is not active, then the value is meaningless.
+		return self._post_loaded_profile if self._profile else None
+
+	@property
 	def profile_loader(self):
 		return self._profile_loader
 


### PR DESCRIPTION
Currently, the post-loaded profile is shown only among regular active profiles. For example:

Current active profile: balanced post

This is not entirely user-friendly, because the user may not know why the post-loaded profile is there, given that they did not specify it in a 'tuned-adm profile' command and given that it's not present in
/etc/tuned/active_profile.

To give the user a hint about this and also to make it easy to see exactly which profile is post-loaded, we make 'tuned-adm active' show the following:

Current active profile: balanced post
Current post-loaded profile: post

This PR additionally fixes a bug with `tuned-adm profile_info`.