### PR TITLE
recommend: do not ignore syspurpose_role if there is no syspurpose

### DIFF
--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -56,6 +56,7 @@ class ProfileRecommender:
 
 	def process_config(self, fname, has_root=True):
 		matching_profile = None
+		syspurpose_error_logged = False
 		try:
 			if not os.path.isfile(fname):
 				return None
@@ -97,11 +98,11 @@ class ProfileRecommender:
 						if not re.match(value, chassis_type, re.IGNORECASE):
 							match = False
 					elif option == "syspurpose_role":
+						role = ""
 						if have_syspurpose:
 							s = syspurpose.files.SyspurposeStore(
 									syspurpose.files.USER_SYSPURPOSE,
 									raise_on_error = True)
-							role = ""
 							try:
 								s.read_file()
 								role = s.contents["role"]
@@ -109,11 +110,13 @@ class ProfileRecommender:
 								if hasattr(e, "errno") and e.errno != errno.ENOENT:
 									log.error("Failed to load the syspurpose\
 										file: %s" % e)
-							if re.match(value, role, re.IGNORECASE) is None:
-								match = False
 						else:
-							log.error("Failed to process 'syspurpose_role' in '%s'\
-								, the syspurpose module is not available" % fname)
+							if not syspurpose_error_logged:
+								log.error("Failed to process 'syspurpose_role' in '%s'\
+									, the syspurpose module is not available" % fname)
+								syspurpose_error_logged = True
+						if re.match(value, role, re.IGNORECASE) is None:
+							match = False
 
 				if match:
 					# remove the ",.*" suffix


### PR DESCRIPTION
Previously, if there wasn't syspurpose (usually provided by the
subscription-manger), all the 'syspurpose_role' matches were ignored.
This wasn't correct, because it didn't allow enforcing of the system
role. Now in such cases the syspurpose_role is matched against the
empty string, i.e. the empty string means 'no syspurpose role or
syspurpose error'.

E.g. previously the following rule matched in case of no syspurpose:
something_that_matched
syspurpose_role=.*atomic.*

Now it doesn't match, but the previous behavior can be still
emulated by e.g.:
something_that_matched
syspurpose_role=(.*atomic.*)|^$

Also the error about the missing syspurpose module is now displayed only
once (for each 'recommend' call) and not multiple times for each
recommend rule.

Resolves: rhbz#2030580

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>