### PR TITLE
profiles: improve regexes to match kernel threads

### DIFF
--- a/profiles/realtime-virtual-guest/tuned.conf
+++ b/profiles/realtime-virtual-guest/tuned.conf
@@ -24,18 +24,18 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 [scheduler]
 # group.group_name=rule_priority:scheduler_policy:scheduler_priority:core_affinity_in_hex:process_name_regex
 # for i in `pgrep ksoftirqd` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.ksoftirqd=0:f:2:*:ksoftirqd.*
+group.ksoftirqd=0:f:2:*:^\[ksoftirqd
 
 # for i in `pgrep rcuc` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.rcuc=0:f:4:*:rcuc.*
+group.rcuc=0:f:4:*:^\[rcuc
 
 # for i in `pgrep rcub` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.rcub=0:f:4:*:rcub.*
+group.rcub=0:f:4:*:^\[rcub
 
 # for i in `pgrep ktimersoftd` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.ktimersoftd=0:f:3:*:ktimersoftd.*
+group.ktimersoftd=0:f:3:*:^\[ktimersoftd
 
-ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*
+ps_blacklist=^\[ksoftirqd;^\[rcuc;^\[rcub;^\[ktimersoftd
 
 [sysfs]
 # Perform lockless check for timer softirq on isolated CPUs.

--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -29,18 +29,18 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 [scheduler]
 # group.group_name=rule_priority:scheduler_policy:scheduler_priority:core_affinity_in_hex:process_name_regex
 # for i in `pgrep ksoftirqd` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.ksoftirqd=0:f:2:*:ksoftirqd.*
+group.ksoftirqd=0:f:2:*:^\[ksoftirqd
 
 # for i in `pgrep rcuc` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.rcuc=0:f:4:*:rcuc.*
+group.rcuc=0:f:4:*:^\[rcuc
 
 # for i in `pgrep rcub` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.rcub=0:f:4:*:rcub.*
+group.rcub=0:f:4:*:^\[rcub
 
 # for i in `pgrep ktimersoftd` ; do grep Cpus_allowed_list /proc/$i/status ; done
-group.ktimersoftd=0:f:3:*:ktimersoftd.*
+group.ktimersoftd=0:f:3:*:^\[ktimersoftd
 
-ps_blacklist=ksoftirqd.*;rcuc.*;rcub.*;ktimersoftd.*;.*pmd.*;.*PMD.*;^DPDK;.*qemu-kvm.*
+ps_blacklist=^\[ksoftirqd;^\[rcuc;^\[rcub;^\[ktimersoftd;pmd;PMD;^DPDK;qemu-kvm
 
 [sysfs]
 # Stop kernel same page merge (KSM) daemon, it may introduce latencies.


### PR DESCRIPTION
  * add "^\[" to the start of the regexes, so they only match
    the intended kernel threads, and not processes that have
    the name of a kthread in their cmdline.
  * remove unneccessary ".*" at start/end of regexes

Signed-off-by: Adriaan Schmidt <adriaan.schmidt@siemens.com>