### PR TITLE
Adding a docstring to the sysctl plugin for the purpose of autogenerating an asciidoc

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -16,7 +16,12 @@ SYSCTL_CONFIG_DIRS = [ "/run/sysctl.d",
 
 class SysctlPlugin(base.Plugin):
 	"""
-	Plugin for applying custom sysctl options.
+	This plugin is used for applying custom `sysctl` settings and should only be used to change 
+        system settings that are not covered by other plugins available in *Tuned*. If the settings
+        are covered by other *Tuned* plugins, please use those plugins instead.
+        
+        The syntax for this plugin is `name=value`, where _name_ is the same as the name provided by
+        the `sysctl` utility.
 	"""
 
 	def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Added a docstring to the sysctl plugin that describes what the plugin does, what its parameters are, and how it should be used.