### PR TITLE
openshift profile: workaround high CPU utilization of [scheduler] plug-in

### DIFF
--- a/profiles/openshift/tuned.conf
+++ b/profiles/openshift/tuned.conf
@@ -28,3 +28,5 @@ vm.max_map_count=262144
 [scheduler]
 # see rhbz#1979352; exclude containers from aligning to house keeping CPUs
 cgroup_ps_blacklist=/kubepods\.slice/
+# workaround for rhbz#1921738
+runtime=0


### PR DESCRIPTION
The `[scheduler]` plug-in can be very CPU intensive, especially on the OpenShift platform.  The bug for this issue is tracked by rhbz#1921738. Until this is fixed, work around this problem in the openshift parent profile by adding `runtime=0` `[scheduler]` plug-in option.

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>