### PR TITLE
spec: added weak dependency on kmod for modprobe

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -88,6 +88,7 @@ Requires: util-linux, dbus, polkit
 Recommends: dmidecode
 Recommends: hdparm
 Recommends: kernel-tools
+Recommends: kmod
 %endif
 %if 0%{?rhel} > 7
 Requires: python3-syspurpose


### PR DESCRIPTION
Fixes: #304

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>