### PR TITLE
ci: fix versioning of autobuild packages

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,3 +1,4 @@
+upstream_tag_template: v{version}
 jobs:
 - job: copr_build
   trigger: pull_request


### PR DESCRIPTION
This should create RPM packages for CI named e.g. tuned-2.15.0...
instead of tuned-v2.15.0... It may fix CI provisioning for
RHEL machines (https://github.com/packit/packit-service/issues/1095).

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>