### PR TITLE
virtual-guest: Decrease the swappiness

### DIFF
--- a/profiles/virtual-guest/tuned.conf
+++ b/profiles/virtual-guest/tuned.conf
@@ -19,4 +19,4 @@ vm.dirty_ratio = 30
 # Filesystem I/O is usually much more efficient than swapping, so try to keep
 # swapping low.  It's usually safe to go even lower than this on systems with
 # server-grade storage.
-vm.swappiness = 30
+vm.swappiness = 5


### PR DESCRIPTION
`vm.swappiness` of `throughput-performance` is [10](https://github.com/redhat-performance/tuned/blob/master/profiles/throughput-performance/tuned.conf#L59), so set `vm.swappiness` of `virtual-guest` to 5.

[RHEL 7: Virtualization Tuning and Optimization Guide: Chapter 4. tuned and tuned-adm](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/chap-virtualization_tuning_optimization_guide-tuned):
> Based on the throughput-performance profile, virtual-guest also decreases the swappiness of virtual memory. 

[RHEL 8: Configuring and managing virtualization: Chapter 16. Optimizing virtual machine performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/optimizing-virtual-machine-performance-in-rhel_configuring-and-managing-virtualization#optimizing-virtual-machine-performance-using-tuned_optimizing-virtual-machine-performance-in-rhel):
>  For RHEL 8 virtual machines, use the virtual-guest profile. It is based on the generally applicable throughput-performance profile, but also decreases the swappiness of virtual memory. 

[RHEL 9: Configuring and managing virtualization: Chapter 17. Optimizing virtual machine performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/optimizing-virtual-machine-performance-in-rhel_configuring-and-managing-virtualization#optimizing-virtual-machine-performance-using-tuned_optimizing-virtual-machine-performance-in-rhel):
>  For RHEL 9 virtual machines, use the virtual-guest profile. It is based on the generally applicable throughput-performance profile, but also decreases the swappiness of virtual memory. 