### PR TITLE
bootloader: make skip_grub_config consistent with initrd_remove_dir

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -510,7 +510,7 @@ class BootloaderPlugin(base.Plugin):
 		if verify:
 			return None
 		if enabling and value is not None:
-			if self._cmd.get_bool(value):
+			if self._cmd.get_bool(value) == "1":
 				log.info("skipping any modification of grub config")
 				self._skip_grub_config_val = True
 


### PR DESCRIPTION
Currently, `skip_grub_config` and `initrd_remove_dir` options in the
bootloader plug-in are inconsistent.  This commit fixes this issue.

The `skip_grub_config=VALUE` does not change grub configuration if VALUE
is true.  However, cmdline options are still processed, and the result
is used to verify the current cmdline.  Only 'y', 'yes', 't', 'true' and
'1' (case insensitive) are accepted as true values for this option.
Other values are interpreted as false.

Example:
```
[bootloader]
skip_grub_config=True
cmdline=+systemd.cpu_affinity=1
```
Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>