### PR TITLE
Add missing entries in the OPTIONS section

### DIFF
--- a/README
+++ b/README
@@ -49,13 +49,13 @@ To disable all tunings, run:
 To show information/description of given profile or current profile if no profile is specified, run:
 # tuned-adm profile_info
 
-To verifies current profile against system settings, run:
+To verify current profile against system settings, run:
 # tuned-adm verify
 
-Enable automatic profile selection mode, switch to the recommended profile, run:
+To enable automatic profile selection mode, switch to the recommended profile, run:
 # tuned-adm auto_profile
 
-Show current profile selection mode, run:
+To show current profile selection mode, run:
 # tuned-adm profile_mode
 
 # tuned-adm recommend

--- a/README
+++ b/README
@@ -46,6 +46,18 @@ choice is used when the daemon is restarted (e.g. with the machine reboot).
 To disable all tunings, run:
 # tuned-adm off
 
+To show information/description of given profile or current profile if no profile is specified, run:
+# tuned-adm profile_info
+
+To verifies current profile against system settings, run:
+# tuned-adm verify
+
+Enable automatic profile selection mode, switch to the recommended profile, run:
+# tuned-adm auto_profile
+
+Show current profile selection mode, run:
+# tuned-adm profile_mode
+
 # tuned-adm recommend
 Recommend profile suitable for your system. Currently only static detection is
 implemented - it decides according to data in /etc/system-release-cpe and


### PR DESCRIPTION
Add missing options profile_info, auto_profile and profile mode in the OPTIONS section of the README.
Signed-off-by: lilinjie <lilinjie@uniontech.com>