### PR TITLE
Do not hardcode disk name in tuned initrd path where not needed

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -395,7 +395,7 @@ class BootloaderPlugin(base.Plugin):
 		initrd_grubpath = "/"
 		lc = len(curr_cmdline)
 		if lc:
-			path = re.sub(r"^\s*BOOT_IMAGE=\s*(\S*/).*$", "\\1", curr_cmdline)
+			path = re.sub(r"^\s*BOOT_IMAGE=\s*(?:\([^)]*\))?(\S*/).*$", "\\1", curr_cmdline)
 			if len(path) < lc:
 				initrd_grubpath = path
 		self._initrd_val = os.path.join(initrd_grubpath, img_name)


### PR DESCRIPTION
On systems where /boot dir is not on separate partition grub cannot resolve disk name and cause kernel panic. This is not needed otherwise and can cause kernel panic when disk is renamed.

Resolves: rhbz#2050246

![tuned_kernel_panic](https://user-images.githubusercontent.com/10585878/157022894-6dbf2650-92a1-4fbd-8ee5-f3e264fed076.png)

Signed-off-by: Jan Zerdik <jzerdik@redhat.com>

