### PR TITLE
bootloader: support for systems that don't have grub installed

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -124,6 +124,8 @@ STR_VERIFY_PROFILE_DEVICE_VALUE_MISSING = "verify: skipped, missing: device %s: 
 STR_VERIFY_PROFILE_VALUE_MISSING = "verify: skipped, missing: '%s'"
 STR_VERIFY_PROFILE_DEVICE_VALUE_FAIL = "verify: failed: device %s: '%s' = '%s', expected '%s'"
 STR_VERIFY_PROFILE_VALUE_FAIL = "verify: failed: '%s' = '%s', expected '%s'"
+STR_VERIFY_PROFILE_CMDLINE_FAIL = "verify: failed: cmdline arg '%s', expected '%s'"
+STR_VERIFY_PROFILE_CMDLINE_FAIL_MISSING = "verify: failed: cmdline arg '%s' is missing, expected '%s'"
 STR_VERIFY_PROFILE_FAIL = "verify: failed: '%s'"
 
 # timout for tuned-adm operations in seconds


### PR DESCRIPTION
This makes some changes to address systems that don't support changing
of grub configurations, e.g. embedded systems, where the cmdline is set in
other ways, but we still want to process it and verify against the tuning profile.

* Introduce new option "skip_grub_config". When this is set, no changes to grub
  config are attempted. cmdline options are still processed, and the result is
  used to verify the current cmdline.
* Improve reporting on expected/found/missing cmdline arguments.
* Add "no_error = True" to the call that reads /etc/default/grub in _bls_enabled().

Signed-off-by: Adriaan Schmidt <adriaan.schmidt@siemens.com>