### PR TITLE
Packit yaml improvements

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,3 +1,4 @@
+srpm_build_deps: []
 upstream_tag_template: v{version}
 jobs:
 - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,20 +3,18 @@ upstream_tag_template: v{version}
 jobs:
 - job: copr_build
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - epel-7-x86_64
-    - epel-8-x86_64
-    - centos-stream-9-x86_64
+  targets:
+  - fedora-all
+  - epel-7-x86_64
+  - epel-8-x86_64
+  - centos-stream-9-x86_64
 - job: tests
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - epel-7-x86_64
-    - epel-8-x86_64
-    - centos-stream-9-x86_64
+  targets:
+  - fedora-all
+  - epel-7-x86_64
+  - epel-8-x86_64
+  - centos-stream-9-x86_64
 
 synced_files:
 - tuned.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,6 @@ jobs:
   - epel-8-x86_64
   - centos-stream-9-x86_64
 
-synced_files:
+files_to_sync:
 - tuned.spec
 - .packit.yaml


### PR DESCRIPTION
We have made a few changes to packit.yaml syntax - so that yours is up to date.

The most important change is the switch to building SRPMs in Copr which is our long-term plan. That should fix the el7 build problems right now.