### PR TITLE
Add conditional profile loading

### DIFF
--- a/tuned/profiles/locator.py
+++ b/tuned/profiles/locator.py
@@ -31,6 +31,10 @@ class Locator(object):
 
 	def get_config(self, profile_name, skip_files=None):
 		ret = None
+		conditional_load = profile_name[0:1] == "-"
+		if conditional_load:
+			profile_name = profile_name[1:]
+
 		for dir_name in reversed(self._load_directories):
 			# basename is protection not to get out of the path
 			config_file = self._get_config_filename(dir_name, os.path.basename(profile_name))
@@ -41,6 +45,9 @@ class Locator(object):
 
 			if os.path.isfile(config_file):
 				return config_file
+
+		if conditional_load and ret is None:
+			ret = ""
 
 		return ret
 


### PR DESCRIPTION
Normally, inclusion of any profile that is not found in profile
directories (`/etc/tuned` and `/usr/lib/tuned`) will fail at profile
application time.

Conditional profile loading can be useful in situations we do not
necessarily expect a certain included profile to exist.  Profile
application failures are undesirable in such cases.  Augment the
TuneD profile hierarchies by adding a functionality to conditionally
include a profile by prefixing its name by '-' symbol.

```
Example:
[main]
summary=An example TuneD profile demonstrating conditional loading
include=-profile1,profile2
```

In this example, the profile "profile1" is conditionally loaded/included
and no error/failure will be reported if the profile does not exist.
Then, the profile "profile2" is unconditionally loaded and errors will be
reported if it is not found in profile directories.
