### PR TITLE
spec: do not require subscription-manager on CentOS

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -95,7 +95,10 @@ Recommends: kmod
 %endif
 # syspurpose
 %if 0%{?rhel} > 8
+# not on CentOS
+%if 0%{!?centos:1}
 Requires: subscription-manager
+%endif
 %else
 %if 0%{?rhel} > 7
 Requires: python3-syspurpose


### PR DESCRIPTION
Resolves: rhbz#2028865

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>