### PR TITLE
Better conntrack configuration for OCP profiles

### DIFF
--- a/profiles/atomic-guest/tuned.conf
+++ b/profiles/atomic-guest/tuned.conf
@@ -10,7 +10,7 @@ include=virtual-guest
 avc_cache_threshold=65536
 
 [net]
-nf_conntrack_hashsize=131072
+nf_conntrack_hashsize=1048576
 
 [sysctl]
 kernel.pid_max=131072

--- a/profiles/atomic-host/tuned.conf
+++ b/profiles/atomic-host/tuned.conf
@@ -10,7 +10,7 @@ include=throughput-performance
 avc_cache_threshold=65536
 
 [net]
-nf_conntrack_hashsize=131072
+nf_conntrack_hashsize=1048576
 
 [sysctl]
 kernel.pid_max=131072

--- a/profiles/openshift/tuned.conf
+++ b/profiles/openshift/tuned.conf
@@ -10,7 +10,7 @@ include=${f:virt_check:virtual-guest:throughput-performance}
 avc_cache_threshold=8192
 
 [net]
-nf_conntrack_hashsize=131072
+nf_conntrack_hashsize=1048576
 
 [sysctl]
 net.ipv4.ip_forward=1


### PR DESCRIPTION
raise the netfilter hash table size in openshift/atomic-{host,guest}
to match the max netfilter conntrack entries, reducing such hash
table load.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>