### PR TITLE
service: fixed for FIPS

### DIFF
--- a/tuned/plugins/plugin_service.py
+++ b/tuned/plugins/plugin_service.py
@@ -164,9 +164,9 @@ class SystemdHandler(InitHandler):
 		if not os.path.exists(path):
 			log.error("Service '%s' configuration not installed in '%s'" % (name, path))
 			return False
-		md5sum1 = cmd.md5sum(cfg_file)
-		md5sum2 = cmd.md5sum(path)
-		return md5sum1 == md5sum2
+		sha256sum1 = cmd.sha256sum(cfg_file)
+		sha256sum2 = cmd.sha256sum(path)
+		return sha256sum1 == sha256sum2
 
 class ServicePlugin(base.Plugin):
 	"""

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -201,6 +201,11 @@ class commands:
 		data = self.read_file(f)
 		return hashlib.md5(str(data).encode("utf-8")).hexdigest()
 
+	# calcualtes sha256sum of file 'f'
+	def sha256sum(self, f):
+		data = self.read_file(f)
+		return hashlib.sha256(str(data).encode("utf-8")).hexdigest()
+
 	# returns machine ID or empty string "" in case of error
 	def get_machine_id(self, no_error = True):
 		return self.read_file(consts.MACHINE_ID_FILE, no_error).strip()


### PR DESCRIPTION
In FIPS MD5 is disabled, thus switch to SHA256 which is available
in FIPS.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>