### PR TITLE
RHBZ#1956387 tuned-adm: Add --verbose option to verify command

### DIFF
--- a/profiles/realtime-virtual-guest/script.sh
+++ b/profiles/realtime-virtual-guest/script.sh
@@ -2,13 +2,8 @@
 
 . /usr/lib/tuned/functions
 
-KTIMER_LOCKLESS_FILE=/sys/kernel/ktimer_lockless_check
-
 start() {
-    if [ -f $KTIMER_LOCKLESS_FILE ]; then
-        echo 1 > $KTIMER_LOCKLESS_FILE
-    fi
-    return "$?"
+    return 0
 }
 
 stop() {
@@ -16,7 +11,7 @@ stop() {
 }
 
 verify() {
-    return "$?"
+    return 0
 }
 
 process $@

--- a/profiles/realtime-virtual-guest/tuned.conf
+++ b/profiles/realtime-virtual-guest/tuned.conf
@@ -36,6 +36,11 @@ group.ktimersoftd=0:f:3:*:ktimersoftd.*
 
 ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*
 
+[sysfs]
+# Perform lockless check for timer softirq on isolated CPUs.
+#
+/sys/kernel/ktimer_lockless_check = 1
+
 [script]
 script=${i:PROFILE_DIR}/script.sh
 

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -17,12 +17,11 @@ stop() {
 verify() {
     # set via /etc/modprobe.d/kvm.conf and /etc/modprobe.d/kvm.rt.tuned.conf
     if [ -f /sys/module/kvm/parameters/kvmclock_periodic_sync ]; then
-        test "$(cat /sys/module/kvm/parameters/kvmclock_periodic_sync)" = "Y"
-        retval=$?
-        if [ $retval -eq 0 ]; then
-            echo "  kvmclock_periodic_sync:(Y): enabled: expected N"
+        kps=$(cat /sys/module/kvm/parameters/kvmclock_periodic_sync)
+        if [ "$kps" != "N" -a "$kps" != "0" ]; then
+            echo "  kvmclock_periodic_sync:($kps): enabled: expected N(0)"
         else
-            echo "  kvmclock_periodic_sync:(N): disabled: okay"
+            echo "  kvmclock_periodic_sync:($kps): disabled: okay"
         fi
     fi
     if [ -f /sys/module/kvm_intel/parameters/ple_gap ]; then

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -2,38 +2,42 @@
 
 . /usr/lib/tuned/functions
 
-KTIMER_LOCKLESS_FILE=/sys/kernel/ktimer_lockless_check
-
 start() {
     setup_kvm_mod_low_latency
-
-    disable_ksm
-
-    if [ -f $KTIMER_LOCKLESS_FILE ]; then
-        echo 1 > $KTIMER_LOCKLESS_FILE
-    fi
-
     return 0
 }
 
 stop() {
     if [ "$1" = "full_rollback" ]; then
         teardown_kvm_mod_low_latency
-        enable_ksm
     fi
     return "$?"
 }
 
 verify() {
+    # set via /etc/modprobe.d/kvm.conf and /etc/modprobe.d/kvm.rt.tuned.conf
     if [ -f /sys/module/kvm/parameters/kvmclock_periodic_sync ]; then
-        test "$(cat /sys/module/kvm/parameters/kvmclock_periodic_sync)" = 0
+        test "$(cat /sys/module/kvm/parameters/kvmclock_periodic_sync)" = "Y"
         retval=$?
+        if [ $retval -eq 0 ]; then
+            echo "  kvmclock_periodic_sync:(Y): enabled: expected N"
+        else
+            echo "  kvmclock_periodic_sync:(N): disabled: okay"
+        fi
     fi
-    if [ $retval -eq 0 -a -f /sys/module/kvm_intel/parameters/ple_gap ]; then
-        test "$(cat /sys/module/kvm_intel/parameters/ple_gap)" = 0
+    if [ -f /sys/module/kvm_intel/parameters/ple_gap ]; then
+        test $(cat /sys/module/kvm_intel/parameters/ple_gap) -eq 0
         retval=$?
+        ple_gap=$(cat /sys/module/kvm_intel/parameters/ple_gap)
+        if [ $retval -eq 0 ]; then
+            echo "  ple_gap:($ple_gap): disabled: okay"
+        else
+            echo "  ple_gap:($ple_gap): enabled: expected 0"
+        fi
     fi
+
     return $retval
 }
+
 
 process $@

--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -41,6 +41,18 @@ group.ktimersoftd=0:f:3:*:ktimersoftd.*
 
 ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*;.*pmd.*;.*PMD.*;^DPDK;.*qemu-kvm.*
 
+[sysfs]
+# Stop kernel same page merge (KSM) daemon, it may introduce latencies.
+#
+# 0: stop ksmd, keep merged pages
+# 1: run ksmd
+# 2: stop ksmd, unmerge all pages
+/sys/kernel/mm/ksm/run = 2
+
+# Perform lockless check for timer softirq on isolated CPUs.
+#
+/sys/kernel/ktimer_lockless_check = 1
+
 [script]
 script=${i:PROFILE_DIR}/script.sh
 

--- a/profiles/realtime/script.sh
+++ b/profiles/realtime/script.sh
@@ -11,8 +11,12 @@ stop() {
 }
 
 verify() {
-    tuna -c "$TUNED_isolated_cores" -P
-    return "$?"
+    retval=0
+    if [ ! -z "$TUNED_isolated_cores" ]; then
+        tuna -c "$TUNED_isolated_cores" -P > /dev/null 2>&1
+        retval=$?
+    fi
+    return $retval
 }
 
 process $@

--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -89,7 +89,8 @@ if __name__ == "__main__":
 
 	parser_verify = subparsers.add_parser("verify", help="verify profile")
 	parser_verify.set_defaults(action="verify_profile")
-	parser_verify.add_argument("--ignore-missing", "-i", action="store_true", help="do not treat missing/non-supported tunings as errors")
+	parser_verify.add_argument("-i", "--ignore-missing", action="store_true", help="do not treat missing/non-supported tunings as errors")
+	parser_verify.add_argument("-v", "--verbose", action="store_true", help="show verification results")
 
 	parser_auto_profile = subparsers.add_parser("auto_profile", help="enable automatic profile selection mode, switch to the recommended profile")
 	parser_auto_profile.set_defaults(action="auto_profile")

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -7,6 +7,7 @@ from .exceptions import TunedAdminDBusException
 from tuned.exceptions import TunedException
 import tuned.consts as consts
 from tuned.utils.profile_recommender import ProfileRecommender
+from tuned.verifylog import VerifyLog
 import os
 import sys
 import errno
@@ -354,24 +355,36 @@ class Admin(object):
 		print(self._profile_recommender.recommend())
 		return True
 
-	def _action_dbus_verify_profile(self, ignore_missing):
+	def _action_dbus_verify_profile(self, ignore_missing, verbose=False):
+		profile_name = self._get_active_profile()
+		if (not profile_name):
+			print("No active profile set, please see "
+				"'tuned-adm profile' to select one ")
+			return self._controller.exit(False)
+
 		if ignore_missing:
-			ret = self._controller.verify_profile_ignore_missing()
+			ret, log = self._controller.verify_profile_ignore_missing()
 		else:
-			ret = self._controller.verify_profile()
+			ret, log = self._controller.verify_profile()
+
+		print("Active profile => %s" % profile_name)
+		if log and verbose:
+			ret = VerifyLog(log).display()
+
 		if ret:
 			print("Verfication succeeded, current system settings match the preset profile.")
 		else:
-			print("Verification failed, current system settings differ from the preset profile.")
-			print("You can mostly fix this by restarting the Tuned daemon, e.g.:")
-			print("  systemctl restart tuned")
-			print("or")
-			print("  service tuned restart")
-			print("Sometimes (if some plugins like bootloader are used) a reboot may be required.")
-		print("See tuned log file ('%s') for details." % consts.LOG_FILE)
+			print("Verification failed, current system settings "
+                              "differ from the preset profile.")
+			if (not verbose):
+				print(" * Use 'tuned-adm verify --verbose' option "
+				"to know differing system settings.")
+			print(" * Sometimes (if some plugins like bootloader are "
+				"used) a reboot may be required.")
+		print(" * See tuned log file ('%s') for details." % consts.LOG_FILE)
 		return self._controller.exit(ret)
 
-	def _action_verify_profile(self, ignore_missing):
+	def _action_verify_profile(self, ignore_missing, verbose=False):
 		print("Not supported in no_daemon mode.")
 		return False
 

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -6,6 +6,8 @@ import threading
 import tuned.consts as consts
 from tuned.utils.commands import commands
 
+import json
+
 __all__ = ["Controller"]
 
 log = tuned.logs.get()
@@ -258,17 +260,19 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			return ""
 		return self._daemon.profile_recommender.recommend()
 
-	@exports.export("", "b")
+	@exports.export("", "bs")
 	def verify_profile(self, caller = None):
 		if caller == "":
-			return False
-		return self._daemon.verify_profile(ignore_missing = False)
+			return False, None
+		ret, lg = self._daemon.verify_profile(ignore_missing = False)
+		return ret, json.dumps(lg)
 
-	@exports.export("", "b")
+	@exports.export("", "bs")
 	def verify_profile_ignore_missing(self, caller = None):
 		if caller == "":
-			return False
-		return self._daemon.verify_profile(ignore_missing = True)
+			return False, None
+		ret, lg = self._daemon.verify_profile(ignore_missing = True)
+		return ret, json.dumps(lg)
 
 	@exports.export("", "a{sa{ss}}")
 	def get_all_plugins(self, caller = None):

--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -3,11 +3,13 @@ import os.path
 from . import base
 from .decorators import *
 import tuned.logs
+from tuned.verifylog import VerifyLog
 from subprocess import *
 from tuned.utils.commands import commands
 import tuned.consts as consts
 
 log = tuned.logs.get()
+vlog = VerifyLog.get_obj()
 
 class ModulesPlugin(base.Plugin):
 	"""
@@ -85,9 +87,14 @@ class ModulesPlugin(base.Plugin):
 			mpath = "/sys/module/%s" % module
 			if not os.path.exists(mpath):
 				ret = False
-				log.error(consts.STR_VERIFY_PROFILE_FAIL % "module '%s' is not loaded" % module)
+				emsg = consts.STR_VERIFY_PROFILE_FAIL % "module '%s' is not loaded" % module
+				log.error(emsg)
+				vlog.add_log(instance.name, {module: {"message": emsg, "result": ret}})
 			else:
-				log.info(consts.STR_VERIFY_PROFILE_OK % "module '%s' is loaded" % module)
+				ret = True
+				imsg = consts.STR_VERIFY_PROFILE_OK % "module '%s' is loaded" % module
+				log.info(imsg)
+				vlog.add_log(instance.name, {module: {"message": imsg, "result": ret}})
 				l = r.split(v)
 				for item in l:
 					arg = item.split("=")

--- a/tuned/plugins/plugin_script.py
+++ b/tuned/plugins/plugin_script.py
@@ -1,10 +1,12 @@
 import tuned.consts as consts
 from . import base
 import tuned.logs
+from tuned.verifylog import VerifyLog
 import os
 from subprocess import Popen, PIPE
 
 log = tuned.logs.get()
+vlog = VerifyLog.get_obj()
 
 class ScriptPlugin(base.Plugin):
 	"""
@@ -68,9 +70,13 @@ class ScriptPlugin(base.Plugin):
 			args += ["ignore_missing"]
 		if self._call_scripts(instance._scripts, args) == True:
 			log.info(consts.STR_VERIFY_PROFILE_OK % instance._scripts)
+			msg = consts.STR_VERIFY_PROFILE_OK % instance._scripts
 		else:
 			log.error(consts.STR_VERIFY_PROFILE_FAIL % instance._scripts)
+			msg = consts.STR_VERIFY_PROFILE_FAIL % instance._scripts
 			ret = False
+		vlog.add_log(instance.name,
+				{"scripts": {"message": msg, "result": ret}})
 		return ret
 
 	def _instance_unapply_static(self, instance, full_rollback = False):

--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -2,6 +2,7 @@ import re
 from . import base
 from .decorators import *
 import tuned.logs
+from tuned.verifylog import VerifyLog
 from subprocess import *
 from tuned.utils.commands import commands
 import tuned.consts as consts
@@ -9,6 +10,7 @@ import errno
 import os
 
 log = tuned.logs.get()
+vlog = VerifyLog.get_obj()
 
 DEPRECATED_SYSCTL_OPTIONS = [ "base_reachable_time", "retrans_time" ]
 SYSCTL_CONFIG_DIRS = [ "/run/sysctl.d",
@@ -76,6 +78,7 @@ class SysctlPlugin(base.Plugin):
 			if value is not None:
 				if self._verify_value(option, self._cmd.remove_ws(value), self._cmd.remove_ws(curr_val), ignore_missing) == False:
 					ret = False
+			vlog.add_log(instance.name, {option: {"value": curr_val, "expected": value, "result": (curr_val == value)}})
 		return ret
 
 	def _instance_unapply_static(self, instance, full_rollback = False):

--- a/tuned/plugins/plugin_sysfs.py
+++ b/tuned/plugins/plugin_sysfs.py
@@ -4,10 +4,12 @@ import re
 import os.path
 from .decorators import *
 import tuned.logs
+from tuned.verifylog import VerifyLog
 from subprocess import *
 from tuned.utils.commands import commands
 
 log = tuned.logs.get()
+vlog = VerifyLog.get_obj()
 
 class SysfsPlugin(base.Plugin):
 	"""
@@ -50,6 +52,7 @@ class SysfsPlugin(base.Plugin):
 					curr_val = self._read_sysfs(f)
 					if self._verify_value(f, v, curr_val, ignore_missing) == False:
 						ret = False
+					vlog.add_log(instance.name, {key: {"value": curr_val, "expected": value, "result": ret}})
 		return ret
 
 	def _instance_unapply_static(self, instance, full_rollback = False):

--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -4,12 +4,14 @@ import re
 import traceback
 import tuned.exceptions
 import tuned.logs
+from tuned.verifylog import VerifyLog
 import tuned.plugins.exceptions
 import tuned.consts as consts
 from tuned.utils.global_config import GlobalConfig
 from tuned.utils.commands import commands
 
 log = tuned.logs.get()
+vlog = VerifyLog.get_obj()
 
 __all__ = ["Manager"]
 
@@ -154,7 +156,7 @@ class Manager(object):
 					instance.verify_tuning, ignore_missing)
 			if res == False:
 				ret = False
-		return ret
+		return ret, vlog.put_log()
 
 	def update_tuning(self):
 		for instance in self._instances:

--- a/tuned/verifylog.py
+++ b/tuned/verifylog.py
@@ -1,0 +1,108 @@
+
+import json
+
+class VerifyLog:
+
+	obj = None
+
+	def __init__(self, log={}):
+		self.vLog = log
+		return
+
+	@classmethod
+	def get_obj(self, log={}):
+		"""
+		Create and return a singleton object.
+		"""
+		if (not self.obj):
+			self.obj = VerifyLog(log)
+		return self.obj
+
+	def add_log(self, iname, log={}):
+		if (iname not in self.vLog.keys()):
+			self.vLog[iname] = []
+		if (log):
+			self.vLog[iname].append(log)
+
+		return
+
+	def get_log(self):
+		return self.vLog
+
+	def put_log(self):
+		vlog = self.vLog
+		self.vLog = {}
+		return vlog
+
+	def _display_device(self, log):
+		ret = True
+		for i in range(len(log)):
+			for cmd in list(log[i].keys()):
+				print(" %s=%s" % (cmd, log[i][cmd]["value"]))
+				for dev in log[i][cmd]["devices"]:
+					for k in dev.keys():
+						cv = dev[k]["value"]
+						rs = dev[k]["result"]
+						print("  %s=%s" % (k, cv))
+						if (ret):
+							ret = rs
+		return ret
+
+	def _display_non_device(self, log):
+		ret = True
+		for i in range(len(log)):
+			for opt in list(log[i].keys()):
+				cv = log[i][opt]["value"]
+				ev = log[i][opt]["expected"]
+				rs = log[i][opt]["result"]
+				print(" %s=%s"
+					% (opt, cv), end="\n" if rs else ", ")
+				if (not rs):
+					print("[Expected: %s]" % ev)
+					ret = rs
+		return ret
+
+	def _display_modules(self, log):
+		ret = True
+		for i in range(len(log)):
+			m = list(log[i].keys())[0]
+			mod = log[i][m]
+			print(" %s: %s" % (m, mod["message"]))
+			ret = mod["result"] if (ret) else False
+
+		return ret
+
+	def _display_net(self, log):
+		ret = True
+		for i in range(len(log)):
+			for opt in list(log[i].keys()):
+				if ("expected" in list(log[i][opt].keys())):
+					rs = self._display_non_device([log[i]])
+				elif ("devices" in list(log[i][opt].keys())):
+					rs = self._display_device([log[i]])
+				if (ret):
+					ret = rs
+		return ret
+
+
+	def display(self):
+		device_log = ["audio", "cpu", "disk", "scsi_host", "video"]
+		non_device_log = ["bootloader", "eeepc_she", "irqbalance",
+				"rtentst", "scheduler", "sysctl",
+				"sysfs", "vm"]
+		ret = True
+		instances = json.loads(self.put_log())
+		for key in instances.keys():
+			print("[%s]" % key)
+			if key in device_log:
+				rs = self._display_device(instances[key])
+			elif key in non_device_log:
+				rs = self._display_non_device(instances[key])
+			elif key in ["modules", "script"]:
+				rs = self._display_modules(instances[key])
+			elif key == "net":
+				rs = self._display_net(instances[key])
+			print("Verification: %s\n" % ("Pass" if rs else "Fail"))
+			if ret:
+				ret = rs
+		return ret


### PR DESCRIPTION
'tuned-adm verify' command validates system settings against the active tuned(8) profiles. But it does not show detailed validation results to the user. User is left to sift through the tuned(8) log file to figure it out.

Adding '--verbose' option to the tuned-adm command addresses this issue. It enables tuned(8) daemon to collect and return
detailed validation results back to the tuned-adm program. tuned-adm displays these results on the console.
    
It enables users to confirm that active tuned(8) profile settings are effective on the system.

Fixes: RHBZ#1956387