### PR TITLE
dbus: fix traceback on python-2.7

### DIFF
--- a/tuned/exports/dbus_exporter.py
+++ b/tuned/exports/dbus_exporter.py
@@ -18,7 +18,7 @@ try:
 	from inspect import getfullargspec
 
 	def getargspec(func):
-		return getfullargspec(func).args
+		return getfullargspec(func)
 except ImportError:
 	# Python2 version, drop after support stops
 	from inspect import getargspec
@@ -75,7 +75,7 @@ class DBusExporter(interfaces.ExporterInterface):
 	def _prepare_for_dbus(self, method, wrapper):
 		source = """def {name}({args}):
 					return wrapper({args})
-		""".format(name=method.__name__, args=', '.join(getargspec(method.__func__)))
+		""".format(name=method.__name__, args=', '.join(getargspec(method.__func__).args))
 		code = compile(source, '<decorator-gen-%d>' % len(self._dbus_methods), 'exec')
 		# https://docs.python.org/3.9/library/inspect.html
 		# co_consts - tuple of constants used in the bytecode


### PR DESCRIPTION
The code which replaced python-decorator introduced python-2.7
incompatibility. The getfullargspec() from the inspect module is drop in
replacement for the getargspec() and both return the named tuple. Thus
the args member has to be extracted the same way in both cases
(python 2/3).

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>