### PR TITLE
recommend: do not ignore chassis_type if there is no dmidecode

### DIFF
--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -91,11 +91,8 @@ class ProfileRecommender:
 					elif option == "chassis_type":
 						chassis_type = self._get_chassis_type()
 
-						if chassis_type:
-							if not re.match(value, chassis_type, re.IGNORECASE):
-								match = False
-						else:
-							log.debug("Ignoring 'chassis_type' in '%s', could not read DMI value." % fname)
+						if not re.match(value, chassis_type, re.IGNORECASE):
+							match = False
 					elif option == "syspurpose_role":
 						if have_syspurpose:
 							s = syspurpose.files.SyspurposeStore(


### PR DESCRIPTION
Previously, if there wasn't dmidecode all 'chassis_type' matches
were ignored. This is not correct, because we cannot enforce
chassis type. Now in such cases the chassis_type is matched
against empty string.

I.e. previously the following matched in case of no dmidecode:
something_that_matched
chassis_type=.*(Notebook|Laptop|Portable).*

Now it doesn't match, but the previous behavior can be still
emulated by e.g.:
something_that_matched
chassis_type=(.*(Notebook|Laptop|Portable).*)|^$

Resolves: rhbz#1959889

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>