### PR TITLE
Support for adjusting netdev queues

### DIFF
--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -9,3 +9,11 @@
 # kernel supports it.
 #
 # isolate_managed_irq=Y
+#
+#
+# Set the desired combined queue count value using the parameter provided
+# below. Ideally this should be set to the number of housekeeping CPUs i.e.,
+# in the example given below it is assumed that the system has 4 housekeeping
+# (non-isolated) CPUs.
+#
+# netdev_queue_count=4

--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -35,6 +35,9 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 isolate_managed_irq = ${isolate_managed_irq}
 managed_irq=${f:regex_search_ternary:${isolate_managed_irq}:\b[y,Y,1,t,T]\b:managed_irq,domain,:}
 
+[net]
+channels=combined ${f:get_queue_count:${netdev_queue_count}}
+
 [sysctl]
 kernel.hung_task_timeout_secs = 600
 kernel.nmi_watchdog = 0

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -123,6 +123,13 @@ class NetTuningPlugin(base.Plugin):
 			"tx": None }
 
 	@classmethod
+	def _get_config_options_channels(cls):
+		return { "rx": None,
+			"tx": None,
+			"other": None,
+			"combined": None }
+
+	@classmethod
 	def _get_config_options(cls):
 		return {
 			"dynamic": True,
@@ -132,6 +139,7 @@ class NetTuningPlugin(base.Plugin):
 			"coalesce": None,
 			"pause": None,
 			"ring": None,
+			"channels": None,
 		}
 
 	def _init_stats_and_idle(self, instance, device):
@@ -282,7 +290,8 @@ class NetTuningPlugin(base.Plugin):
 		params = set(d.keys())
 		supported_getter = { "coalesce": self._get_config_options_coalesce, \
 				"pause": self._get_config_options_pause, \
-				"ring": self._get_config_options_ring }
+				"ring": self._get_config_options_ring, \
+				"channels": self._get_config_options_channels }
 		supported = set(supported_getter[context]().keys())
 		if not params.issubset(supported):
 			log.error("unknown %s parameter(s): %s" % (context, str(params - supported)))
@@ -313,6 +322,29 @@ class NetTuningPlugin(base.Plugin):
 		l = [x for x in [re.split(r":\s*", x) for x in l] if len(x) == 2]
 		return dict(l)
 
+	# parse output of ethtool -l
+	def _parse_channels_parameters(self, s):
+		a = re.split(r"^Current hardware settings:$", s, flags=re.MULTILINE)
+		s = a[1]
+		s = self._cmd.multiple_re_replace(\
+				{"RX": "rx",
+				"TX": "tx",
+				"Other": "other",
+				"Combined": "combined"}, s)
+		l = s.split("\n")
+		l = [x for x in l if x != '']
+		l = [x for x in [re.split(r":\s*", x) for x in l] if len(x) == 2]
+		return dict(l)
+
+	def _replace_channels_parameters(self, context, params_list, dev_params):
+		mod_params_list = []
+		if "combined" in params_list:
+			mod_params_list.extend(["rx", params_list[1], "tx", params_list[1]])
+		else:
+			cnt = str(max(int(params_list[1]), int(params_list[3])))
+			mod_params_list.extend(["combined", cnt])
+		return dict(list(zip(mod_params_list[::2], mod_params_list[1::2])))
+
 	def _check_device_support(self, context, parameters, device, dev_params):
 		"""Filter unsupported parameters and log warnings about it
 
@@ -337,7 +369,8 @@ class NetTuningPlugin(base.Plugin):
 			parameters.pop(param, None)
 
 	def _get_device_parameters(self, context, device):
-		context2opt = { "coalesce": "-c", "features": "-k", "pause": "-a", "ring": "-g" }
+		context2opt = { "coalesce": "-c", "features": "-k", "pause": "-a", "ring": "-g", \
+                        "channels": "-l"}
 		opt = context2opt[context]
 		ret, value = self._cmd.execute(["ethtool", opt, device])
 		if ret != 0 or len(value) == 0:
@@ -345,7 +378,8 @@ class NetTuningPlugin(base.Plugin):
 		context2parser = { "coalesce": self._parse_device_parameters, \
 				"features": self._parse_device_parameters, \
 				"pause": self._parse_pause_parameters, \
-				"ring": self._parse_ring_parameters }
+				"ring": self._parse_ring_parameters, \
+				"channels": self._parse_channels_parameters }
 		parser = context2parser[context]
 		d = parser(value)
 		if context == "coalesce" and not self._check_parameters(context, d):
@@ -362,10 +396,14 @@ class NetTuningPlugin(base.Plugin):
 		# check if device supports parameters and filter out unsupported ones
 		if dev_params:
 			self._check_device_support(context, d, device, dev_params)
+			# replace the channel parameters based on the device support
+			if context == "channels" and int(dev_params[next(iter(d))]) == 0:
+				d = self._replace_channels_parameters(context, self._cmd.dict2list(d), dev_params)
 
 		if not sim and len(d) != 0:
 			log.debug("setting %s: %s" % (context, str(d)))
-			context2opt = { "coalesce": "-C", "features": "-K", "pause": "-A", "ring": "-G" }
+			context2opt = { "coalesce": "-C", "features": "-K", "pause": "-A", "ring": "-G", \
+                                "channels": "-L"}
 			opt = context2opt[context]
 			# ignore ethtool return code 80, it means parameter is already set
 			self._cmd.execute(["ethtool", opt, device] + self._cmd.dict2list(d), no_errors = [80])
@@ -422,3 +460,7 @@ class NetTuningPlugin(base.Plugin):
 	@command_custom("ring", per_device = True)
 	def _ring(self, start, value, device, verify, ignore_missing):
 		return self._custom_parameters("ring", start, value, device, verify)
+
+	@command_custom("channels", per_device = True)
+	def _channels(self, start, value, device, verify, ignore_missing):
+		return self._custom_parameters("channels", start, value, device, verify)

--- a/tuned/profiles/functions/function_get_queue_count.py
+++ b/tuned/profiles/functions/function_get_queue_count.py
@@ -1,0 +1,23 @@
+import tuned.logs
+from . import base
+from tuned.utils.commands import commands
+
+log = tuned.logs.get()
+
+class get_queue_count(base.Function):
+	"""
+	Checks whether the user has specified a queue count for net devices. If
+        not, return the number of housekeeping CPUs.
+	"""
+	def __init__(self):
+		# 1 argument
+		super(get_queue_count, self).__init__("get_queue_count", 1, 1)
+
+	def execute(self, args):
+		if not super(get_queue_count, self).execute(args):
+			return None
+		if args[0].isdigit():
+			return args[0]
+		(ret, out) = self._cmd.execute(["nproc"])
+		log.warn("net-dev queue count is not correctly specified, setting it to HK CPUs %s" % (out))
+		return out


### PR DESCRIPTION
Following patch-set enables tuned to adjust the queue count for
each network device via tuned configuration file. This functionality is
implemented by integrating the ethtool channels control feature with tuned.

This support is essentially required for the real-time setup that has
several isolated but very few housekeeping CPUs. In such environments, it
has been observed that the housekeeping CPUs often run out of vectors when
the IRQs are moved from isolated to housekeeping CPUs. This primarily
happens due to a large number of queues (hence IRQs) creation for each
network device based on all available online CPUs.

With this support added tuned can be configured to adjust the queue count
based on the housekeeping CPUs.

Nitesh Narayan Lal (2):
  plugin_net: Implement setting 'channels' parameters
  realtime: added support for netdev_queue_count

 profiles/realtime/realtime-variables.conf     |  8 +++
 profiles/realtime/tuned.conf                  |  3 ++
 tuned/plugins/plugin_net.py                   | 50 +++++++++++++++++--
 .../functions/function_get_queue_count.py     | 23 +++++++++
 4 files changed, 80 insertions(+), 4 deletions(-)
 create mode 100644 tuned/profiles/functions/function_get_queue_count.py

