### PR TITLE
scheduler: added default_irq_smp_affinity option

### DIFF
--- a/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
+++ b/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
@@ -84,6 +84,25 @@ It sets Aggressive Link Power Management (ALPM) to the value specified by the [o
 `mounts`::
 Enables or disables barriers for mounts according to the Boolean value of the [option]`disable_barriers` option. 
 
+`scheduler`::
+Allows tuning of scheduling priorities, processes/threads/IRQs affinities, and CPU cores isolation.
++
+The `default_irq_smp_affinity` parameter controls the values *Tuned* writes to `/proc/irq/default_smp_affinity`.
+The following values are supported:
++
+--
+`calc`::
+Content of `/proc/irq/default_smp_affinity` will be calculated from the `isolated_cores` parameter.
+Non-isolated cores are calculated as an inversion of the `isolated_cores`. Then the intersection of the non-isolated cores
+and the previous content of `/proc/irq/default_smp_affinity` is written to `/proc/irq/default_smp_affinity`.
+If the intersection is an empty set, then just the non-isolated cores are written to `/proc/irq/default_smp_affinity`.
+This behavior is the default if the parameter `default_irq_smp_affinity` is omitted.
+`ignore`::
+*Tuned* will not touch `/proc/irq/default_smp_affinity`.
+cpulist such as `1,3-4`::
+The cpulist is unpacked and written directly to `/proc/irq/default_smp_affinity`.
+--
+
 `script`::
 Executes an external script or binary when the profile is loaded or unloaded. You can choose an arbitrary executable.
 +


### PR DESCRIPTION
The option 'default_irq_smp_affinity' affects what will be written to the
/proc/irq/default_smp_affinity. The option supports the following values:

calc:
  Content of the /proc/irq/default_smp_affinity will be calculated from
  the 'isolated_cores'. Non-isolated cores are calculated as an inversion
  of the 'isolated_cores'. Then the intersection of the non-isolated cores
  and the previous content of the /proc/irq/default_smp_affinity is
  written to the /proc/irq/default_smp_affinity. If the intersection is
  empty set, then just the non-isolated cores are written to the
  /proc/irq/default_smp_affinity. This behavior is the default if
  option 'default_irq_smp_affinity' is not specified.

ignore:
  The /proc/irq/default_smp_affinity is not touched by Tuned.

cpulist like e.g. '1,3-4':
  The cpulist is unpacked and directly written to the
  /proc/irq/default_smp_affinity

Examples:

[scheduler]
isolated_cores = 1, 2
default_irq_smp_affinity = calc

[scheduler]
isolated_cores = 1, 2
default_irq_smp_affinity = ignore

[scheduler]
isolated_cores = 1, 3
default_irq_smp_affinity = 2, 4

Resolves: rhbz#1896348

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>