### PR TITLE
throughput-performance: fix performance regression on AMD

### DIFF
--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -85,4 +85,3 @@ type=sysctl
 uname_regex=x86_64
 cpuinfo_regex=${amd_cpuinfo_regex}
 kernel.sched_migration_cost_ns=5000000
-kernel.numa_balancing=0


### PR DESCRIPTION
It turned out that disablement of the numa_balancing could result in
upto 20% performance drop on some loads.

Related: rhbz#1746957

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>