### PR TITLE
Prevent unnecessary ksm* error log messages.

### DIFF
--- a/profiles/functions
+++ b/profiles/functions
@@ -559,6 +559,8 @@ disable_ksm()
 		if ! touch $KSM_MASK_FILE; then
 			die "failed to create $KSM_MASK_FILE"
 		fi
+		# Do not run any systemctl commands if $KSM_SERVICES units do not exist
+		systemctl cat -- $KSM_SERVICES &> /dev/null || return
 		systemctl --now --quiet mask $KSM_SERVICES
 		# Unmerge all shared pages
 		test -f $KSM_RUN_PATH && echo 2 > $KSM_RUN_PATH
@@ -569,6 +571,8 @@ disable_ksm()
 enable_ksm()
 {
 	if [ -f $KSM_MASK_FILE ]; then
+		# Do not run any systemctl commands if $KSM_SERVICES units do not exist
+		systemctl cat -- $KSM_SERVICES &> /dev/null || return
 		if systemctl --quiet unmask $KSM_SERVICES; then
 			rm -f $KSM_MASK_FILE
 		fi


### PR DESCRIPTION
Check the presence of `ksm` and `ksmtuned` units before (un)masking them.

Prevents messages in the logs such as:
```
2021-02-24 14:46:52,399 ERROR    tuned.plugins.plugin_script: script '/usr/lib/tuned/cpu-partitioning/script.sh' error output: 'Unit ksm.service does not exist, proceeding anyway.
```

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>