### PR TITLE
Remove rcu_nocbs from cpu-partitioning profile

### DIFF
--- a/profiles/cpu-partitioning/tuned.conf
+++ b/profiles/cpu-partitioning/tuned.conf
@@ -66,4 +66,4 @@ priority=10
 initrd_remove_dir=True
 initrd_dst_img=tuned-initrd.img
 initrd_add_dir=${tmpdir}
-cmdline_cpu_part=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup
+cmdline_cpu_part=+nohz=on nohz_full=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup


### PR DESCRIPTION
This seem to be redundant, at least according to https://github.com/torvalds/linux/blob/4c388a8e740d3235a194f330c8ef327deef710f6/Documentation/admin-guide/kernel-parameters.txt#L3484