### PR TITLE
scheduler: fix construction of the process name regex

### DIFF
--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -660,8 +660,9 @@ class SchedulerPlugin(base.Plugin):
 			sched = dict([(pid, (cmd, option, scheduler, priority, affinity, regex))
 					for pid, cmd in processes])
 			sched_all.update(sched)
-			regex = str(regex).replace("(", r"\(")
-			regex = regex.replace(")", r"\)")
+			# make any contained regexes non-capturing: replace "(" with "(?:",
+			# unless the "(" is preceded by "\" or followed by "?"
+			regex = re.sub(r"(?<!\\)\((?!\?)", "(?:", str(regex))
 			instance._sched_lookup[regex] = [scheduler, priority, affinity]
 		for pid, (cmd, option, scheduler, priority, affinity, regex) \
 				in sched_all.items():


### PR DESCRIPTION
To optimize process name matching, the regexes of all groups are combined
into one (r1)|(r2)|..., and after matching the capture is used to determine
which of the original regexes matched. This means that the individual
group regexes must not contain any captures. The current solution replaces
all "(" and ")" with "\\(" and "\\)".

Thus, if we want a group to match "thread(1|2|3)", this will turn into
"thread\\(1|2|3\\)", a regex that matches the three strings "thread(1",
"2" and "3)", which is definitely not what is intended.

This is fixed by instead replacing any "(" by "(?:", making the group
non-capturing. Replacement is not performed if the "(" is preceded by "\\"
or follwed by "?".

Signed-off-by: Adriaan Schmidt <adriaan.schmidt@siemens.com>