### PR TITLE
Fix test case for post-loaded profile feature

### DIFF
--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/runtest.sh
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/runtest.sh
@@ -172,7 +172,7 @@ rlJournalStart
         # Restart Tuned so that the post-loaded profile gets applied
         rlRun "rlServiceStart tuned"
         rlAssertEquals "Check the output of tuned-adm active" \
-                       "$(tuned-adm active)" \
+                       "$(tuned-adm active | grep 'Current active profile')" \
                        "Current active profile: post"
         rlAssertEquals "Check that dirty ratio is set correctly" \
                        "$(sysctl -n $DIRTY_RATIO)" 8


### PR DESCRIPTION
Starting with commit 902292088338bce, 'tuned-adm active' now prints two lines - one for all active profiles and one for the post-loaded profile. This breaks one of the test cases. Fix it.

Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>