### PR TITLE
scheduler: added perf_mmap_pages option to set perf buffer size

### DIFF
--- a/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
+++ b/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
@@ -94,6 +94,12 @@ from their parents, the `scheduler` plugin usually does not need to explicitly p
 can pose a significant CPU overhead, the `perf_process_fork` parameter is set to `false` by default and child processes
 are not processed by the scheduler plugin.
 +
+For perf events mmapped buffer is used. Under heavy load the buffer may overflow. In such cases the `scheduler` plugin
+may start missing events and not process some newly created processes. Increasing the buffer size may help. The buffer size
+can be set with the `perf_mmap_pages` parameter. Value of this parameter has to be power of 2. If it is not the power of 2,
+the nearest bigger power of 2 value is calculated from it and this calculated value is used. If the `perf_mmap_pages`
+parameter is omitted, the default kernel value is used, which should be 128 for the recent kernels (tested on kernel-5.9.8).
++
 The `default_irq_smp_affinity` parameter controls the values *Tuned* writes to `/proc/irq/default_smp_affinity`.
 The following values are supported:
 +


### PR DESCRIPTION
For perf events mmapped buffer is used. Under heavy load the buffer may
overflow. In such cases the `scheduler` plugin may start missing events
and not process some newly created processes. Increasing the buffer size
may help.

The buffer size can be set with the `perf_mmap_pages` parameter.
Value of this parameter has to be power of 2. If it is not the power of 2,
the nearest bigger power of 2 value is calculated from it and this
calculated value is used. If the `perf_mmap_pages` parameter is omitted,
the default kernel value is used, which should be 128 for the recent
kernels (tested on kernel-5.9.8).

Example:

[scheduler]
perf_mmap_pages = 256

Resolves: rhbz#1890219

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>