### PR TITLE
Disable dynamic tuning by default

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -7,7 +7,7 @@
 daemon = 1
 
 # Dynamicaly tune devices, if disabled only static tuning will be used.
-dynamic_tuning = 1
+dynamic_tuning = 0
 
 # How long to sleep before checking for events (in seconds)
 # higher number means lower overhead but longer response time.


### PR DESCRIPTION
Dynamic tuning is counterproductiv in general:
HW should be set in the correct state statically, dynamic wake-ups and adjustings
cost performance and power and should only apply in specific scenarios.

On recent Intel CPUS:
(e.g. Gold 5115 CPU @ 2.40GHz, Silver 4110 CPU @ 2.10GHz)
CPU family:                      6
Model:                           85
Stepping:                        4

when utilizing one CPU core (cat /dev/null >/dev/zero &)
The CPU load calculated by the cpu plugin exceeds and latency_low
options apply:
self._set_latency(instance.options["latency_low"])

Latency limit is that low, that lower C-states are not entered anymore
and CPU cores cannot enter Turbo modes, due to CPU socket thermal
restrictions.

Therefore, the utilized CPU core is processing data slower, even
tuned set "low_latency" settings AND power consumption is increased as well.