### PR TITLE
Fix conditional order for setting net device param

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -397,7 +397,7 @@ class NetTuningPlugin(base.Plugin):
 		if dev_params:
 			self._check_device_support(context, d, device, dev_params)
 			# replace the channel parameters based on the device support
-			if context == "channels" and (int(dev_params[next(iter(d))]) == 0 or str(dev_params[next(iter(d))]) == 'n/a'):
+			if context == "channels" and str(dev_params[next(iter(d))]) in ["n/a", "0"]:
 				d = self._replace_channels_parameters(context, self._cmd.dict2list(d), dev_params)
 
 		if not sim and len(d) != 0:


### PR DESCRIPTION
The conditional for setting a net device parameter has
a faulty order where it can potentially try to first cast a string to int
in a wrong manner and only then check if the value is a specific integer value.

current order:
1. check if a net device has a combined channel containing 0
2. check if a net device has a combined channel containing 'n/a'

fixed order:
robust check to see if device parameter is either 0 or 'n/a'

Signed-off-by: Yanir Quinn <yquinn@redhat.com>