### PR TITLE
scheduler: abstract sched_ and numa_ knobs

### DIFF
--- a/profiles/accelerator-performance/tuned.conf
+++ b/profiles/accelerator-performance/tuned.conf
@@ -15,20 +15,6 @@ force_latency=99
 readahead=>4096
 
 [sysctl]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns = 10000000
-
-# SCHED_OTHER wake-up granularity.
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-#
-# This option delays the preemption effects of decoupled workloads
-# and reduces their over-scheduling. Synchronous workloads will still
-# have immediate wakeup/sleep latencies.
-kernel.sched_wakeup_granularity_ns = 15000000
-
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
 # swapping, so it's time to throttle writes until I/O can catch up.  Workloads
@@ -58,3 +44,18 @@ vm.dirty_background_ratio = 10
 # 100 tells the kernel to aggressively swap processes out of physical memory
 # and move them to swap cache
 vm.swappiness=10
+
+[scheduler]
+# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+sched_min_granularity_ns = 10000000
+
+# SCHED_OTHER wake-up granularity.
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+#
+# This option delays the preemption effects of decoupled workloads
+# and reduces their over-scheduling. Synchronous workloads will still
+# have immediate wakeup/sleep latencies.
+sched_wakeup_granularity_ns = 15000000

--- a/profiles/latency-performance/tuned.conf
+++ b/profiles/latency-performance/tuned.conf
@@ -12,13 +12,6 @@ energy_perf_bias=performance
 min_perf_pct=100
 
 [sysctl]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns=3000000
-kernel.sched_wakeup_granularity_ns=4000000
-
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
 # swapping, so it's time to throttle writes until I/O can catch up.  Workloads
@@ -40,7 +33,15 @@ vm.dirty_background_ratio=3
 # and move them to swap cache
 vm.swappiness=10
 
+[scheduler]
+# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+sched_min_granularity_ns = 3000000
+sched_wakeup_granularity_ns = 4000000
+
 # The total time the scheduler will consider a migrated process
 # "cache hot" and thus less likely to be re-migrated
 # (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=5000000
+sched_migration_cost_ns = 5000000

--- a/profiles/latency-performance/tuned.conf
+++ b/profiles/latency-performance/tuned.conf
@@ -32,16 +32,3 @@ vm.dirty_background_ratio=3
 # 100 tells the kernel to aggressively swap processes out of physical memory
 # and move them to swap cache
 vm.swappiness=10
-
-[scheduler]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-sched_min_granularity_ns = 3000000
-sched_wakeup_granularity_ns = 4000000
-
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-sched_migration_cost_ns = 5000000

--- a/profiles/mssql/tuned.conf
+++ b/profiles/mssql/tuned.conf
@@ -25,7 +25,9 @@ net.core.rmem_max=4194304
 net.core.wmem_default=262144
 net.core.wmem_max=1048576
 kernel.numa_balancing=0
-kernel.sched_latency_ns=60000000
-kernel.sched_migration_cost_ns=500000
-kernel.sched_min_granularity_ns=15000000
-kernel.sched_wakeup_granularity_ns=2000000
+
+[scheduler]
+sched_latency_ns=60000000
+sched_migration_cost_ns=500000
+sched_min_granularity_ns=15000000
+sched_wakeup_granularity_ns=2000000

--- a/profiles/postgresql/tuned.conf
+++ b/profiles/postgresql/tuned.conf
@@ -17,11 +17,6 @@ force_latency=1
 transparent_hugepages=never
 
 [sysctl]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns=10000000
 
 # The dirty_background_ratio and dirty_ratio controls percentage of memory
 # that file system cache have to fill with dirty data before kernel will
@@ -45,11 +40,18 @@ vm.dirty_bytes = 536870912
 # and move them to swap cache
 vm.swappiness=3
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=50000000
-
 # The autogroup feature of the CFS
 # (system default is 1, e.q enabled)
 kernel.sched_autogroup_enabled = 0
+
+[scheduler]
+# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+sched_min_granularity_ns = 10000000
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+sched_migration_cost_ns = 50000000

--- a/profiles/sap-hana/tuned.conf
+++ b/profiles/sap-hana/tuned.conf
@@ -20,7 +20,3 @@ kernel.numa_balancing = 0
 vm.dirty_ratio = 40
 vm.dirty_background_ratio = 10
 vm.swappiness = 10
-
-[scheduler]
-sched_min_granularity_ns = 3000000
-sched_wakeup_granularity_ns = 4000000

--- a/profiles/sap-hana/tuned.conf
+++ b/profiles/sap-hana/tuned.conf
@@ -17,8 +17,10 @@ transparent_hugepages=never
 [sysctl]
 kernel.sem = 32000 1024000000 500 32000
 kernel.numa_balancing = 0
-kernel.sched_min_granularity_ns = 3000000
-kernel.sched_wakeup_granularity_ns = 4000000
 vm.dirty_ratio = 40
 vm.dirty_background_ratio = 10
 vm.swappiness = 10
+
+[scheduler]
+sched_min_granularity_ns = 3000000
+sched_wakeup_granularity_ns = 4000000

--- a/profiles/spectrumscale-ece/tuned.conf
+++ b/profiles/spectrumscale-ece/tuned.conf
@@ -12,14 +12,16 @@ energy_perf_bias=performance
 min_perf_pct=100
 
 [sysctl]
-kernel.sched_min_granularity_ns = 10000000
-kernel.sched_wakeup_granularity_ns = 15000000
 kernel.numa_balancing = 1
 vm.dirty_ratio = 40
 vm.dirty_background_ratio = 10
 vm.swappiness=10
 net.ipv4.tcp_window_scaling = 1
 net.ipv4.tcp_timestamps = 1
+
+[scheduler]
+sched_min_granularity_ns = 10000000
+sched_wakeup_granularity_ns = 15000000
 
 [disk-sas]
 type=disk

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -28,20 +28,6 @@ transparent_hugepages=never
 readahead=>4096
 
 [sysctl]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns = 10000000
-
-# SCHED_OTHER wake-up granularity.
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-#
-# This option delays the preemption effects of decoupled workloads
-# and reduces their over-scheduling. Synchronous workloads will still
-# have immediate wakeup/sleep latencies.
-kernel.sched_wakeup_granularity_ns = 15000000
-
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
 # swapping, so it's time to throttle writes until I/O can catch up.  Workloads
@@ -72,6 +58,21 @@ vm.dirty_background_ratio = 10
 # and move them to swap cache
 vm.swappiness=10
 
+[scheduler]
+# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+sched_min_granularity_ns = 10000000
+
+# SCHED_OTHER wake-up granularity.
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+#
+# This option delays the preemption effects of decoupled workloads
+# and reduces their over-scheduling. Synchronous workloads will still
+# have immediate wakeup/sleep latencies.
+sched_wakeup_granularity_ns = 15000000
+
 # Marvell ThunderX
 [sysctl.thunderx]
 type=sysctl
@@ -80,8 +81,8 @@ cpuinfo_regex=${thunderx_cpuinfo_regex}
 kernel.numa_balancing=0
 
 # AMD
-[sysctl.amd]
-type=sysctl
+[scheduler.amd]
+type=scheduler
 uname_regex=x86_64
 cpuinfo_regex=${amd_cpuinfo_regex}
-kernel.sched_migration_cost_ns=5000000
+sched_migration_cost_ns=5000000

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -58,31 +58,9 @@ vm.dirty_background_ratio = 10
 # and move them to swap cache
 vm.swappiness=10
 
-[scheduler]
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-sched_min_granularity_ns = 10000000
-
-# SCHED_OTHER wake-up granularity.
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-#
-# This option delays the preemption effects of decoupled workloads
-# and reduces their over-scheduling. Synchronous workloads will still
-# have immediate wakeup/sleep latencies.
-sched_wakeup_granularity_ns = 15000000
-
 # Marvell ThunderX
 [sysctl.thunderx]
 type=sysctl
 uname_regex=aarch64
 cpuinfo_regex=${thunderx_cpuinfo_regex}
 kernel.numa_balancing=0
-
-# AMD
-[scheduler.amd]
-type=scheduler
-uname_regex=x86_64
-cpuinfo_regex=${amd_cpuinfo_regex}
-sched_migration_cost_ns=5000000

--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -14,9 +14,3 @@ vm.dirty_background_ratio = 5
 [cpu]
 # Setting C3 state sleep mode/power savings
 force_latency=cstate.id:3|70
-
-[scheduler]
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-sched_migration_cost_ns = 5000000

--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -11,11 +11,12 @@ include=throughput-performance
 # default is 10%)
 vm.dirty_background_ratio = 5
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns = 5000000
-
 [cpu]
 # Setting C3 state sleep mode/power savings
 force_latency=cstate.id:3|70
+
+[scheduler]
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+sched_migration_cost_ns = 5000000


### PR DESCRIPTION
New kernels (5.13 and newer) moved some sched_ and numa_ knobs from
the sysctl to the debugfs, thus add and abstract these knobs under the
scheduler plugin. With help of this abstraction it will write
the tuning to the correct place according to the kernel used.

Example:
[scheduler]
sched_migration_cost_ns = 500000

Will work on the old kernel the same way as:
[sysctl]
kernel.sched_migration_cost_ns = 500000

I.e. it will write '500000' to the:
/proc/sys/kernel/sched_migration_cost_ns

And on the new kernel it will write '500000' to the:
/sys/kernel/debug/sched/migration_cost_ns

Also updated TuneD profiles.

Resolves: rhbz#1952687

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>