### PR TITLE
Changes to scheduler plugin to support os interface instead of schedutils in newer python versions.

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -68,7 +68,10 @@ BuildRequires: %{_py}-mock
 BuildRequires: %{_py}-configobj
 BuildRequires: %{_py}-decorator, %{_py}-pyudev
 Requires: %{_py}-decorator, %{_py}-pyudev, %{_py}-configobj
-Requires: %{_py}-schedutils, %{_py}-linux-procfs, %{_py}-perf
+Requires: %{_py}-linux-procfs, %{_py}-perf
+%if %{without python3}
+Requires: %{_py}-schedutils
+%endif
 # requires for packages with inconsistent python2/3 names
 %if %{with python3}
 # BuildRequires for 'make test'


### PR DESCRIPTION
schedutils library becomes obsolete in newer versions, so this change allows to use interface in os module where is presented with possibility of usage of schedutils where is not.

Signed-off-by: Jan Zerdik <jzerdik@redhat.com>