### PR TITLE
bootloader: cmdline parser change and fixed escaping

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -164,13 +164,16 @@ class BootloaderPlugin(base.Plugin):
 			if val is None or val == "":
 				continue
 			op = val[0]
+			op1 = val[1:2]
 			vals = val[1:].strip()
-			if op == "+" and vals != "":
-				cmdline += " " + vals
-			elif op == "-" and vals != "":
-				for p in vals.split():
-					regex = re.escape(p)
-					cmdline = re.sub(r"(\A|\s)" + regex + r"(?=\Z|\s)", r"", cmdline)
+			if op == "+" or (op == "\\" and op1 in ["\\", "+", "-"]):
+				if vals != "":
+					cmdline += " " + vals
+			elif op == "-":
+				if vals != "":
+					for p in vals.split():
+						regex = re.escape(p)
+						cmdline = re.sub(r"(\A|\s)" + regex + r"(?=\Z|\s)", r"", cmdline)
 			else:
 				cmdline += " " + val
 		cmdline = cmdline.strip()
@@ -310,7 +313,7 @@ class BootloaderPlugin(base.Plugin):
 			grub2_cfg_new = grub2_cfg
 			patch_initial = False
 			for opt in d:
-				(grub2_cfg_new, nsubs) = re.subn(r"\b(set\s+" + opt + "\s*=).*$", r"\1" + "\"" + d[opt] + "\"", grub2_cfg_new, flags = re.MULTILINE)
+				(grub2_cfg_new, nsubs) = re.subn(r"\b(set\s+" + opt + "\s*=).*$", r"\1" + "\"" + self._cmd.escape(d[opt]) + "\"", grub2_cfg_new, flags = re.MULTILINE)
 				if nsubs < 1 or re.search(r"\$" + opt, grub2_cfg, flags = re.MULTILINE) is None:
 					patch_initial = True
 

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -192,7 +192,7 @@ class commands:
 						data += "\n"
 					data += "%s=\"%s\"\n" % (o, v)
 			else:
-				data = re.sub(r"\b(" + o + r"\s*=).*$", r"\1" + "\"" + v + "\"", data, flags = re.MULTILINE)
+				data = re.sub(r"\b(" + o + r"\s*=).*$", r"\1" + "\"" + self.escape(v) + "\"", data, flags = re.MULTILINE)
 
 		return self.write_to_file(f, data)
 


### PR DESCRIPTION
The following is now parsed differently:

[bootloader]
cmdline =+

Previously it was parsed as operator "=" adding symbol "+" to the cmdline,
now it is parsed as operator "=+" adding empty string "".

For the previous behaviour the leading "+" can now be escaped. It works the
following way:
cmdline =+ -> operator "=+" adding ""
cmdline =\\+ -> operator "=" adding "+"
cmdline =\\\\+ -> operator "=" adding "\\+"

Non leading escaping is ignored, e.g.:
cmdline =ab\\+ -> operator "=" adding "ab\\+"

Similarly for the operator "=-".

Also the arguments are now correctly escaped when further processed by
TuneD and the following problems should be now fixed:

cmdline =\n -> corruption of the /etc/tuned/bootcmdline with newlines
cmdline =\k -> TuneD traceback
cmdline =\1 -> operator "=" adding "TUNED_BOOT_CMDLINE="

There could be more undesired effects and that's why the escaping different
from the previously described leading escaping "\\\\", "\\+", "\\-" should be
now ignored.

Resolves: rhbz#1884472

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>