### PR TITLE
openshift profile: tuning for NVMe devices

### DIFF
--- a/profiles/openshift/tuned.conf
+++ b/profiles/openshift/tuned.conf
@@ -25,6 +25,10 @@ net.ipv6.neigh.default.gc_thresh2=32768
 net.ipv6.neigh.default.gc_thresh3=65536
 vm.max_map_count=262144
 
+[sysfs]
+/sys/module/nvme_core/parameters/io_timeout=4294967295
+/sys/module/nvme_core/parameters/max_retries=10
+
 [scheduler]
 # see rhbz#1979352; exclude containers from aligning to house keeping CPUs
 cgroup_ps_blacklist=/kubepods\.slice/


### PR DESCRIPTION
AWS Nitro instances need special tuning for NVMe devices:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes

```
[sysfs]
/sys/module/nvme_core/parameters/io_timeout=4294967295
/sys/module/nvme_core/parameters/max_retries=10
```

This tuning should probably be moved to Cloud Provider-specific profiles
once the functionality is implemented.

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>