### PR TITLE
RHBZ#1817827 profiles: add isolate_managed_irq & netdev_queue_count variables

### DIFF
--- a/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
+++ b/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
@@ -1,4 +1,23 @@
+#
+# Variable settings below override the definitions from the
+# /etc/tuned/realtime-variables.conf file.
+#
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
+#
+# Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
+# managed IRQs out of isolated cores. Note that this requires kernel
+# support. Please only specify this parameter if you are sure that the
+# kernel supports it.
+#
+# isolate_managed_irq=Y
+#
+#
+# Set the desired combined queue count value using the parameter provided
+# below. Ideally this should be set to the number of housekeeping CPUs i.e.,
+# in the example given below it is assumed that the system has 4 housekeeping
+# (non-isolated) CPUs.
+#
+# netdev_queue_count=4

--- a/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
+++ b/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
@@ -1,4 +1,23 @@
+#
+# Variable settings below override the definitions from the
+# /etc/tuned/realtime-variables.conf file.
+#
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
+#
+# Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
+# managed IRQs out of isolated cores. Note that this requires kernel
+# support. Please only specify this parameter if you are sure that the
+# kernel supports it.
+#
+# isolate_managed_irq=Y
+#
+#
+# Set the desired combined queue count value using the parameter provided
+# below. Ideally this should be set to the number of housekeeping CPUs i.e.,
+# in the example given below it is assumed that the system has 4 housekeeping
+# (non-isolated) CPUs.
+#
+# netdev_queue_count=4


### PR DESCRIPTION
For realtime KVM host and guests it is important to use housekeeping
CPUs for processing interrupts (IRQs) and network packets transmission.
So that isolated CPUs focus on the -realtime tasks assigned to them.

The 'isolate_managed_irq' and 'netdev_queue_count' variables help
to configure kernels towards this end. Users can define these
variables via tuned(8) configuration files.

Fixes: RHBZ#1817827