### PR TITLE
realtime-virtual-host profile: exclude ovs-vswitchd pmds

### DIFF
--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -39,7 +39,7 @@ group.rcub=0:f:4:*:rcub.*
 # for i in `pgrep ktimersoftd` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.ktimersoftd=0:f:3:*:ktimersoftd.*
 
-ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*
+ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*;.*pmd.*;.*PMD.*;^DPDK;.*qemu-kvm.*
 
 [script]
 script=${i:PROFILE_DIR}/script.sh


### PR DESCRIPTION
Like the cpu-partitioning profile, exclude all 'pmd' threads
to avoid repinning ovs-vswitchd pmds.

Resolves: rhbz#1861767

Signed-off-by: Christophe Fontaine <cfontain@redhat.com>