### PR TITLE
RHBZ#1947858 profiles: improve realtime verify functions

### DIFF
--- a/profiles/realtime-virtual-guest/script.sh
+++ b/profiles/realtime-virtual-guest/script.sh
@@ -2,13 +2,8 @@
 
 . /usr/lib/tuned/functions
 
-KTIMER_LOCKLESS_FILE=/sys/kernel/ktimer_lockless_check
-
 start() {
-    if [ -f $KTIMER_LOCKLESS_FILE ]; then
-        echo 1 > $KTIMER_LOCKLESS_FILE
-    fi
-    return "$?"
+    return 0
 }
 
 stop() {
@@ -16,7 +11,7 @@ stop() {
 }
 
 verify() {
-    return "$?"
+    return 0
 }
 
 process $@

--- a/profiles/realtime-virtual-guest/tuned.conf
+++ b/profiles/realtime-virtual-guest/tuned.conf
@@ -36,6 +36,11 @@ group.ktimersoftd=0:f:3:*:ktimersoftd.*
 
 ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*
 
+[sysfs]
+# Perform lockless check for timer softirq on isolated CPUs.
+#
+/sys/kernel/ktimer_lockless_check = 1
+
 [script]
 script=${i:PROFILE_DIR}/script.sh
 

--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -41,6 +41,18 @@ group.ktimersoftd=0:f:3:*:ktimersoftd.*
 
 ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*;.*pmd.*;.*PMD.*;^DPDK;.*qemu-kvm.*
 
+[sysfs]
+# Stop kernel same page merge (KSM) daemon, it may introduce latencies.
+#
+# 0: stop ksmd, keep merged pages
+# 1: run ksmd
+# 2: stop ksmd, unmerge all pages
+/sys/kernel/mm/ksm/run = 2
+
+# Perform lockless check for timer softirq on isolated CPUs.
+#
+/sys/kernel/ktimer_lockless_check = 1
+
 [script]
 script=${i:PROFILE_DIR}/script.sh
 

--- a/profiles/realtime/script.sh
+++ b/profiles/realtime/script.sh
@@ -11,8 +11,12 @@ stop() {
 }
 
 verify() {
-    tuna -c "$TUNED_isolated_cores" -P
-    return "$?"
+    retval=0
+    if [ "$TUNED_isolated_cores" ]; then
+        tuna -c "$TUNED_isolated_cores" -P > /dev/null 2>&1
+        retval=$?
+    fi
+    return $retval
 }
 
 process $@


### PR DESCRIPTION
tuned(8) realtime-virtual-{host|guest} profiles set Kernel and
KVM module parameters via script.sh plugin. These parameters are
to be verified in a verify() function, invoked by tuned-adm verify
command.

* This patch updates verify() functions to validate KVM module
  parameters.

* It moves kernel parameters to the tuned.conf file under the
  [sysfs] & [sysctl] plugin sections. And removes call to
  disable_ksm function, no longer required.

Fixes: RHBZ#1947858