### PR TITLE
Implementing steps to sync docs repos

### DIFF
--- a/doc/manual/assemblies/assembly_customizing-tuned-profiles.adoc
+++ b/doc/manual/assemblies/assembly_customizing-tuned-profiles.adoc
@@ -5,14 +5,27 @@
 
 :context: customizing-tuned-profiles
 
+[role="_abstract"]
 You can create or modify *TuneD* profiles to optimize system performance for your intended use case.
 
 .Prerequisites
 
-* Install and enable *TuneD* as described in xref:installing-and-enabling-tuned_getting-started-with-tuned[].
+ifndef::pantheonenv[]
+* Install and enable *TuneD* as described in xref:installing-and-enabling-tuned_getting-started-with-tuned[Installing and Enabling Tuned] for details.
+endif::[]
+
+ifdef::pantheonenv[]
+* Install and enable *TuneD* as described in xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and Enabling Tuned] for details.
+endif::[]
 
 
 include::modules/performance/con_tuned-profiles.adoc[leveloffset=+1]
+
+include::modules/performance/con_the-default-tuned-profile.adoc[leveloffset=+1]
+
+include::modules/performance/con_merged-tuned-profiles.adoc[leveloffset=+1]
+
+include::modules/performance/con_the-location-of-tuned-profiles.adoc[leveloffset=+1]
 
 include::modules/performance/con_inheritance-between-tuned-profiles.adoc[leveloffset=+1]
 
@@ -22,7 +35,9 @@ include::modules/performance/con_tuned-plug-ins.adoc[leveloffset=+1]
 
 include::modules/performance/ref_available-tuned-plug-ins.adoc[leveloffset=+1]
 
-include::modules/performance/con_variables-and-built-in-functions-in-tuned-profiles.adoc[leveloffset=+1]
+include::modules/performance/con_variables-in-tuned-profiles.adoc[leveloffset=+1]
+
+include::modules/performance/con_built-in-functions-in-tuned-profiles.adoc[leveloffset=+1]
 
 include::modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc[leveloffset=+1]
 
@@ -32,11 +47,12 @@ include::modules/performance/proc_modifying-existing-tuned-profiles.adoc[levelof
 
 include::modules/performance/proc_setting-the-disk-scheduler-using-tuned.adoc[leveloffset=+1]
 
-
+ifdef::upstream[]
 [id='related-information-{context}']
 == Related information
 
 * The `tuned.conf(5)` man page
 * The *TuneD* project website: link:https://tuned-project.org/[]
+endif::[]
 
 :context: {parent-context-of-customizing-tuned-profiles}

--- a/doc/manual/assemblies/assembly_getting-started-with-tuned.adoc
+++ b/doc/manual/assemblies/assembly_getting-started-with-tuned.adoc
@@ -5,10 +5,11 @@
 
 :context: getting-started-with-tuned
 
+[role="_abstract"]
 As a system administrator, you can use the *TuneD* application to optimize the performance profile of your system for a variety of use cases.
 
 // .Prerequisites
-// 
+//
 // * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 // * You can also link to other modules or assemblies the user must follow before starting this assembly.
 // * Delete the section title and bullets if the assembly has no prerequisites.
@@ -18,7 +19,15 @@ include::modules/performance/con_the-purpose-of-tuned.adoc[leveloffset=+1]
 
 include::modules/performance/con_tuned-profiles.adoc[leveloffset=+1]
 
+include::modules/performance/con_the-default-tuned-profile.adoc[leveloffset=+1]
+
+include::modules/performance/con_merged-tuned-profiles.adoc[leveloffset=+1]
+
+include::modules/performance/con_the-location-of-tuned-profiles.adoc[leveloffset=+1]
+
 include::modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc[leveloffset=+1]
+
+include::modules/performance/ref_real-time-tuned-profiles-distributed-with-rhel.adoc[leveloffset=+1]
 
 include::modules/performance/con_static-and-dynamic-tuning-in-tuned.adoc[leveloffset=+1]
 
@@ -32,12 +41,13 @@ include::modules/performance/proc_setting-a-tuned-profile.adoc[leveloffset=+1]
 
 include::modules/performance/proc_disabling-tuned.adoc[leveloffset=+1]
 
-
+ifdef::upstream[]
 [id='related-information-{context}']
 == Related information
 
 * The `tuned(8)` man page
 * The `tuned-adm(8)` man page
 * The *TuneD* project website: link:https://tuned-project.org/[]
+endif::[]
 
 :context: {parent-context-of-getting-started-with-tuned}

--- a/doc/manual/modules/performance/con_built-in-functions-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_built-in-functions-in-tuned-profiles.adoc
@@ -1,0 +1,46 @@
+:_module-type: CONCEPT
+[id="built-in-functions-in-tuned-profiles_{context}"]
+= Built-in functions in TuneD profiles
+
+[role="_abstract"]
+Built-in functions expand at run time when a *TuneD* profile is activated.
+
+You can:
+
+* Use various built-in functions together with *TuneD* variables
+* Create custom functions in Python and add them to *TuneD* in the form of plug-ins
+
+To call a function, use the following syntax:
+
+[subs=+quotes]
+----
+${f:[replaceable]__function_name__:[replaceable]__argument_1__:[replaceable]__argument_2__}
+----
+
+To expand the directory path where the profile and the `tuned.conf` file are located, use the `PROFILE_DIR` function, which requires special syntax:
+
+----
+${i:PROFILE_DIR}
+----
+
+
+
+.Isolating CPU cores using variables and built-in functions
+====
+In the following example, the `${non_isolated_cores}` variable expands to `0,3-5`, and the `cpulist_invert` built-in function is called with the `0,3-5` argument:
+
+----
+[variables]
+non_isolated_cores=0,3-5
+
+[bootloader]
+cmdline=isolcpus=${f:cpulist_invert:${non_isolated_cores}}
+----
+
+The `cpulist_invert` function inverts the list of CPUs. For a 6-CPU machine, the inversion is `1,2`, and the kernel boots with the [option]`isolcpus=1,2` command-line option.
+
+====
+
+[role="_additional-resources"]
+.Additional resources
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
@@ -1,6 +1,8 @@
+:_module-type: CONCEPT
 [id="inheritance-between-tuned-profiles_{context}"]
 = Inheritance between TuneD profiles
 
+[role="_abstract"]
 *TuneD* profiles can be based on other profiles and modify only certain aspects of their parent profile.
 
 The `[main]` section of *TuneD* profiles recognizes the [option]`include` option:
@@ -15,7 +17,7 @@ All settings from the [replaceable]_parent_ profile are loaded in this _child_ p
 
 You can create your own _child_ profile in the [filename]`/etc/tuned/` directory based on a pre-installed profile in [filename]`/usr/lib/tuned/` with only some parameters adjusted.
 
-If the [replaceable]_parent_ profile is updated, such as after a *TuneD* upgrade, the changes are reflected in the _child_ profile. 
+If the [replaceable]_parent_ profile is updated, such as after a *TuneD* upgrade, the changes are reflected in the _child_ profile.
 
 
 .A power-saving profile based on balanced
@@ -31,8 +33,6 @@ alpm=min_power
 ----
 ====
 
-
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned.conf(5)` man page
-
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/con_merged-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_merged-tuned-profiles.adoc
@@ -1,0 +1,23 @@
+:_module-type: CONCEPT
+[id="merged-tuned-profiles_{context}"]
+= Merged TuneD profiles
+
+[role="_abstract"]
+As an experimental feature, it is possible to select more profiles at once. *TuneD* will try to merge them during the load.
+
+If there are conflicts, the settings from the last specified profile takes precedence.
+
+.Low power consumption in a virtual guest
+====
+The following example optimizes the system to run in a virtual machine for the best performance and concurrently tunes it for low power consumption, while the low power consumption is the priority:
+
+----
+# tuned-adm profile virtual-guest powersave
+----
+====
+
+WARNING: Merging is done automatically without checking whether the resulting combination of parameters makes sense. Consequently, the feature might tune some parameters the opposite way, which might be counterproductive: for example, setting the disk for high throughput by using the `throughput-performance` profile and concurrently setting the disk spindown to the low value by the `spindown-disk` profile.
+
+[role="_additional-resources"]
+.Additional resources
+* `tuned.conf(5)` man page.

--- a/doc/manual/modules/performance/con_static-and-dynamic-tuning-in-tuned.adoc
+++ b/doc/manual/modules/performance/con_static-and-dynamic-tuning-in-tuned.adoc
@@ -1,6 +1,8 @@
+:_module-type: CONCEPT
 [id="static-and-dynamic-tuning-in-tuned_{context}"]
 = Static and dynamic tuning in TuneD
 
+[role="_abstract"]
 This section explains the difference between the two categories of system tuning that *TuneD* applies: _static_ and _dynamic_.
 
 // TODO: Move some of this content into a separate module ("Enabling dynamic tuning"). It seems to be necessary to (1) enable dynamic tuning globally *and* (2) manually enable it in performance-oriented profiles.
@@ -32,7 +34,7 @@ This principle is used for other plug-ins for CPU and disks as well.
 
 
 // .Additional resources
-// 
+//
 // * A bulleted list of links to other material closely related to the contents of the concept module.
 // * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 // * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/doc/manual/modules/performance/con_the-default-tuned-profile.adoc
+++ b/doc/manual/modules/performance/con_the-default-tuned-profile.adoc
@@ -1,0 +1,18 @@
+:_module-type: CONCEPT
+[id="the-default-tuned-profile_{context}"]
+= The default TuneD profile
+
+[role="_abstract"]
+During the installation, the best profile for your system is selected automatically. Currently, the default profile is selected according to the following customizable rules:
+
+[options="header",cols="2,2,3"]
+|===
+| Environment | Default profile | Goal
+| Compute nodes | `throughput-performance` | The best throughput performance
+| Virtual machines | `virtual-guest` | The best performance. If you are not interested in the best performance, you can change it to the `balanced` or `powersave` profile.
+| Other cases | `balanced` | Balanced performance and power consumption
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* `tuned.conf(5)` man page.

--- a/doc/manual/modules/performance/con_the-location-of-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_the-location-of-tuned-profiles.adoc
@@ -1,0 +1,16 @@
+:_module-type: CONCEPT
+[id="the-location-of-tuned-profiles_{context}"]
+= The location of TuneD profiles
+
+[role="_abstract"]
+*TuneD* stores profiles in the following directories:
+
+[filename]`/usr/lib/tuned/`::
+Distribution-specific profiles are stored in the  directory. Each profile has its own directory. The profile consists of the main configuration file called `tuned.conf`, and optionally other files, for example helper scripts.
+
+[filename]`/etc/tuned/`::
+If you need to customize a profile, copy the profile directory into the  directory, which is used for custom profiles. If there are two profiles of the same name, the custom profile located in [filename]`/etc/tuned/` is used.
+
+[role="_additional-resources"]
+.Additional resources
+* `tuned.conf(5)` man page.

--- a/doc/manual/modules/performance/con_the-purpose-of-tuned.adoc
+++ b/doc/manual/modules/performance/con_the-purpose-of-tuned.adoc
@@ -1,6 +1,8 @@
+:_module-type: CONCEPT
 [id="the-purpose-of-tuned_{context}"]
 = The purpose of TuneD
 
+[role="_abstract"]
 *TuneD* is a service that monitors your system and optimizes the performance under certain workloads. The core of *TuneD* are _profiles_, which tune your system for different use cases.
 
 *TuneD* is distributed with a number of predefined profiles for use cases such as:
@@ -16,7 +18,7 @@ You can also configure *TuneD* to react to changes in device usage and adjusts s
 // The TuneD tuning service can adapt the operating system to perform better under certain workloads by setting a tuning profile.
 
 // .Additional resources
-// 
+//
 // * A bulleted list of links to other material closely related to the contents of the concept module.
 // * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 // * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/doc/manual/modules/performance/con_tuned-no-daemon-mode.adoc
+++ b/doc/manual/modules/performance/con_tuned-no-daemon-mode.adoc
@@ -1,8 +1,10 @@
+:_module-type: CONCEPT
 [id="tuned-no-daemon-mode_{context}"]
 = TuneD no-daemon mode
 
 // TODO: Should this be a procedure? A user story? Is there a common use case?
 
+[role="_abstract"]
 You can run *TuneD* in `no-daemon` mode, which does not require any resident memory. In this mode, *TuneD* applies the settings and exits.
 
 By default, `no-daemon` mode is disabled because a lot of *TuneD* functionality is missing in this mode, including:
@@ -18,7 +20,7 @@ daemon = 0
 ----
 
 // .Additional resources
-// 
+//
 // * A bulleted list of links to other material closely related to the contents of the concept module.
 // * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 // * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/doc/manual/modules/performance/con_tuned-plug-ins.adoc
+++ b/doc/manual/modules/performance/con_tuned-plug-ins.adoc
@@ -1,24 +1,19 @@
+:_module-type: CONCEPT
 [id="tuned-plug-ins_{context}"]
 = TuneD plug-ins
 
+[role="_abstract"]
 Plug-ins are modules in *TuneD* profiles that *TuneD* uses to monitor or optimize different devices on the system.
 
 *TuneD* uses two types of plug-ins:
 
-* monitoring plug-ins
-* tuning plug-ins
-
-[discrete]
-== Monitoring plug-ins
-
+Monitoring plug-ins::
 Monitoring plug-ins are used to get information from a running system. The output of the monitoring plug-ins can be used by tuning plug-ins for dynamic tuning.
-
++
 Monitoring plug-ins are automatically instantiated whenever their metrics are needed by any of the enabled tuning plug-ins. If two tuning plug-ins require the same data, only one instance of the monitoring plug-in is created and the data is shared.
 
-[discrete]
-== Tuning plug-ins
-
-Each tuning plug-in tunes an individual subsystem and takes several parameters that are populated from the TuneD profiles. Each subsystem can have multiple devices, such as multiple CPUs or network cards, that are handled by individual instances of the tuning plug-ins. Specific settings for individual devices are also supported. 
+Tuning plug-ins::
+Each tuning plug-in tunes an individual subsystem and takes several parameters that are populated from the TuneD profiles. Each subsystem can have multiple devices, such as multiple CPUs or network cards, that are handled by individual instances of the tuning plug-ins. Specific settings for individual devices are also supported.
 
 [discrete]
 == Syntax for plug-ins in TuneD profiles
@@ -33,13 +28,13 @@ devices=_DEVICES_
 ----
 
 NAME::
-is the name of the plug-in instance as it is used in the logs. It can be an arbitrary string. 
+is the name of the plug-in instance as it is used in the logs. It can be an arbitrary string.
 
 TYPE::
-is the type of the tuning plug-in. 
+is the type of the tuning plug-in.
 
 DEVICES::
-is the list of devices that this plug-in instance handles. 
+is the list of devices that this plug-in instance handles.
 +
 The `devices` line can contain a list, a wildcard (`\*`), and negation (`!`). If there is no `devices` line, all devices present or later attached on the system of the [replaceable]_TYPE_ are handled by the plug-in instance. This is same as using the [option]`devices=*` option.
 +
@@ -59,13 +54,13 @@ The following example matches all block devices except `sda1` and `sda2`:
 ----
 [data_disk]
 type=disk
-devices=!sda1, !sda2 
+devices=!sda1, !sda2
 disable_barriers=false
 ----
 
 ====
 
-If no instance of a plug-in is specified, the plug-in is not enabled. 
+If no instance of a plug-in is specified, the plug-in is not enabled.
 
 If the plug-in supports more options, they can be also specified in the plug-in section. If the option is not specified and it was not previously specified in the included plug-in, the default value is used.
 
@@ -98,14 +93,11 @@ If the same section is specified more than once using the `include` option, the 
 
 You can also disable the plug-in by specifying the [option]`enabled=false` option. This has the same effect as if the instance was never defined. Disabling the plug-in is useful if you are redefining the previous definition from the [option]`include` option and do not want the plug-in to be active in your custom profile.
 
-[discrete]
-== Functionality not implemented in any plug-in
-
+NOTE::
 *TuneD* includes the ability to run any shell command as part of enabling or disabling a tuning profile. This enables you to extend *TuneD* profiles with functionality that has not been integrated into TuneD yet.
-
++
 You can specify arbitrary shell commands using the `script` plug-in.
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned.conf(5)` man page
-
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/con_tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_tuned-profiles.adoc
@@ -1,6 +1,8 @@
+:_module-type: CONCEPT
 [id="tuned-profiles_{context}"]
 = TuneD profiles
 
+[role="_abstract"]
 A detailed analysis of a system can be very time-consuming. *TuneD* provides a number of predefined profiles for typical use cases. You can also create, modify, and delete profiles.
 
 The profiles provided with *TuneD* are divided into the following categories:
@@ -16,57 +18,12 @@ The performance-boosting profiles include profiles that focus on the following a
 * Virtualization host performance
 
 [discrete]
-== The default profile
-
-During the installation, the best profile for your system is selected automatically. Currently, the default profile is selected according to the following customizable rules:
-
-[options="header",cols="2,2,3"]
-|===
-| Environment | Default profile | Goal
-| Compute nodes | `throughput-performance` | The best throughput performance
-| Virtual machines | `virtual-guest` | The best performance. If you are not interested in the best performance, you can change it to the `balanced` or `powersave` profile.
-| Other cases | `balanced` | Balanced performance and power consumption
-|===
-
-
-[discrete]
-== Merged profiles
-
-As an experimental feature, it is possible to select more profiles at once. *TuneD* will try to merge them during the load.
-
-If there are conflicts, the settings from the last specified profile takes precedence.
-
-.Low power consumption in a virtual guest
-====
-The following example optimizes the system to run in a virtual machine for the best performance and concurrently tunes it for low power consumption, while the low power consumption is the priority:
-
-----
-# tuned-adm profile virtual-guest powersave
-----
-====
-
-WARNING: Merging is done automatically without checking whether the resulting combination of parameters makes sense. Consequently, the feature might tune some parameters the opposite way, which might be counterproductive: for example, setting the disk for high throughput by using the `throughput-performance` profile and concurrently setting the disk spindown to the low value by the `spindown-disk` profile.
-
-[discrete]
-== The location of profiles
-
-*TuneD* stores profiles in the following directories:
-
-[filename]`/usr/lib/tuned/`::
-Distribution-specific profiles are stored in the  directory. Each profile has its own directory. The profile consists of the main configuration file called `tuned.conf`, and optionally other files, for example helper scripts.
-
-[filename]`/etc/tuned/`::
-If you need to customize a profile, copy the profile directory into the  directory, which is used for custom profiles. If there are two profiles of the same name, the custom profile located in [filename]`/etc/tuned/` is used.
-
-
-[discrete]
-== The syntax of profile configuration
+== Syntax of profile configuration
 
 The `tuned.conf` file can contain one `[main]` section and other sections for configuring plug-in instances. However, all sections are optional.
 
 Lines starting with the hash sign (`#`) are comments.
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned.conf(5)` man page.
-
+* `tuned.conf(5)` man page.

--- a/doc/manual/modules/performance/con_variables-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_variables-in-tuned-profiles.adoc
@@ -1,0 +1,55 @@
+:_module-type: CONCEPT
+[id="variables-in-tuned-profiles_{context}"]
+= Variables in TuneD profiles
+
+[role="_abstract"]
+Variables expand at run time when a *TuneD* profile is activated.
+
+Using *TuneD* variables reduces the amount of necessary typing in *TuneD* profiles.
+
+There are no predefined variables in *TuneD* profiles. You can define your own variables by creating the `[variables]` section in a profile and using the following syntax:
+
+[subs=+quotes]
+----
+[variables]
+
+[replaceable]__variable_name__=[replaceable]__value__
+----
+
+To expand the value of a variable in a profile, use the following syntax:
+
+[subs=+quotes]
+----
+${[replaceable]__variable_name__}
+----
+
+.Isolating CPU cores using variables
+====
+In the following example, the `${isolated_cores}` variable expands to `1,2`; hence the kernel boots with the [option]`isolcpus=1,2` option:
+
+----
+[variables]
+isolated_cores=1,2
+
+[bootloader]
+cmdline=isolcpus=${isolated_cores}
+----
+
+The variables can be specified in a separate file. For example, you can add the following lines to [filename]`tuned.conf`:
+
+[subs=+quotes]
+----
+[variables]
+include=/etc/tuned/[replaceable]_my-variables.conf_
+
+[bootloader]
+cmdline=isolcpus=${isolated_cores}
+----
+
+If you add the [option]`isolated_cores=1,2` option to the [filename]`/etc/tuned/my-variables.conf` file, the kernel boots with the [option]`isolcpus=1,2` option.
+
+====
+
+[role="_additional-resources"]
+.Additional resources
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
@@ -1,11 +1,19 @@
+:_module-type: PROCEDURE
 [id="creating-new-tuned-profiles_{context}"]
 = Creating new TuneD profiles
 
+[role="_abstract"]
 This procedure creates a new *TuneD* profile with custom performance rules.
 
 .Prerequisites
 
-* The `tuned` service is installed and running. See xref:installing-and-enabling-tuned_getting-started-with-tuned[] for details.
+ifndef::pantheonenv[]
+* The `tuned` service is running. See xref:installing-and-enabling-tuned_getting-started-with-tuned[Installing and Enabling Tuned] for details.
+endif::[]
+
+ifdef::pantheonenv[]
+* The `tuned` service is running. See xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and Enabling Tuned] for details.
+endif::[]
 
 .Procedure
 
@@ -61,7 +69,6 @@ Verfication succeeded, current system settings match the preset profile.
 See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned.conf(5)` man page
-
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/proc_disabling-tuned.adoc
+++ b/doc/manual/modules/performance/proc_disabling-tuned.adoc
@@ -1,10 +1,12 @@
+:_module-type: PROCEDURE
 [id="disabling-tuned_{context}"]
 = Disabling TuneD
 
+[role="_abstract"]
 This procedure disables *TuneD* and resets all affected system settings to their original state before *TuneD* modified them.
 
 // .Prerequisites
-// 
+//
 // * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 // * You can also link to other modules or assemblies the user must follow before starting this assembly.
 // * Delete the section title and bullets if the assembly has no prerequisites.
@@ -25,7 +27,6 @@ The tunings are applied again after the `tuned` service restarts.
 # systemctl disable --now tuned
 ----
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned-adm(8)` man page.
-
+* `tuned-adm(8)` man page

--- a/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
+++ b/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
@@ -1,10 +1,12 @@
+:_module-type: PROCEDURE
 [id="installing-and-enabling-tuned_{context}"]
 = Installing and enabling TuneD
 
+[role="_abstract"]
 This procedure installs and enables the *TuneD* application, installs *TuneD* profiles, and presets a default *TuneD* profile for your system.
 
 // .Prerequisites
-// 
+//
 // * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 // * You can also link to other modules or assemblies the user must follow before starting this assembly.
 // * Delete the section title and bullets if the assembly has no prerequisites.
@@ -47,6 +49,5 @@ See TuneD log file ('/var/log/tuned/tuned.log') for details.
 
 
 // .Additional resources
-// 
+//
 // * The `tuned-adm(8)` man page.
-

--- a/doc/manual/modules/performance/proc_listing-available-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_listing-available-tuned-profiles.adoc
@@ -1,6 +1,8 @@
+:_module-type: PROCEDURE
 [id="listing-available-tuned-profiles_{context}"]
 = Listing available TuneD profiles
 
+[role="_abstract"]
 This procedure lists all *TuneD* profiles that are currently available on your system.
 
 //No prerequisites are needed
@@ -40,7 +42,6 @@ $ *tuned-adm active*
 Current active profile: [replaceable]_balanced_
 ----
 
+[role="_additional-resources"]
 .Additional resources
-
 * The `tuned-adm(8)` man page.
-

--- a/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
@@ -1,11 +1,19 @@
+:_module-type: PROCEDURE
 [id="modifying-existing-tuned-profiles_{context}"]
 = Modifying existing TuneD profiles
 
+[role="_abstract"]
 This procedure creates a modified child profile based on an existing *TuneD* profile.
 
 .Prerequisites
 
-* The `tuned` service is installed and running. See xref:installing-and-enabling-tuned_getting-started-with-tuned[] for details.
+ifndef::pantheonenv[]
+* The `tuned` service is running. See xref:installing-and-enabling-tuned_getting-started-with-tuned[Installing and Enabling Tuned] for details.
+endif::[]
+
+ifdef::pantheonenv[]
+* The `tuned` service is running. See xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and Enabling Tuned] for details.
+endif::[]
 
 .Procedure
 
@@ -72,10 +80,9 @@ See TuneD log file ('/var/log/tuned/tuned.log') for details.
 // ----
 // # cp -r /usr/lib/tuned/throughput-performance /etc/tuned
 // ----
-// 
-// . Then, edit the profile in /etc/tuned according to your needs. Note that if there are two profiles of the same name, the profile located in /etc/tuned/ is loaded. The disadvantage of this approach is that if a system profile is updated after a TuneD upgrade, the changes will not be reflected in the now-outdated modified version. 
+//
+// . Then, edit the profile in /etc/tuned according to your needs. Note that if there are two profiles of the same name, the profile located in /etc/tuned/ is loaded. The disadvantage of this approach is that if a system profile is updated after a TuneD upgrade, the changes will not be reflected in the now-outdated modified version.
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned.conf(5)` man page
-
+* `tuned.conf(5)` man page

--- a/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
+++ b/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
@@ -1,11 +1,19 @@
+:_module-type: PROCEDURE
 [id="setting-a-tuned-profile_{context}"]
 = Setting a TuneD profile
 
+[role="_abstract"]
 This procedure activates a selected *TuneD* profile on your system.
 
 .Prerequisites
 
-* The `tuned` service is running. See xref:installing-and-enabling-tuned_{context}[] for details.
+ifndef::pantheonenv[]
+* The `tuned` service is running. See xref:installing-and-enabling-tuned_getting-started-with-tuned[Installing and Enabling Tuned] for details.
+endif::[]
+
+ifdef::pantheonenv[]
+* The `tuned` service is running. See xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and Enabling Tuned] for details.
+endif::[]
 
 .Procedure
 
@@ -68,7 +76,6 @@ See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 
 
+[role="_additional-resources"]
 .Additional resources
-
-* The `tuned-adm(8)` man page
-
+* `tuned-adm(8)` man page

--- a/doc/manual/modules/performance/proc_setting-the-disk-scheduler-using-tuned.adoc
+++ b/doc/manual/modules/performance/proc_setting-the-disk-scheduler-using-tuned.adoc
@@ -1,6 +1,8 @@
+:_module-type: PROCEDURE
 [id="setting-the-disk-scheduler-using-tuned_{context}"]
 = Setting the disk scheduler using TuneD
 
+[role="_abstract"]
 This procedure creates and enables a *TuneD* profile that sets a given disk scheduler for selected block devices. The setting persists across system reboots.
 
 In the following commands and configuration, replace:
@@ -10,9 +12,14 @@ In the following commands and configuration, replace:
 
 .Prerequisites
 
-// Use an xref if we're inside the performance title or the upstream TuneD manual.
+// Use an xref if we're inside the performance title or the upstream Tuned manual. Wrap performance title inside pantheonenv[] ifndef. Use pantheonenv[] ifdef to use correct xref syntax for PV2.
+ifndef::pantheonenv[]
 ifdef::performance-title[]
-:installing-tuned-link: pass:macros[xref:installing-and-enabling-tuned_getting-started-with-tuned[]]
+:installing-tuned-link: pass:macros[xref:installing-and-enabling-tuned_getting-started-with-tuned[Installing and enabling Tuned]]
+endif::[]
+endif::[]
+ifdef::pantheonenv[]
+:installing-tuned-link: pass:macros[xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and enabling Tuned]]
 endif::[]
 ifdef::upstream[]
 :installing-tuned-link: pass:macros[xref:installing-and-enabling-tuned_getting-started-with-tuned[]]
@@ -23,15 +30,18 @@ ifndef::performance-title[]
 :installing-tuned-link: pass:macros[https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance#installing-and-enabling-tuned_getting-started-with-tuned]
 endif::[]
 
-* The `tuned` service is installed and enabled.
-+
-For details, see {installing-tuned-link}.
+* The `tuned` service is installed and enabled. For details, see {installing-tuned-link}.
 
 .Procedure
 
-// Use an xref if we're inside the performance title or the upstream TuneD manual.
+// Use an xref if we're inside the performance title or the upstream Tuned manual. Wrap performance title inside pantheonenv[] ifndef. Use pantheonenv[] ifdef to use correct xref syntax for PV2.
+ifndef::pantheonenv[]
 ifdef::performance-title[]
-:tuned-profiles-link: pass:macros[xref:tuned-profiles-distributed-with-rhel_getting-started-with-tuned[]]
+:tuned-profiles-link: pass:macros[xref:tuned-profiles-distributed-with-rhel_getting-started-with-tuned[Tuned profiles distributed with RHEL]]
+endif::[]
+endif::[]
+ifdef::pantheonenv[]
+:tuned-profiles-link: pass:macros[xref:modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc[Tuned profiles distributed with RHEL]]
 endif::[]
 ifdef::upstream[]
 :tuned-profiles-link: pass:macros[xref:tuned-profiles-distributed-with-rhel_getting-started-with-tuned[]]
@@ -57,39 +67,51 @@ $ tuned-adm active
 # mkdir /etc/tuned/[replaceable]__my-profile__
 ----
 
-. Find the World Wide Name (WWN) identifier of the selected block device:
+. Find the system unique identifier of the selected block device:
 +
 [subs=+quotes]
 ----
-$ udevadm info --query=property --name=/dev/[replaceable]__device__ | grep WWN=
+$ udevadm info --query=property --name=/dev/_device_ | grep -E '(WWN|SERIAL)'
 
-ID_WWN=[replaceable]__0x5002538d00000000__
+ID_WWN=_0x5002538d00000000__
+ID_SERIAL=_Generic-_SD_MMC_20120501030900000-0:0_
+ID_SERIAL_SHORT=_20120501030900000_
 ----
++
+[NOTE]
+====
+The command in the this example will return all values identified as a World Wide Name (WWN) or serial number associated with the specified block device. Although it is preferred to use a WWN, the WWN is not always available for a given device and any values returned by the example command are acceptable to use as the _device system unique ID_.
+====
 
-. Create the [filename]`/etc/tuned/[replaceable]__my-profile__/tuned.conf` configuration file. In the file, set the following options:
+. Create the `/etc/tuned/_my-profile_/tuned.conf` configuration file. In the file, set the following options:
 
-** Optional: Include an existing profile:
+.. Optional: Include an existing profile:
 +
 [subs=+quotes]
 ----
 [main]
-include=[replaceable]__existing-profile__
+include=_existing-profile_
 ----
 
-** Set the selected disk scheduler for the device that matches the WWN identifier:
+.. Set the selected disk scheduler for the device that matches the WWN identifier:
 +
 [subs=+quotes]
 ----
 [disk]
-devices_udev_regex=ID_WWN=[replaceable]__0x5002538d00000000__
-elevator=[replaceable]__selected-scheduler__
+devices_udev_regex=_IDNAME_=_device system unique id_
+elevator=_selected-scheduler_
 ----
 +
-To match multiple devices in the [option]`devices_udev_regex` option, enclose the identifiers in parentheses and separate them with vertical bars:
+Here:
+
+* Replace _IDNAME_ with the name of the identifier being used (for example, `ID_WWN`).
+* Replace _device system unique id_ with the value of the chosen identifier (for example, `0x5002538d00000000`).
++
+To match multiple devices in the `devices_udev_regex` option, enclose the identifiers in parentheses and separate them with vertical bars:
 +
 [subs=+quotes]
 ----
-devices_udev_regex=(ID_WWN=[replaceable]__0x5002538d00000000__)|(ID_WWN=[replaceable]__0x1234567800000000__)
+devices_udev_regex=(ID_WWN=_0x5002538d00000000_)|(ID_WWN=_0x1234567800000000_)
 ----
 
 . Enable your profile:
@@ -98,6 +120,8 @@ devices_udev_regex=(ID_WWN=[replaceable]__0x5002538d00000000__)|(ID_WWN=[replace
 ----
 # tuned-adm profile [replaceable]__my-profile__
 ----
+
+.Verification steps
 
 . Verify that the TuneD profile is active and applied:
 +
@@ -116,20 +140,23 @@ See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 
 
+[role="_additional-resources"]
 .Additional resources
-
-// Use an xref if we're inside the performance title or the upstream TuneD manual.
+// Use an xref if we're inside the performance title or the upstream Tuned manual. Wrap performance title inside pantheonenv[] ifndef. Use pantheonenv[] ifdef to use correct xref syntax for PV2.
+ifndef::pantheonenv[]
 ifdef::performance-title[]
-:customizing-tuned-link: pass:macros[xref:customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance[]]
+:customizing-tuned-link: pass:macros[xref:customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance[Customizing Tuned profiles]]
+endif::[]
+endif::[]
+ifdef::pantheonenv[]
+:customizing-tuned-link: pass:macros[xref:assemblies/assembly_customizing-tuned-profiles.adoc[Customizing Tuned Profiles]]
 endif::[]
 ifdef::upstream[]
-:customizing-tuned-link: pass:macros[xref:customizing-tuned-profiles_tuned-documentation[]]
+:customizing-tuned-link: pass:macros[xref:customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance[Customizing Tuned profiles]]
 endif::[]
-
 // Use a link elsewhere.
 ifndef::performance-title[]
 :customizing-tuned-link: pass:macros[https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance]
 endif::[]
-
-* For more information on creating a *TuneD* profile, see {customizing-tuned-link}.
-
+//* For more information on creating a *TuneD* profile, see
+* {customizing-tuned-link}.

--- a/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
+++ b/doc/manual/modules/performance/ref_available-tuned-plug-ins.adoc
@@ -1,6 +1,8 @@
+:_module-type: REFERENCE
 [id="available-tuned-plug-ins_{context}"]
 = Available TuneD plug-ins
 
+[role="_abstract"]
 This section lists all monitoring and tuning plug-ins currently available in *TuneD*.
 
 [discrete]
@@ -9,13 +11,13 @@ This section lists all monitoring and tuning plug-ins currently available in *Tu
 Currently, the following monitoring plug-ins are implemented:
 
 `disk`::
-Gets disk load (number of IO operations) per device and measurement interval. 
+Gets disk load (number of IO operations) per device and measurement interval.
 
 `net`::
-Gets network load (number of transferred packets) per network card and measurement interval. 
+Gets network load (number of transferred packets) per network card and measurement interval.
 
 `load`::
-Gets CPU load per CPU and measurement interval. 
+Gets CPU load per CPU and measurement interval.
 
 [discrete]
 == Tuning plug-ins
@@ -27,19 +29,19 @@ Sets the CPU governor to the value specified by the [option]`governor` option an
 +
 If the CPU load is lower than the value specified by the [option]`load_threshold` option, the latency is set to the value specified by the [option]`latency_high` option, otherwise it is set to the value specified by [option]`latency_low`.
 +
-You can also force the latency to a specific value and prevent it from dynamically changing further. To do so, set the [option]`force_latency` option to the required latency value. 
+You can also force the latency to a specific value and prevent it from dynamically changing further. To do so, set the [option]`force_latency` option to the required latency value.
 
 `eeepc_she`::
-Dynamically sets the front-side bus (FSB) speed according to the CPU load. 
+Dynamically sets the front-side bus (FSB) speed according to the CPU load.
 +
 This feature can be found on some netbooks and is also known as the ASUS Super Hybrid Engine (SHE).
 +
-If the CPU load is lower or equal to the value specified by the [option]`load_threshold_powersave` option, the plug-in sets the FSB speed to the value specified by the [option]`she_powersave` option. If the CPU load is higher or equal to the value specified by the [option]`load_threshold_normal` option, it sets the FSB speed to the value specified by the [option]`she_normal` option. 
+If the CPU load is lower or equal to the value specified by the [option]`load_threshold_powersave` option, the plug-in sets the FSB speed to the value specified by the [option]`she_powersave` option. If the CPU load is higher or equal to the value specified by the [option]`load_threshold_normal` option, it sets the FSB speed to the value specified by the [option]`she_normal` option.
 +
-Static tuning is not supported and the plug-in is transparently disabled if *TuneD* does not detect the hardware support for this feature. 
+Static tuning is not supported and the plug-in is transparently disabled if *TuneD* does not detect the hardware support for this feature.
 
 `net`::
-Configures the Wake-on-LAN functionality to the values specified by the [option]`wake_on_lan` option. It uses the same syntax as the `ethtool` utility. It also dynamically changes the interface speed according to the interface utilization. 
+Configures the Wake-on-LAN functionality to the values specified by the [option]`wake_on_lan` option. It uses the same syntax as the `ethtool` utility. It also dynamically changes the interface speed according to the interface utilization.
 
 `sysctl`::
 Sets various `sysctl` settings specified by the plug-in options.
@@ -49,17 +51,25 @@ The syntax is ``[replaceable]__name__=[replaceable]__value__``, where [replaceab
 Use the `sysctl` plug-in if you need to change system settings that are not covered by other plug-ins available in *TuneD*. If the settings are covered by some specific plug-ins, prefer these plug-ins.
 
 `usb`::
-Sets autosuspend timeout of USB devices to the value specified by the [option]`autosuspend` parameter. 
+Sets autosuspend timeout of USB devices to the value specified by the [option]`autosuspend` parameter.
 +
-The value `0` means that autosuspend is disabled. 
+The value `0` means that autosuspend is disabled.
 
 `vm`::
 Enables or disables transparent huge pages depending on the Boolean value of the [option]`transparent_hugepages` option.
++
+Valid values of the [option]`transparent_hugepages` option are:
++
+--
+* "always"
+* "never"
+* "madvise"
+--
 
 `audio`::
 Sets the autosuspend timeout for audio codecs to the value specified by the [option]`timeout` option.
 +
-Currently, the `snd_hda_intel` and `snd_ac97_codec` codecs are supported. The value `0` means that the autosuspend is disabled. You can also enforce the controller reset by setting the Boolean option [option]`reset_controller` to `true`. 
+Currently, the `snd_hda_intel` and `snd_ac97_codec` codecs are supported. The value `0` means that the autosuspend is disabled. You can also enforce the controller reset by setting the Boolean option [option]`reset_controller` to `true`.
 
 `disk`::
 Sets the disk elevator to the value specified by the [option]`elevator` option.
@@ -74,7 +84,7 @@ It also sets:
 * The current disk readahead to a value multiplied by the constant specified by the [option]`readahead_multiply` option
 --
 +
-In addition, this plug-in dynamically changes the advanced power management and spindown timeout setting for the drive according to the current drive utilization. The dynamic tuning can be controlled by the Boolean option [option]`dynamic` and is enabled by default. 
+In addition, this plug-in dynamically changes the advanced power management and spindown timeout setting for the drive according to the current drive utilization. The dynamic tuning can be controlled by the Boolean option [option]`dynamic` and is enabled by default.
 
 `scsi_host`::
 Tunes options for SCSI hosts.
@@ -82,7 +92,7 @@ Tunes options for SCSI hosts.
 It sets Aggressive Link Power Management (ALPM) to the value specified by the [option]`alpm` option.
 
 `mounts`::
-Enables or disables barriers for mounts according to the Boolean value of the [option]`disable_barriers` option. 
+Enables or disables barriers for mounts according to the Boolean value of the [option]`disable_barriers` option.
 
 `scheduler`::
 Allows tuning of scheduling priorities, processes/threads/IRQs affinities, and CPU cores isolation.
@@ -119,7 +129,7 @@ The cpulist is unpacked and written directly to `/proc/irq/default_smp_affinity`
 `script`::
 Executes an external script or binary when the profile is loaded or unloaded. You can choose an arbitrary executable.
 +
-IMPORTANT: The `script` plug-in is provided mainly for compatibility with earlier releases. Prefer other *TuneD* plug-ins if they cover the required functionality. 
+IMPORTANT: The `script` plug-in is provided mainly for compatibility with earlier releases. Prefer other *TuneD* plug-ins if they cover the required functionality.
 +
 *TuneD* calls the executable with one of the following arguments:
 +
@@ -128,7 +138,7 @@ IMPORTANT: The `script` plug-in is provided mainly for compatibility with earlie
 ** `stop` when unloading the profile
 --
 +
-You need to correctly implement the `stop` action in your executable and revert all settings that you changed during the `start` action. Otherwise, the roll-back step after changing your *TuneD* profile will not work. 
+You need to correctly implement the `stop` action in your executable and revert all settings that you changed during the `start` action. Otherwise, the roll-back step after changing your *TuneD* profile will not work.
 +
 Bash scripts can import the [filename]`/usr/lib/tuned/functions` Bash library and use the functions defined there. Use these functions only for functionality that is not natively provided by *TuneD*. If a function name starts with an underscore, such as `_wifi_set_power_level`, consider the function private and do not use it in your scripts, because it might change in the future.
 +
@@ -147,14 +157,14 @@ script=${i:PROFILE_DIR}/script.sh
 `sysfs`::
 Sets various `sysfs` settings specified by the plug-in options.
 +
-The syntax is ``[replaceable]__name__=[replaceable]__value__``, where [replaceable]_name_ is the `sysfs` path to use. 
+The syntax is ``[replaceable]__name__=[replaceable]__value__``, where [replaceable]_name_ is the `sysfs` path to use.
 +
 Use this plugin in case you need to change some settings that are not covered by other plug-ins. Prefer specific plug-ins if they cover the required settings.
 
 `video`::
 Sets various powersave levels on video cards. Currently, only the Radeon cards are supported.
 +
-The powersave level can be specified by using the [option]`radeon_powersave` option. Supported values are: 
+The powersave level can be specified by using the [option]`radeon_powersave` option. Supported values are:
 +
 --
 * `default`
@@ -168,7 +178,7 @@ The powersave level can be specified by using the [option]`radeon_powersave` opt
 * `dpm-perfomance`
 --
 +
-For details, see link:http://www.x.org/wiki/RadeonFeature#KMS_Power_Management_Options[www.x.org]. Note that this plug-in is experimental and the option might change in future releases. 
+For details, see link:http://www.x.org/wiki/RadeonFeature#KMS_Power_Management_Options[www.x.org]. Note that this plug-in is experimental and the option might change in future releases.
 
 `bootloader`::
 Adds options to the kernel command line. This plug-in supports only the GRUB 2 boot loader.
@@ -205,4 +215,3 @@ cmdline=isolcpus=2
 
 ====
 --
-

--- a/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
@@ -1,6 +1,8 @@
+:_module-type: REFERENCE
 [id="built-in-functions-available-in-tuned-profiles_{context}"]
 = Built-in functions available in TuneD profiles
 
+[role="_abstract"]
 The following built-in functions are available in all *TuneD* profiles:
 
 `PROFILE_DIR`::
@@ -53,4 +55,3 @@ Unpacks a CPU list in the form of `1-3,4` to `1,2,3,4`.
 
 `cpulist_pack`::
 Packs a CPU list in the form of `1,2,3,5` to `1-3,5`.
-

--- a/doc/manual/modules/performance/ref_real-time-tuned-profiles-distributed-with-rhel.adoc
+++ b/doc/manual/modules/performance/ref_real-time-tuned-profiles-distributed-with-rhel.adoc
@@ -1,0 +1,23 @@
+:_module-type: REFERENCE
+[id="real-time-tuned-profiles-distributed-with-rhel_{context}"]
+= Real-time TuneD profiles distributed with RHEL
+
+[role="_abstract"]
+Real-time profiles are intended for systems running the real-time kernel. Without a special kernel build, they do not configure the system to be real-time. On RHEL, the profiles are available from additional repositories.
+
+The following real-time profiles are available:
+
+`realtime`::
+Use on bare-metal real-time systems.
++
+Provided by the [package]`tuned-profiles-realtime` package, which is available from the RT or NFV repositories.
+
+`realtime-virtual-host`::
+Use in a virtualization host configured for real-time.
++
+Provided by the [package]`tuned-profiles-nfv-host` package, which is available from the NFV repository.
+
+`realtime-virtual-guest`::
+Use in a virtualization guest configured for real-time.
++
+Provided by the [package]`tuned-profiles-nfv-guest` package, which is available from the NFV repository.

--- a/doc/manual/modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc
+++ b/doc/manual/modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc
@@ -1,6 +1,8 @@
+:_module-type: CONCEPT
 [id="tuned-profiles-distributed-with-rhel_{context}"]
 = TuneD profiles distributed with RHEL
 
+[role="_abstract"]
 The following is a list of profiles that are installed with *TuneD* on {RHEL}.
 
 NOTE: There might be more product-specific or third-party *TuneD* profiles available. Such profiles are usually provided by separate RPM packages.
@@ -8,9 +10,13 @@ NOTE: There might be more product-specific or third-party *TuneD* profiles avail
 
 `balanced`::
 The default power-saving profile. It is intended to be a compromise between performance and power consumption. It uses auto-scaling and auto-tuning whenever possible. The only drawback is the increased latency. In the current *TuneD* release, it enables the CPU, disk, audio, and video plugins, and activates the `conservative` CPU governor. The `radeon_powersave` option uses the `dpm-balanced` value if it is supported, otherwise it is set to `auto`.
++
+It changes the `energy_performance_preference` attribute to the `normal` energy setting. It also changes the `scaling_governor` policy attribute to either the `conservative` or `powersave` CPU governor.
 
 `powersave`::
 A profile for maximum power saving performance. It can throttle the performance in order to minimize the actual power consumption. In the current *TuneD* release it enables USB autosuspend, WiFi power saving, and Aggressive Link Power Management (ALPM) power savings for SATA host adapters. It also schedules multi-core power savings for systems with a low wakeup rate and activates the `ondemand` governor. It enables AC97 audio power saving or, depending on your system, HDA-Intel power savings with a 10 seconds timeout. If your system contains a supported Radeon graphics card with enabled KMS, the profile configures it to automatic power saving. On ASUS Eee PCs, a dynamic Super Hybrid Engine is enabled.
++
+It changes the `energy_performance_preference` attribute to the `powersave` or `power` energy setting. It also changes the `scaling_governor` policy attribute to either the `ondemand` or `powersave` CPU governor.
 +
 [NOTE]
 --
@@ -23,6 +29,8 @@ That is why the `balanced` profile can be generally a better option.
 
 `throughput-performance`::
 A server profile optimized for high throughput. It disables power savings mechanisms and enables `sysctl` settings that improve the throughput performance of the disk and network IO. CPU governor is set to `performance`.
++
+It changes the `energy_performance_preference` and `scaling_governor` attribute to the `performance` profile.
 
 `accelerator-performance`::
 The `accelerator-performance` profile contains the same tuning as the `throughput-performance` profile. Additionally, it locks the CPU to low C states so that the latency is less than 100us. This improves the performance of certain accelerators, such as GPUs.
@@ -100,25 +108,3 @@ A profile optimized for systems with user-defined Intel Speed Select Technology 
 ----
 # tuned-adm profile cpu-partitioning intel-sst
 ----
-
-[discrete]
-== Real-time profiles
-
-Real-time profiles are intended for systems running the real-time kernel. Without a special kernel build, they do not configure the system to be real-time. On RHEL, the profiles are available from additional repositories.
-
-The following real-time profiles are available:
-
-`realtime`::
-Use on bare-metal real-time systems.
-+
-Provided by the [package]`tuned-profiles-realtime` package, which is available from the RT or NFV repositories.
-
-`realtime-virtual-host`::
-Use in a virtualization host configured for real-time.
-+
-Provided by the [package]`tuned-profiles-nfv-host` package, which is available from the NFV repository.
-
-`realtime-virtual-guest`::
-Use in a virtualization guest configured for real-time.
-+
-Provided by the [package]`tuned-profiles-nfv-guest` package, which is available from the NFV repository.


### PR DESCRIPTION
This PR implements various changes to keep the upstream and downstream repos synced. Largely it is changes of syntax used that alters the rendering of the docs in a new downstream environment and other syntax used to define metadata in addition to breaking some modules into several modules where appropriate to keep up with downstream docs guidelines. Once the repos are largely in sync (after this PR, most modules are >98% similar, save for things such as Tuned being renamed TuneD), further changes (such as renaming Tuned to TuneD in downstream docs) will be a simple matter of copying either the upstream or downstream using the automated tuned-docs-sync tool.
Signed off: Jacob Valdez <jvaldez@redhat.com>