### PR TITLE
builtin functions: added calc_isolated_cores function

### DIFF
--- a/profiles/cpu-partitioning/cpu-partitioning-variables.conf
+++ b/profiles/cpu-partitioning/cpu-partitioning-variables.conf
@@ -2,5 +2,8 @@
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
 # To disable the kernel load balancing in certain isolated CPUs:
 # no_balance_cores=5-10

--- a/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
+++ b/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
@@ -6,6 +6,9 @@
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
 #
 # Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
 # managed IRQs out of isolated cores. Note that this requires kernel

--- a/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
+++ b/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
@@ -6,7 +6,9 @@
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
-#
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
 # Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
 # managed IRQs out of isolated cores. Note that this requires kernel
 # support. Please only specify this parameter if you are sure that the

--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -2,6 +2,9 @@
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
 #
 # Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
 # managed IRQs out of isolated cores. Note that this requires kernel

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -66,6 +66,9 @@ SYSTEMD_CPUAFFINITY_VAR = "CPUAffinity"
 # irqbalance plugin configuration
 IRQBALANCE_SYSCONFIG_FILE = "/etc/sysconfig/irqbalance"
 
+# built-in functions configuration
+SYSFS_CPUS_PATH = "/sys/devices/system/cpu"
+
 # number of backups
 LOG_FILE_COUNT = 2
 LOG_FILE_MAXBYTES = 100*1000

--- a/tuned/profiles/functions/function_calc_isolated_cores.py
+++ b/tuned/profiles/functions/function_calc_isolated_cores.py
@@ -1,0 +1,44 @@
+import os
+import glob
+import tuned.logs
+from . import base
+import tuned.consts as consts
+
+log = tuned.logs.get()
+
+class calc_isolated_cores(base.Function):
+	"""
+	Calculates and returns isolated cores. The argument specifies how many
+	cores per socket reserve for housekeeping. If not specified, 1 core
+	per socket is reserved for housekeeping and the rest is isolated.
+	"""
+	def __init__(self):
+		# max 1 argument
+		super(calc_isolated_cores, self).__init__("calc_isolated_cores", 1)
+
+	def execute(self, args):
+		if not super(calc_isolated_cores, self).execute(args):
+			return None
+		cpus_reserve = 1
+		if len(args) > 0:
+			if not args[0].isdecimal() or int(args[0]) < 0:
+				log.error("invalid argument '%s' for builtin function '%s', it must be non-negative integer" %
+					(args[0], self._name))
+				return None
+			else:
+				cpus_reserve = int(args[0])
+
+		topo = {}
+		for cpu in glob.iglob(os.path.join(consts.SYSFS_CPUS_PATH, "cpu*")):
+			cpuid = os.path.basename(cpu)[3:]
+			if cpuid.isdecimal():
+				socket = self._cmd.read_file(os.path.join(cpu, "topology/physical_package_id")).strip()
+				if socket.isdecimal():
+					topo[socket] = topo.get(socket, []) + [cpuid]
+
+		isol_cpus = []
+		for cpus in topo.values():
+			cpus.sort(key = int)
+			isol_cpus = isol_cpus + cpus[cpus_reserve:]
+		isol_cpus.sort(key = int)
+		return ",".join(isol_cpus)


### PR DESCRIPTION
The calc_isolated_cores function expands to the list of cores to
isolate. It accepts optional argument which specifies how many cores
from each socket reserve for housekeeping. If not specified, one core
from each socket is reserved for housekeeping.

Example:
Machine with 2 sockets, each 4 cores, using the following user variable
configuration file, e.g. /etc/tuned/realtime-variables.conf:
isolated_cores=${f:calc_isolated_cores:2}

It will expand to:
isolated_cores=2, 3, 6, 7

I.e. cores 0, 1 and 4, 5 will be used for housekeeping.

Resolves: rhbz#2093847

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>