### PR TITLE
Add version/help command automatic complete

### DIFF
--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -24,7 +24,7 @@
 tuned\-adm - command line tool for switching between different tuning profiles
 .SH SYNOPSIS
 .B tuned\-adm 
-.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | " verify " | " recommend ]
+.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | "auto_profile" | "profile_mode" | " verify " | " recommend ]
 
 .SH DESCRIPTION
 This command line utility allows you to switch between user definable tuning

--- a/tuned-adm.bash
+++ b/tuned-adm.bash
@@ -2,7 +2,7 @@
 
 _tuned_adm()
 {
-	local commands="active list off profile recommend verify --version -v --help -h"
+	local commands="active list off profile recommend verify --version -v --help -h auto_profile profile_mode profile_info"
 	local cur prev words cword
 	_init_completion || return
 

--- a/tuned-adm.bash
+++ b/tuned-adm.bash
@@ -2,7 +2,7 @@
 
 _tuned_adm()
 {
-	local commands="active list off profile recommend verify"
+	local commands="active list off profile recommend verify --version -v --help -h"
 	local cur prev words cword
 	_init_completion || return
 


### PR DESCRIPTION
Add version/help command automatic complete & Add missing entries in the OPTIONS section
Users can view version/help related commands using the tab key, as convenient as any other procedure，supplementary man file missing option 
Signed-off-by: lilinjie@uniontech.com