### PR TITLE
plugin_net: Fix check for channels supported mode

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -397,7 +397,7 @@ class NetTuningPlugin(base.Plugin):
 		if dev_params:
 			self._check_device_support(context, d, device, dev_params)
 			# replace the channel parameters based on the device support
-			if context == "channels" and int(dev_params[next(iter(d))]) == 0:
+			if context == "channels" and (int(dev_params[next(iter(d))]) == 0 or str(dev_params[next(iter(d))]) == 'n/a'):
 				d = self._replace_channels_parameters(context, self._cmd.dict2list(d), dev_params)
 
 		if not sim and len(d) != 0:


### PR DESCRIPTION
Commit 0ab1f8cc3f87a adds a check which replaces the channels mode parameters
based on the supported mode. With the older kernels, the un-supported mode
was indicated by 0, however recently that has been replaced by a string 'n/a'.
Due to this the check, in plugin_net that verifies if a replacement is
required or not fails.

Fix the check to incorporate this new string that indicates the un-supported
queue mode.

Resolves: rhbz#1943291

Signed-off-by: Nitesh Narayan Lal <nitesh@redhat.com>