### PR TITLE
RHBZ#1820626 profiles: enable isolate_managed_irq by default

### DIFF
--- a/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
+++ b/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
@@ -12,8 +12,8 @@
 # support. Please only specify this parameter if you are sure that the
 # kernel supports it.
 #
-# isolate_managed_irq=Y
-#
+isolate_managed_irq=Y
+
 #
 # Set the desired combined queue count value using the parameter provided
 # below. Ideally this should be set to the number of housekeeping CPUs i.e.,

--- a/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
+++ b/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
@@ -12,8 +12,8 @@
 # support. Please only specify this parameter if you are sure that the
 # kernel supports it.
 #
-# isolate_managed_irq=Y
-#
+isolate_managed_irq=Y
+
 #
 # Set the desired combined queue count value using the parameter provided
 # below. Ideally this should be set to the number of housekeeping CPUs i.e.,

--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -8,8 +8,8 @@
 # support. Please only specify this parameter if you are sure that the
 # kernel supports it.
 #
-# isolate_managed_irq=Y
-#
+isolate_managed_irq=Y
+
 #
 # Set the desired combined queue count value using the parameter provided
 # below. Ideally this should be set to the number of housekeeping CPUs i.e.,


### PR DESCRIPTION
Enable 'isolate_managed_irq' parameter by default. It is important
for -realtime systems. When it is enabled, kernel directs interrupts
to the housekeeping CPUs and thus reduces latencies for the isolated
ones.

Fixes: RHBZ#1820626