### PR TITLE
realtime-virtual-host: Disable kvm.nx_huge_pages module option

### DIFF
--- a/profiles/functions
+++ b/profiles/functions
@@ -526,18 +526,24 @@ teardown_kvm_mod_low_latency()
 setup_kvm_mod_low_latency()
 {
 	local HAS_KPS=""
+	local HAS_NX_HP=""
 	local HAS_PLE_GAP=""
 	local WANTS_KPS=""
+	local WANTS_NX_HP=""
 	local WANTS_PLE_GAP=""
 
 	modinfo -p kvm | grep -q kvmclock_periodic_sync && HAS_KPS=1
+	modinfo -p kvm | grep -q nx_huge_pages && HAS_NX_HP=1
 	modinfo -p kvm_intel | grep -q ple_gap && HAS_PLE_GAP=1
 	grep -qs kvmclock_periodic_sync "$kvm_modprobe_file" && WANTS_KPS=1
+	grep -qs nx_huge_pages "$kvm_modprobe_file" && WANTS_NX_HP=1
 	grep -qs ple_gap "$kvm_modprobe_file" && WANTS_PLE_GAP=1
 
-	if [ "$HAS_KPS" != "$WANTS_KPS" -o "$HAS_PLE_GAP" != "$WANTS_PLE_GAP" ]; then
+	if [ "$HAS_KPS" != "$WANTS_KPS" -o "$HAS_PLE_GAP" != "$WANTS_PLE_GAP" -o \
+	     "$HAS_NX_HP" != "$WANTS_NX_HP" ]; then
 		teardown_kvm_mod_low_latency
 		[ "$HAS_KPS" ] && echo "options kvm kvmclock_periodic_sync=0" > $kvm_modprobe_file
+		[ "$HAS_NX_HP" ] && echo "options kvm nx_huge_pages=0" >> $kvm_modprobe_file
 		[ "$HAS_PLE_GAP" ] && echo "options kvm_intel ple_gap=0" >> $kvm_modprobe_file
 	fi
 	return 0

--- a/profiles/realtime-virtual-host/script.sh
+++ b/profiles/realtime-virtual-host/script.sh
@@ -36,6 +36,15 @@ verify() {
             retval=1
         fi
     fi
+    if [ -f /sys/module/kvm/parameters/nx_huge_pages ]; then
+        kps=$(cat /sys/module/kvm/parameters/nx_huge_pages)
+        if [ "$kps" = "N" -o "$kps" = "0" ]; then
+            echo "  kvmclock_periodic_sync:($kps): disabled: okay"
+        else
+            echo "  kvmclock_periodic_sync:($kps): enabled: expected N(0)"
+            retval=1
+        fi
+    fi
     return $retval
 }
 


### PR DESCRIPTION
The 'nx_huge_pages' option, will force any executable page mapping to be
performed at 4KiB granularity and requires any existing overlapping
huge-page mapping to be also split in 4KiB chunks[1]. This is due to a HW
bug that doesn't affect our NFV use-cases.

The way a huge-page mapping is dropped is by simply deleting the EPT
entry and flushing TLB caches on all affected CPUs. Next vCPU access to
that address will trigger an EPT_VIOLATION, which will jump into the
host for it to handle the page-fault. In our specific case, this means
all isolated CPUs running oslat will hit an EPT_VIOLATION almost exactly
at the same time. Which is bad enough already, but, given our systems
might have a huge number of isolated CPUs, will also create a lot of
contention over the KVM MMU lock. This has been observed to trigger
~100us latency spikes while testing with oslat.

So let's disable the 'kvm.nx_huge_pages' module option.

[1] see kernel commit b7e8c8303ff28

Resolves: rhbz#1976825
Signed-off-by: Nicolas Saenz Julienne <nsaenzju@redhat.com>