### PR TITLE
network-throughput: Remove explicit udp_mem amount

### DIFF
--- a/profiles/network-throughput/tuned.conf
+++ b/profiles/network-throughput/tuned.conf
@@ -13,4 +13,3 @@ include=throughput-performance
 # Ensure that you do not oversubscribe system memory.
 net.ipv4.tcp_rmem="4096 87380 16777216"
 net.ipv4.tcp_wmem="4096 16384 16777216"
-net.ipv4.udp_mem="3145728 4194304 16777216"


### PR DESCRIPTION
Explicitly setting a value for udp_mem does not make sense.

An explicit value does not take into account how much RAM the user's system
has, so setting values here like "12G 16G 64G" works for few specific use
cases but makes no sense for others.

This actually could cause problems if applied on a system with <16G RAM
and UDP protocol usage is allowed to grow as large as it likes, causing
kernel memory pressure in other areas.

Remove these values for now. If still required, a better way to calculate
a larger value based on system RAM can be implemented later.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>