### PR TITLE
Adding better log for nf_conntrack_hashsize option when nf_conntrack module missing

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -23,6 +23,7 @@ class NetTuningPlugin(base.Plugin):
 		self._cmd = commands()
 		self._re_ip_link_show = {}
 		self._use_ip = True
+		self._nf_conntrack_loaded = None
 
 	def _init_devices(self):
 		self._devices_supported = True
@@ -268,6 +269,14 @@ class NetTuningPlugin(base.Plugin):
 			pass
 		return value
 
+	def _check_nf_conntrack_loaded(self):
+		if self._nf_conntrack_loaded is None:
+			_, out, _ = self._cmd.execute("lsmod | grep nf_conntrack", return_err=True)
+			self._nf_conntrack_loaded = out != ""
+			if not self._nf_conntrack_loaded:
+				log.warn("Module 'nf_conntrack' needed by 'nf_conntrack_hashsize' option in net plugin is not loaded. Load it and try again.")
+		return self._nf_conntrack_loaded
+
 	@command_set("nf_conntrack_hashsize")
 	def _set_nf_conntrack_hashsize(self, value, sim):
 		if value is None:
@@ -276,7 +285,8 @@ class NetTuningPlugin(base.Plugin):
 		hashsize = int(value)
 		if hashsize >= 0:
 			if not sim:
-				self._cmd.write_to_file(self._nf_conntrack_hashsize_path(), hashsize)
+				if not self._cmd.write_to_file(self._nf_conntrack_hashsize_path(), hashsize):
+					self._check_nf_conntrack_loaded()
 			return hashsize
 		else:
 			return None
@@ -286,6 +296,8 @@ class NetTuningPlugin(base.Plugin):
 		value = self._cmd.read_file(self._nf_conntrack_hashsize_path())
 		if len(value) > 0:
 			return int(value)
+		else:
+			self._check_nf_conntrack_loaded()
 		return None
 
 	def _call_ip_link(self, args=[]):


### PR DESCRIPTION
Related: rhbz#2064755

Signed-off-by: Jan Zerdik <jzerdik@redhat.com>