### PR TITLE
Reference the correct manpage

### DIFF
--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -107,7 +107,7 @@ Unload tunings.
 
 .SH "SEE ALSO"
 .BR tuned (8)
-.BR tuned\-conf (5)
+.BR tuned.conf (5)
 .BR tuned\-profiles (7)
 .BR tuned\-profiles\-atomic (7)
 .BR tuned\-profiles\-sap (7)


### PR DESCRIPTION
Replaces reference to the non-existent tuned-conf with the correct
manpage (tuned.conf)

Signed-off-by: Jacob Collins <jaco3collins@gmail.com>