### PR TITLE
plugin_sysctl.py: Sysctl config files order applying.

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -96,11 +96,11 @@ def _apply_system_sysctl():
 			if fname not in files:
 				files[fname] = d
 
+	_apply_sysctl_config_file("/etc/sysctl.conf")
 	for fname in sorted(files.keys()):
 		d = files[fname]
 		path = "%s/%s" % (d, fname)
 		_apply_sysctl_config_file(path)
-	_apply_sysctl_config_file("/etc/sysctl.conf")
 
 def _apply_sysctl_config_file(path):
 	log.debug("Applying sysctl settings from file %s" % path)


### PR DESCRIPTION
There is a fix whitch changes order of applying /etc/sysctl.d/*.conf and /etc/sysctl.conf files. First sysctl needs to apply main (/etc/sysctl.conf) config and only after - custom configs from /etc/sysctl.d/*.conf.

Fixes #409 