### PR TITLE
udev: explicitly sort udev properties

### DIFF
--- a/tuned/hardware/device_matcher_udev.py
+++ b/tuned/hardware/device_matcher_udev.py
@@ -18,7 +18,7 @@ class DeviceMatcherUdev(device_matcher.DeviceMatcher):
 		except AttributeError:
 			items = device.items()
 
-		for key, val in list(items):
+		for key, val in sorted(list(items)):
 			properties += key + '=' + val + '\n'
 
 		return re.search(regex, properties, re.MULTILINE) is not None


### PR DESCRIPTION
Although udev properties are sorted by libudev, according
to libudev/systemd upstream this behavior cannot be relied
upon. Sort them explicitly for consistent behavior.

Resolves: rhbz#1939970

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>