### PR TITLE
profiles: drop sched_ tuning from openshift-control-plane

### DIFF
--- a/profiles/openshift-control-plane/tuned.conf
+++ b/profiles/openshift-control-plane/tuned.conf
@@ -5,19 +5,3 @@
 [main]
 summary=Optimize systems running OpenShift control plane
 include=openshift
-
-[scheduler]
-# ktune sysctl settings, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-sched_min_granularity_ns=10000000
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-sched_migration_cost_ns=5000000
-# SCHED_OTHER wake-up granularity.
-#
-# Preemption granularity when tasks wake up.  Lower the value to
-# improve wake-up latency and throughput for latency critical tasks.
-sched_wakeup_granularity_ns=4000000


### PR DESCRIPTION
According to testing done by the kernel QE and performance teams,
the sched_* tunables should be dropped in several profiles.

The openshift-control-plane profile is based on other profiles
which have already dropped these tunables (network-latency,
throughput-performance). 

@yarda We would like to drop these tunables on RHEL9, but keep them on RHEL8. is it possible with a patch to ensure this change only takes effect on RHEL9, at least for the FDP builds that will feed into the Node Tuning Operator?

/cc @jmencak 