### PR TITLE
Don't modify boom managed BLS snippets

### DIFF
--- a/92-tuned.install
+++ b/92-tuned.install
@@ -25,10 +25,16 @@ ARCH=`uname -m`
 
 pushd "$LOADER_ENTRIES" &> /dev/null
 for f in `basename "$MACHINE_ID"`-*.conf; do
-  if [ -f "$f" -a "${f: -12}" != "-rescue.conf" ]; then
-    grep -q '^\s*options\s\+.*\$tuned_params' "$f" || sed -i '/^\s*options\s\+/ s/\(.*\)/\1 \$tuned_params/' "$f"
-    grep -q '^\s*initrd\s\+.*\$tuned_initrd' "$f" || sed -i '/^\s*initrd\s\+/ s/\(.*\)/\1 \$tuned_initrd/' "$f"
+  # Skip non-files and rescue entries
+  if [ ! -f "$f" -o "${f: -12}" == "-rescue.conf" ]; then
+    continue
   fi
+  # Skip boom managed entries
+  if [[ "$f" =~ \w*-[0-9a-f]{7,}-.*-.*.conf ]]; then
+    continue
+  fi
+  grep -q '^\s*options\s\+.*\$tuned_params' "$f" || sed -i '/^\s*options\s\+/ s/\(.*\)/\1 \$tuned_params/' "$f"
+  grep -q '^\s*initrd\s\+.*\$tuned_initrd' "$f" || sed -i '/^\s*initrd\s\+/ s/\(.*\)/\1 \$tuned_initrd/' "$f"
 done
 popd &> /dev/null
 

--- a/tuned.spec
+++ b/tuned.spec
@@ -335,11 +335,18 @@ if [ "$1" == 0 ]; then
   then
     for f in /boot/loader/entries/$MACHINE_ID-*.conf
     do
-      if [ -f "$f" -a "${f: -12}" != "-rescue.conf" ]
+      # Skip non-files and rescue entries
+      if [ ! -f "$f" -o "${f: -12}" == "-rescue.conf" ]
       then
-        sed -i '/^\s*options\s\+.*\$tuned_params/ s/\s\+\$tuned_params\b//g' "$f" &>/dev/null || :
-        sed -i '/^\s*initrd\s\+.*\$tuned_initrd/ s/\s\+\$tuned_initrd\b//g' "$f" &>/dev/null || :
+        continue
       fi
+      # Skip boom managed entries
+      if [[ "$f" =~ \w*-[0-9a-f]{7,}-.*-.*.conf ]]
+      then
+        continue
+      fi
+      sed -i '/^\s*options\s\+.*\$tuned_params/ s/\s\+\$tuned_params\b//g' "$f" &>/dev/null || :
+      sed -i '/^\s*initrd\s\+.*\$tuned_initrd/ s/\s\+\$tuned_initrd\b//g' "$f" &>/dev/null || :
     done
   fi
 fi


### PR DESCRIPTION
Currently the 92-tuned.install kernel-install plugin modifies all
BLS snippets that match the KERNEL_INSTALL_MACHINE_ID passed to
the script.

This makes sense for the system managed entries but it conflicts
with entries that are managed by the boom boot manager: boom will
propagate these options if they are present when the entry is set
up, but the files should not be modified outside boom's control
since this will cause the boom boot identifier to change.

Boom boot entries include the boot_id in the file name pattern:

  %{machine_id}-%{boot_id}-%{version}.conf

Compared to the system managed entries which use:

  %{machine_id}-%{version}.conf

Modify 92-tuned.install to skip this change for files that match
the boom naming convention.

Rather than rely on the presence of '-' (which may appear in some
kernel builds, especially custom or debug kernels), use a regular
expression to match the 7-character or greater SHA1 hash that
appears in boom BLS snippet file names and the remaining structure
of the file name.

A paired change is made to the tuned.spec %postun script to apply
the same scope to the logic that reverts these changes on removal.

This gives the correct behaviour for me of continuing to add the
$tuned_... references to the system managed entries where needed,
but without causing unexpected changes to the boom boot entries.
The spec file also correctly reverts the change for the same set
of entries when %postun is executed.

Signed-off-by: Bryn M. Reeves <bmr@redhat.com>