### PR TITLE
configparser: switch to the read_file(), python-3.11 fix

### DIFF
--- a/tuned/gtk/gui_plugin_loader.py
+++ b/tuned/gtk/gui_plugin_loader.py
@@ -28,12 +28,13 @@ import importlib
 
 import tuned.consts as consts
 import tuned.logs
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-    from configparser import ConfigParser, Error
+    from configparser import Error
     from io import StringIO
 except ImportError:
     # python2.7 support, remove RHEL-7 support end
-    from ConfigParser import ConfigParser, Error
+    from ConfigParser import Error
     from StringIO import StringIO
 from tuned.exceptions import TunedException
 from tuned.utils.global_config import GlobalConfig
@@ -82,10 +83,10 @@ class GuiPluginLoader():
         """
 
         try:
-            config_parser = ConfigParser()
+            config_parser = TuneDConfigParser()
             config_parser.optionxform = str
             with open(file_name) as f:
-                config_parser.readfp(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
+                config_parser.read_file(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
             config, functions = GlobalConfig.get_global_config_spec()
             for option in config_parser.options(consts.MAGIC_HEADER_NAME):
                 if option in config:

--- a/tuned/gtk/gui_profile_loader.py
+++ b/tuned/gtk/gui_profile_loader.py
@@ -25,12 +25,13 @@ Created on Mar 13, 2014
 '''
 
 import os
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-    from configparser import ConfigParser, Error
+    from configparser import Error
     from io import StringIO
 except ImportError:
     # python2.7 support, remove RHEL-7 support end
-    from ConfigParser import ConfigParser, Error
+    from ConfigParser import Error
     from StringIO import StringIO
 import subprocess
 import json
@@ -68,9 +69,9 @@ class GuiProfileLoader(object):
 
         if profilePath == tuned.consts.LOAD_DIRECTORIES[1]:
             file_path = profilePath + '/' + profile_name + '/' + tuned.consts.PROFILE_FILE
-            config_parser = ConfigParser()
+            config_parser = TuneDConfigParser()
             config_parser.optionxform = str
-            config_parser.readfp(StringIO(config))
+            config_parser.read_file(StringIO(config))
 
             config_obj = {
                 'main': collections.OrderedDict(),
@@ -90,11 +91,11 @@ class GuiProfileLoader(object):
 
     def load_profile_config(self, profile_name, path):
         conf_path = path + '/' + profile_name + '/' + tuned.consts.PROFILE_FILE
-        config = ConfigParser()
+        config = TuneDConfigParser()
         config.optionxform = str
         profile_config = collections.OrderedDict()
         with open(conf_path) as f:
-            config.readfp(f)
+            config.read_file(f)
         for s in config.sections():
             profile_config[s] = collections.OrderedDict()
             for o in config.options(s):

--- a/tuned/gtk/gui_profile_saver.py
+++ b/tuned/gtk/gui_profile_saver.py
@@ -1,11 +1,7 @@
 import os
 import sys
 import json
-try:
-	from configparser import ConfigParser
-except ImportError:
-	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser
+from tuned.utils.config_parser import TuneDConfigParser
 
 
 if __name__ == "__main__":
@@ -15,7 +11,7 @@ if __name__ == "__main__":
 	if not os.path.exists(profile_dict['filename']):
 		os.makedirs(os.path.dirname(profile_dict['filename']))
 
-	profile_configobj = ConfigParser()
+	profile_configobj = TuneDConfigParser()
 	profile_configobj.optionxform = str
 	for section, options in profile_dict['main'].items():
 		profile_configobj.add_section(section)

--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -1,10 +1,11 @@
 import tuned.profiles.profile
 import tuned.profiles.variables
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-	from configparser import ConfigParser, Error
+	from configparser import Error
 except ImportError:
 	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser, Error
+	from ConfigParser import Error
 import tuned.consts as consts
 import os.path
 import collections
@@ -100,10 +101,10 @@ class Loader(object):
 
 	def _load_config_data(self, file_name):
 		try:
-			config_obj = ConfigParser()
+			config_obj = TuneDConfigParser()
 			config_obj.optionxform=str
 			with open(file_name) as f:
-				config_obj.readfp(f)
+				config_obj.read_file(f)
 		except Error as e:
 			raise InvalidProfileException("Cannot parse '%s'." % file_name, e)
 

--- a/tuned/profiles/locator.py
+++ b/tuned/profiles/locator.py
@@ -1,11 +1,12 @@
 import os
 import tuned.consts as consts
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-	from configparser import ConfigParser, Error
+	from configparser import Error
 	from io import StringIO
 except ImportError:
 	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser, Error
+	from ConfigParser import Error
 	from StringIO import StringIO
 
 class Locator(object):
@@ -61,10 +62,10 @@ class Locator(object):
 		if config_file is None:
 			return None
 		try:
-			config = ConfigParser()
+			config = TuneDConfigParser()
 			config.optionxform = str
 			with open(config_file) as f:
-				config.readfp(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
+				config.read_file(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
 			return config
 		except (IOError, OSError, Error) as e:
 			return None

--- a/tuned/profiles/variables.py
+++ b/tuned/profiles/variables.py
@@ -4,12 +4,13 @@ import tuned.logs
 from .functions import functions as functions
 import tuned.consts as consts
 from tuned.utils.commands import commands
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-	from configparser import ConfigParser, Error
+	from configparser import Error
 	from io import StringIO
 except ImportError:
 	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser, Error
+	from ConfigParser import Error
 	from StringIO import StringIO
 
 log = tuned.logs.get()
@@ -51,10 +52,10 @@ class Variables():
 			log.error("unable to find variables_file: '%s'" % filename)
 			return
 		try:
-			config = ConfigParser()
+			config = TuneDConfigParser()
 			config.optionxform = str
 			with open(filename) as f:
-				config.readfp(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
+				config.read_file(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
 		except Error:
 			log.error("error parsing variables_file: '%s'" % filename)
 			return

--- a/tuned/utils/config_parser.py
+++ b/tuned/utils/config_parser.py
@@ -1,0 +1,18 @@
+try:
+	from configparser import ConfigParser
+except ImportError:
+	# python2.7 support, remove RHEL-7 support end
+	from ConfigParser import ConfigParser
+
+class TuneDConfigParser(ConfigParser, object):
+	# Wrapper to support deprecated readfp() on python < 3.2 where read_file() is not available
+	def read_file(self, fp, source = None):
+		def readline_generator(fp):
+			line = fp.readline()
+			while line:
+				yield line
+				line = fp.readline()
+		try:
+			super(TuneDConfigParser, self).read_file(readline_generator(fp), source)
+		except AttributeError:
+			self.readfp(fp, source)

--- a/tuned/utils/global_config.py
+++ b/tuned/utils/global_config.py
@@ -1,10 +1,11 @@
 import tuned.logs
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-	from configparser import ConfigParser, Error
+	from configparser import Error
 	from io import StringIO
 except ImportError:
 	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser, Error
+	from ConfigParser import Error
 	from StringIO import StringIO
 from tuned.exceptions import TunedException
 import tuned.consts as consts
@@ -18,8 +19,8 @@ class GlobalConfig():
 
 	def __init__(self,config_file = consts.GLOBAL_CONFIG_FILE):
 		self._cfg = {}
-		self.load_config(file_name=config_file)
 		self._cmd = commands()
+		self.load_config(file_name=config_file)
 
 	@staticmethod
 	def get_global_config_spec():
@@ -45,10 +46,10 @@ class GlobalConfig():
 		"""
 		log.debug("reading and parsing global configuration file '%s'" % file_name)
 		try:
-			config_parser = ConfigParser()
+			config_parser = TuneDConfigParser()
 			config_parser.optionxform = str
 			with open(file_name) as f:
-				config_parser.readfp(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
+				config_parser.read_file(StringIO("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read()))
 			self._cfg, _global_config_func = self.get_global_config_spec()
 			for option in config_parser.options(consts.MAGIC_HEADER_NAME):
 				if option in self._cfg:

--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -3,11 +3,12 @@ import re
 import errno
 import procfs
 import subprocess
+from tuned.utils.config_parser import TuneDConfigParser
 try:
-	from configparser import ConfigParser, Error
+	from configparser import Error
 except ImportError:
 	# python2.7 support, remove RHEL-7 support end
-	from ConfigParser import ConfigParser, Error
+	from ConfigParser import Error
 
 try:
 	import syspurpose.files
@@ -63,10 +64,10 @@ class ProfileRecommender:
 		try:
 			if not os.path.isfile(fname):
 				return None
-			config = ConfigParser()
+			config = TuneDConfigParser()
 			config.optionxform = str
 			with open(fname) as f:
-				config.readfp(f)
+				config.read_file(f)
 			for section in config.sections():
 				match = True
 				for option in config.options(section):


### PR DESCRIPTION
ConfigParser.readfp() is deprecated since python-3.2 and was finally dropped
in the python-3.11 which caused breakage of the TuneD.

This commit switches from the readfp() to the read_file() while still
keeping backward compatibility with the python-3.2 and lower (e.g. python-2.7).

It utilizes wrapper which tries to call the read_file() first and if it
fails it fallbacks to the readfp().

Resolves: rhbz#2038886

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>