### PR TITLE
realtime-virtual-*: Set irqaffinity through kernel command line

### DIFF
--- a/profiles/realtime-virtual-guest/tuned.conf
+++ b/profiles/realtime-virtual-guest/tuned.conf
@@ -16,6 +16,7 @@ assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isola
 
 isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
 isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
+non_isolated_cores=${f:cpulist_invert:${isolated_cores}}
 
 # Fail if isolated_cores contains CPUs which are not online
 assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
@@ -45,4 +46,4 @@ ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*
 script=${i:PROFILE_DIR}/script.sh
 
 [bootloader]
-cmdline_rvg=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores}
+cmdline_rvg=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} irqaffinity=${non_isolated_cores}

--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -21,6 +21,7 @@ assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isola
 
 isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
 isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
+non_isolated_cores=${f:cpulist_invert:${isolated_cores}}
 
 # Fail if isolated_cores contains CPUs which are not online
 assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
@@ -57,4 +58,4 @@ ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*;.*pmd.*;.*PMD.*;^DPDK;.*qem
 script=${i:PROFILE_DIR}/script.sh
 
 [bootloader]
-cmdline_rvh=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores}
+cmdline_rvh=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} irqaffinity=${non_isolated_cores}


### PR DESCRIPTION
I/O APIC, one of intel's interrupt controllers, can only change the
affinity on an IRQ line during an EOI (end of interrupt)[1]. In other
words, on boot, although tuned will set a preferred IRQ affinity, it
might not be applied until the next time the interrupt is triggered.
This might be right away, or hours later while oslat or a
latency-sensitive workload is running.

To mitigate this set the 'irqaffinity='kernel command-line[2] option to
match the non-isolated CPU mask when running the realtime-virtual-*
profiles. This way we'll get the right affinity regardless of the
situation stated above.

[1] For more reference see kernel's ioapic_ack_level() function and the
    IRQD_SETAFFINITY_PENDING flag.

[2] Actually, this is why irqaffinity was introduced in the first place,
    see kernel commit fbf198030e0b0.

Resolves: rhbz#1974820
Signed-off-by: Nicolas Saenz Julienne <nsaenzju@redhat.com>