### PR TITLE
ci: beakerlib tests fixes

### DIFF
--- a/ci.fmf
+++ b/ci.fmf
@@ -1,4 +1,4 @@
 discover:
     how: fmf
 execute:
-    how: beakerlib
+    how: tmt

--- a/tests/beakerlib/Program-tuned-tried-to-access-dev-mem-between/main.fmf
+++ b/tests/beakerlib/Program-tuned-tried-to-access-dev-mem-between/main.fmf
@@ -7,3 +7,4 @@ duration: 20m
 relevancy: |
     distro = rhel-4, rhel-5, rhel-6: False
 summary: Test for BZ#1688371 (Program tuned tried to access /dev/mem between)
+framework: beakerlib

--- a/tests/beakerlib/Tuned-takes-too-long-to-reload-start-when-ulimit/main.fmf
+++ b/tests/beakerlib/Tuned-takes-too-long-to-reload-start-when-ulimit/main.fmf
@@ -7,3 +7,4 @@ duration: 20m
 relevancy: |
     distro = rhel-4, rhel-5, rhel-6: False
 summary: Test for BZ#1663412 (Tuned takes too long to reload/start when \"ulimit)
+framework: beakerlib

--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/main.fmf
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/main.fmf
@@ -10,3 +10,4 @@ require:
 - tuned
 duration: 5m
 extra-task: /CoreOS/tuned/Regression/bz1798183-RFE-support-post-loaded-profile
+framework: beakerlib

--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/runtest.sh
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/runtest.sh
@@ -173,7 +173,7 @@ rlJournalStart
         rlRun "rlServiceStart tuned"
         rlAssertEquals "Check the output of tuned-adm active" \
                        "$(tuned-adm active)" \
-                       "Current active profile: post"
+                       "Current active profile: post"$'\n'"Current post-loaded profile: post"
         rlAssertEquals "Check that dirty ratio is set correctly" \
                        "$(sysctl -n $DIRTY_RATIO)" 8
     rlPhaseEnd

--- a/tests/beakerlib/error-messages/main.fmf
+++ b/tests/beakerlib/error-messages/main.fmf
@@ -7,3 +7,4 @@ duration: 5m
 relevancy: |
     distro = rhel-4, rhel-5: False
 summary: Test for BZ#1416712 (Tuned logs error message if)
+framework: beakerlib

--- a/tests/beakerlib/tuned-adm-functionality/main.fmf
+++ b/tests/beakerlib/tuned-adm-functionality/main.fmf
@@ -7,3 +7,4 @@ relevancy: |
     distro = rhel-6: False
     distro < rhel-7.3: False
 summary: Check functionality of tuned-adm tool.
+framework: beakerlib


### PR DESCRIPTION
Switch from the deprecated execution method.
Fix for the bz1798183-RFE-support-post-loaded-profile beakerlib test.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>