### PR TITLE
explicitly use /bin/bash for tuned scripts

### DIFF
--- a/experiments/powertop2tuned.py
+++ b/experiments/powertop2tuned.py
@@ -41,7 +41,7 @@ except ImportError:
 	from htmlentitydefs import name2codepoint
 
 
-SCRIPT_SH = """#!/bin/sh
+SCRIPT_SH = """#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/cpu-partitioning/00-tuned-pre-udev.sh
+++ b/profiles/cpu-partitioning/00-tuned-pre-udev.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/profiles/cpu-partitioning/script.sh
+++ b/profiles/cpu-partitioning/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/functions
+++ b/profiles/functions
@@ -205,7 +205,7 @@ set_disk_scheduler_quantum() {
 
 restore_disk_scheduler_quantum() {
 	if [ -r "$DISK_QUANTUM_SAVE" ]; then
-		/bin/sh "$DISK_QUANTUM_SAVE" &>/dev/null
+		/bin/bash "$DISK_QUANTUM_SAVE" &>/dev/null
 		rm -f "$DISK_QUANTUM_SAVE"
 	fi
 }

--- a/profiles/laptop-ac-powersave/script.sh
+++ b/profiles/laptop-ac-powersave/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/powersave/script.sh
+++ b/profiles/powersave/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/realtime-virtual-guest/script.sh
+++ b/profiles/realtime-virtual-guest/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/realtime/script.sh
+++ b/profiles/realtime/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 

--- a/profiles/spindown-disk/script.sh
+++ b/profiles/spindown-disk/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /usr/lib/tuned/functions
 


### PR DESCRIPTION
`/bin/sh` is bash on Red Hat/Fedora, but other distributions (especially Debian/Ubuntu based ones) have other (POSIX compatible) shells there. Let's explicitly use `/bin/bash` for things that use bash features (the `functions` file uses some, for example).