### PR TITLE
Support for adjusting netdev queue count

### DIFF
--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -9,3 +9,11 @@
 # kernel supports it.
 #
 # isolate_managed_irq=Y
+#
+#
+# Set the desired combined queue count value using the parameter provided
+# below. Ideally this should be set to the number of housekeeping CPUs i.e.,
+# in the example given below it is assumed that the system has 4 housekeeping
+# (non-isolated) CPUs.
+#
+# netdev_queue_count=4

--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -35,6 +35,9 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 isolate_managed_irq = ${isolate_managed_irq}
 managed_irq=${f:regex_search_ternary:${isolate_managed_irq}:\b[y,Y,1,t,T]\b:managed_irq,domain,:}
 
+[net]
+channels=combined ${f:check_net_queue_count:${netdev_queue_count}}
+
 [sysctl]
 kernel.hung_task_timeout_secs = 600
 kernel.nmi_watchdog = 0

--- a/tuned/profiles/functions/function_check_net_queue_count.py
+++ b/tuned/profiles/functions/function_check_net_queue_count.py
@@ -1,0 +1,22 @@
+import tuned.logs
+from . import base
+
+log = tuned.logs.get()
+
+class check_net_queue_count(base.Function):
+	"""
+	Checks whether the user has specified a queue count for net devices. If
+        not, return the number of housekeeping CPUs.
+	"""
+	def __init__(self):
+		# 1 argument
+		super(check_net_queue_count, self).__init__("check_net_queue_count", 1, 1)
+
+	def execute(self, args):
+		if not super(check_net_queue_count, self).execute(args):
+			return None
+		if args[0].isdigit():
+			return args[0]
+		(ret, out) = self._cmd.execute(["nproc"])
+		log.warn("net-dev queue count is not correctly specified, setting it to HK CPUs %s" % (out))
+		return out


### PR DESCRIPTION
Following patch-set enables tuned to adjust the queue count for
each network device via tuned configuration file. This functionality is
implemented by integrating the ethtool channels control feature with tuned.

This support is essentially required for the real-time setup that has
several isolated but very few housekeeping CPUs. In such environments, it
has been observed that the housekeeping CPUs often run out of vectors when
the IRQs are moved from isolated to housekeeping CPUs. This primarily
happens due to a large number of queues (hence IRQs) creation for each
network device based on all available online CPUs.

With this support added tuned can be configured to adjust the queue count
based on the housekeeping CPUs.

Changelog from v1[1]:
- Replaced get_queue_count with check_net_queue_count based on Jaroslav's suggestion.
- Fixed Inconsitent whitespaces, tabs/spaces.

[1] https://github.com/redhat-performance/tuned/pull/314

Nitesh Narayan Lal (2):
plugin_net: Implement setting 'channels' parameters
realtime: added support for netdev_queue_count

profiles/realtime/realtime-variables.conf | 8 +++
profiles/realtime/tuned.conf | 3 ++
tuned/plugins/plugin_net.py | 50 +++++++++++++++++--
.../functions/function_get_queue_count.py | 23 +++++++++
4 files changed, 80 insertions(+), 4 deletions(-)
create mode 100644 tuned/profiles/functions/function_get_queue_count.py