### PR TITLE
Closing fd from perf module in scheduler plugin

### DIFF
--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -242,7 +242,8 @@ class SchedulerPlugin(base.Plugin):
 				instance._runtime_tuning = False
 
 	def _instance_cleanup(self, instance):
-		pass
+		for fd in instance._evlist.get_pollfd():
+			os.close(fd.name)
 
 	@classmethod
 	def _get_config_options(cls):


### PR DESCRIPTION
perf module does not close it's file descriptors and it seams there is no better/nicer interface in python.

Resolves: rhbz#2080227

Signed-off-by: Jan Zerdik <jzerdik@redhat.com>