### PR TITLE
add cpu-partitioning based on virt-host profile

### DIFF
--- a/profiles/cpu-partitioning-virt-host/00-tuned-pre-udev.sh
+++ b/profiles/cpu-partitioning-virt-host/00-tuned-pre-udev.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+cpumask="$(getargs tuned.non_isolcpus)"
+
+files=$(echo /sys/devices/virtual/workqueue{/,/*/}cpumask)
+
+log()
+{
+  echo "tuned: $@" >> /dev/kmsg
+}
+
+if [ -n "$cpumask" ]; then
+  log "setting workqueues CPU mask to $cpumask"
+  for f in $files; do
+    if [ -f $f ]; then
+      if ! echo $cpumask > $f 2>/dev/null; then
+        log "ERROR: could not write workqueue CPU mask '$cpumask' to '$f'"
+      fi
+    fi
+  done
+fi

--- a/profiles/cpu-partitioning-virt-host/cpu-partitioning-variables.conf
+++ b/profiles/cpu-partitioning-virt-host/cpu-partitioning-variables.conf
@@ -1,0 +1,6 @@
+# Examples:
+# isolated_cores=2,4-7
+# isolated_cores=2-23
+#
+# To disable the kernel load balancing in certain isolated CPUs:
+# no_balance_cores=5-10

--- a/profiles/cpu-partitioning-virt-host/script.sh
+++ b/profiles/cpu-partitioning-virt-host/script.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+. /usr/lib/tuned/functions
+
+no_balance_cpus_file=$STORAGE/no-balance-cpus.txt
+
+change_sd_balance_bit()
+{
+    local set_bit=$1
+    local flags_cur=
+    local file=
+    local cpu=
+
+    for cpu in $(cat $no_balance_cpus_file); do
+        for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
+            flags_cur=$(cat $file)
+            if [ $set_bit -eq 1 ]; then
+                flags_cur=$((flags_cur | 0x1))
+            else
+                flags_cur=$((flags_cur & 0xfffe))
+            fi
+            echo $flags_cur > $file
+        done
+    done
+}
+
+disable_balance_domains()
+{
+    change_sd_balance_bit 0
+}
+
+enable_balance_domains()
+{
+    change_sd_balance_bit 1
+}
+
+start() {
+    mkdir -p "${TUNED_tmpdir}/etc/systemd"
+    mkdir -p "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev"
+    cp /etc/systemd/system.conf "${TUNED_tmpdir}/etc/systemd/"
+    cp 00-tuned-pre-udev.sh "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev/"
+    setup_kvm_mod_low_latency
+    disable_ksm
+
+    echo "$TUNED_no_balance_cores_expanded" | sed 's/,/ /g' > $no_balance_cpus_file
+    disable_balance_domains
+    return "$?"
+}
+
+stop() {
+    if [ "$1" = "full_rollback" ]
+    then
+        teardown_kvm_mod_low_latency
+        enable_ksm
+    fi
+    enable_balance_domains
+    return "$?"
+}
+
+process $@

--- a/profiles/cpu-partitioning-virt-host/tuned.conf
+++ b/profiles/cpu-partitioning-virt-host/tuned.conf
@@ -1,0 +1,76 @@
+# tuned configuration
+#
+
+[main]
+summary=Optimize for CPU partitioning
+include=virtual-host
+
+[variables]
+# User is responsible for updating variables.conf with variable content such as isolated_cores=X-Y
+include=/etc/tuned/cpu-partitioning-variables.conf
+
+isolated_cores_assert_check = \\${isolated_cores}
+# Make sure isolated_cores is defined before any of the variables that
+# use it (such as assert1) are defined, so that child profiles can set
+# isolated_cores directly in the profile (tuned.conf)
+isolated_cores = ${isolated_cores}
+# Fail if isolated_cores are not set
+assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
+
+# tmpdir
+tmpdir=${f:strip:${f:exec:mktemp:-d}}
+# Non-isolated cores cpumask including offline cores
+isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
+isolated_cpumask=${f:cpulist2hex:${isolated_cores_expanded}}
+not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
+not_isolated_cores_online_expanded=${f:cpulist_online:${not_isolated_cores_expanded}}
+not_isolated_cpumask=${f:cpulist2hex:${not_isolated_cores_expanded}}
+# Make sure no_balance_cores is defined before
+# no_balance_cores_expanded is defined, so that child profiles can set
+# no_balance_cores directly in the profile (tuned.conf)
+no_balance_cores=${no_balance_cores}
+no_balance_cores_expanded=${f:cpulist_unpack:${no_balance_cores}}
+
+# Fail if isolated_cores contains CPUs which are not online
+assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
+
+[sysfs]
+/sys/bus/workqueue/devices/writeback/cpumask = ${not_isolated_cpumask}
+/sys/devices/virtual/workqueue/cpumask = ${not_isolated_cpumask}
+/sys/devices/virtual/workqueue/*/cpumask = ${not_isolated_cpumask}
+/sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
+
+# Forces hugepages to be allocated on non-hotpluggable memory
+vm.hugepages_treat_as_movable=0
+# Most HPC applications are NUMA aware. Enabling zone reclaim ensures
+# memory is reclaimed and reallocated from local pages. Disabling
+# automatic NUMA balancing prevents unwanted memory unmapping.
+vm.zone_reclaim_mode=1
+kernel.numa_balancing=0
+
+# TCP fast open reduces network latency by enabling data exchange
+# during the sender's initial TCP SYN. The value 3 enables fast open
+# on client and server connections.
+net.ipv4.tcp_fastopen=3
+
+[systemd]
+cpu_affinity=${not_isolated_cores_expanded}
+
+[irqbalance]
+banned_cpus=${isolated_cores}
+
+[script]
+priority=5
+script=${i:PROFILE_DIR}/script.sh
+
+[scheduler]
+isolated_cores=${isolated_cores}
+ps_blacklist=.*pmd.*;.*PMD.*;^DPDK;.*qemu-kvm.*;^contrail-vroute$;^lcore-slave-.*;^rte_mp_handle$;^rte_mp_async$;^eal-intr-thread$
+
+[bootloader]
+priority=10
+initrd_remove_dir=True
+initrd_dst_img=tuned-initrd.img
+initrd_add_dir=${tmpdir}
+cmdline_cpu_part=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} nosoftlockup


### PR DESCRIPTION
add a second cpu-partitioning profile based on the virt-host profile.
the intent here is to configure cpu partition without disabling hardware pstates
or optimizing for latency at the cost of throughput.

the cpu-partitioning-virt-host profile should be used on non realtime host where
deterministic latency is not required and higher aggregate throughput of virtualization workloads are desired.