### PR TITLE
Add make as BuildRequires for new fedora and rhel

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -59,6 +59,7 @@ BuildRequires: asciidoctor
 Requires(post): systemd, virt-what
 Requires(preun): systemd
 Requires(postun): systemd
+BuildRequires: make
 BuildRequires: %{_py}, %{_py}-devel
 # BuildRequires for 'make test'
 # python-mock is needed for python-2.7, but it's not available on RHEL-7


### PR DESCRIPTION
make has been removed from BuildRoot and is needed to be add as BuildRequires for new systems.
bz#1900006