### PR TITLE
cpu-partitioning: do not hardcode path to mktemp

### DIFF
--- a/profiles/cpu-partitioning/tuned.conf
+++ b/profiles/cpu-partitioning/tuned.conf
@@ -18,7 +18,7 @@ isolated_cores = ${isolated_cores}
 assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
 
 # tmpdir
-tmpdir=${f:strip:${f:exec:/usr/bin/mktemp:-d}}
+tmpdir=${f:strip:${f:exec:mktemp:-d}}
 # Non-isolated cores cpumask including offline cores
 isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
 isolated_cpumask=${f:cpulist2hex:${isolated_cores_expanded}}


### PR DESCRIPTION
E.g. Ubuntu uses /bin/mktemp, while e.g. Fedora uses /usr/bin/mktemp.
There is probably no need to hardcode the path, so rely on the system path.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>