### PR TITLE
realtime: Set tsc as 'reliable'

### DIFF
--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -52,7 +52,7 @@ kernel.timer_migration = 0
 /sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
 
 [bootloader]
-cmdline_realtime=+isolcpus=${managed_irq}${isolated_cores} intel_pstate=disable nosoftlockup tsc=nowatchdog
+cmdline_realtime=+isolcpus=${managed_irq}${isolated_cores} intel_pstate=disable nosoftlockup tsc=reliable
 
 [irqbalance]
 banned_cpus=${isolated_cores}


### PR DESCRIPTION
We already disable the clocksource watchdog, it's there to double-check
whether clock results are coherent between reads. But a new reliability
test was introduced in recent kernels[1], tracking tsc drift between
CPUs[2]. It works by programming timers on all CPUs, including isolated
ones, and checks whether the tsc was adjusted in between runs. This
introduces unwarranted latency on real time systems. So let's promote
tsc to 'reliable', which disables both checks.

There shouldn't be any impact on old nor new setups. First, this test
didn't exist in the past, so any eventual drift was left uncorrected.
Second, most telco and HPC use-cases will make heavy use of tsc in
user-space, and its reliability is already assumed in the system's
design.

[1] c7719e793478 x86/tsc: Add a timer to make sure TSC_adjust is always
		 checked
[2] Generally caused by rogue BIOSes adjusting the tsc on a CPU and not
    doing so on the rest

Signed-off-by: Nicolas Saenz Julienne <nsaenzju@redhat.com>