### PR TITLE
virtual-host: More aggressive writeback of dirty

### DIFF
--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -7,6 +7,15 @@ summary=Optimize for running KVM guests
 include=throughput-performance
 
 [sysctl]
+# If a workload mostly uses anonymous memory and it hits this limit, the entire
+# working set is buffered for I/O, and any more write buffering would require
+# swapping, so it's time to throttle writes until I/O can catch up.  Workloads
+# that mostly use file mappings may be able to use even higher values.
+#
+# The generator of dirty data starts writeback at this percentage (system default
+# is 20%)
+vm.dirty_ratio = 10
+
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
 vm.dirty_background_ratio = 5


### PR DESCRIPTION
`vm.dirty_ratio` of system default is 20, so set `vm.dirty_ratio` of `virtual-host` to 10.

[RHEL 7: Virtualization Tuning and Optimization Guide: Chapter 4. tuned and tuned-adm](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/chap-virtualization_tuning_optimization_guide-tuned):
> Based on the throughput-performance profile, virtual-host also enables more aggressive writeback of dirty pages. This profile is the recommended profile for virtualization hosts, including both KVM and Red Hat Virtualization (RHV) hosts. 

[RHEL 8: Configuring and managing virtualization: Chapter 16. Optimizing virtual machine performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/optimizing-virtual-machine-performance-in-rhel_configuring-and-managing-virtualization#optimizing-virtual-machine-performance-using-tuned_optimizing-virtual-machine-performance-in-rhel):
>  For RHEL 8 virtualization hosts, use the virtual-host profile. This enables more aggressive writeback of dirty memory pages, which benefits the host performance. 

[RHEL 9: Configuring and managing virtualization: Chapter 17. Optimizing virtual machine performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/optimizing-virtual-machine-performance-in-rhel_configuring-and-managing-virtualization#optimizing-virtual-machine-performance-using-tuned_optimizing-virtual-machine-performance-in-rhel):
>  For RHEL 9 virtualization hosts, use the virtual-host profile. This enables more aggressive writeback of dirty memory pages, which benefits the host performance. 