### PR TITLE
Ensure tuned is started before the network

### DIFF
--- a/tuned.service
+++ b/tuned.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Dynamic System Tuning Daemon
-After=systemd-sysctl.service network.target dbus.service polkit.service
+Before=network-pre.target
+Wants=network-pre.target
+After=systemd-sysctl.service dbus.service polkit.service
 Requires=dbus.service
 Conflicts=cpupower.service auto-cpufreq.service tlp.service power-profiles-daemon.service
 Documentation=man:tuned(8) man:tuned.conf(5) man:tuned-adm(8)


### PR DESCRIPTION
After=network.target was introduced in dd9ee3ef5d207f766d01688184ff8b717483a56f
to work around network initscripts reloading sysctls

Some sysctls like net.core.default_qdisc need to be applied before
network interface are brought up, so use Before=network-pre.target

Signed-off-by: Etienne Champetier <e.champetier@ateme.com>