### PR TITLE
tuned-adm: fix typo in the verification output

### DIFF
--- a/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
@@ -65,7 +65,7 @@ Current active profile: [replaceable]_my-profile_
 ----
 $ tuned-adm verify
 
-Verfication succeeded, current system settings match the preset profile.
+Verification succeeded, current system settings match the preset profile.
 See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 

--- a/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
+++ b/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
@@ -43,7 +43,7 @@ Current active profile: [replaceable]_balanced_
 ----
 $ tuned-adm verify
 
-Verfication succeeded, current system settings match the preset profile.
+Verification succeeded, current system settings match the preset profile.
 See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 

--- a/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
@@ -70,7 +70,7 @@ Current active profile: [replaceable]_my-profile_
 ----
 $ tuned-adm verify
 
-Verfication succeeded, current system settings match the preset profile.
+Verification succeeded, current system settings match the preset profile.
 See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 

--- a/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
+++ b/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
@@ -71,7 +71,7 @@ Current active profile: [replaceable]_selected-profile_
 ----
 $ tuned-adm verify
 
-Verfication succeeded, current system settings match the preset profile.
+Verification succeeded, current system settings match the preset profile.
 See TuneD log file ('/var/log/tuned/tuned.log') for details.
 ----
 

--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -23,8 +23,8 @@
 .SH NAME
 tuned\-adm - command line tool for switching between different tuning profiles
 .SH SYNOPSIS
-.B tuned\-adm 
-.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | "auto_profile" | "profile_mode" | " verify " | " recommend ]
+.B tuned\-adm
+.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | " auto_profile " | " profile_mode " | " "verify \fI[\-i | \-\-ignore\-missing]\fP" " | " recommend ]
 
 .SH DESCRIPTION
 This command line utility allows you to switch between user definable tuning
@@ -76,11 +76,13 @@ performing any operation.
 Show information/description of given profile or current profile if no profile is specified.
 
 .TP
-.B verify
+.B "verify " \fI[\-i | \-\-ignore\-missing]\fP
 Verifies current profile against system settings. Outputs information whether
 system settings match current profile or not (e.g. somebody modified
 a sysfs/sysctl value by hand). Detailed information about what is checked, what
-value is set and what value is expected can be found in the log.
+value is set and what value is expected can be found in the log. With the
+\fI\-i\fP or \fI\-\-ignore\-missing\fP it does not treat missing tuning
+(tuning unsupported by the platform) as error.
 
 .TP
 .B recommend

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -360,7 +360,7 @@ class Admin(object):
 		else:
 			ret = self._controller.verify_profile()
 		if ret:
-			print("Verfication succeeded, current system settings match the preset profile.")
+			print("Verification succeeded, current system settings match the preset profile.")
 		else:
 			print("Verification failed, current system settings differ from the preset profile.")
 			print("You can mostly fix this by restarting the TuneD daemon, e.g.:")


### PR DESCRIPTION
Also added the -i and --ignore-missing options to the tuned-adm manual page.

Related: rhbz#2075827

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>