### PR TITLE
 .packit.yaml update

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,12 +1,11 @@
-downstream_package_name: tuned
 jobs:
 - job: copr_build
+  trigger: pull_request
   metadata:
     targets:
     - fedora-all
     - epel-8-x86_64
     - centos-stream-8-x86_64
-  trigger: pull_request
 - job: tests
   trigger: pull_request
   metadata:
@@ -14,8 +13,7 @@ jobs:
     - fedora-all
     - epel-8-x86_64
     - centos-stream-8-x86_64
-specfile_path: tuned.spec
+
 synced_files:
 - tuned.spec
 - .packit.yaml
-upstream_package_name: tuned

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ jobs:
     targets:
     - fedora-all
     - epel-8-x86_64
-    - centos-stream-x86_64
+    - centos-stream-8-x86_64
   trigger: pull_request
 - job: tests
   trigger: pull_request
@@ -13,7 +13,7 @@ jobs:
     targets:
     - fedora-all
     - epel-8-x86_64
-    - centos-stream-x86_64
+    - centos-stream-8-x86_64
 specfile_path: tuned.spec
 synced_files:
 - tuned.spec


### PR DESCRIPTION
* rename `centos-stream-x86_64` -> `centos-stream-8-x86_64` because of [this](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/PJT7PK2TLW7T2Z2WLXUGHUYBWR244SBB/)
* remove [upstream_package_name](https://packit.dev/docs/configuration/#upstream_package_name), [downstream_package_name](https://packit.dev/docs/configuration/#downstream_package_name) and [specfile_path](https://packit.dev/docs/configuration/#specfile_path) as the default values should be just fine