### PR TITLE
Profile openshift: increase fs.aio-max-nr tunable

### DIFF
--- a/profiles/openshift/tuned.conf
+++ b/profiles/openshift/tuned.conf
@@ -15,6 +15,7 @@ nf_conntrack_hashsize=1048576
 [sysctl]
 net.ipv4.ip_forward=1
 kernel.pid_max=>4194304
+fs.aio-max-nr=>1048576
 net.netfilter.nf_conntrack_max=1048576
 net.ipv4.conf.all.arp_announce=2
 net.ipv4.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
The kernel tunable `fs.aio-max-nr` specifies the maximum number of events specified on the `io_setup()` call for all currently active aio contexts.  On large systems this causes issues with the userspace `io_setup()` call failing with `EAGAIN`.  Libvirt already increases this setting to 1048576:
https://github.com/libvirt/libvirt/blob/96e99e49483de4fb293ce26691cbce19110fb3a9/src/remote/libvirtd.sysctl

The only potential drawback of a larger limit is that a malicious users could issue parallel `io_setup()` requests to cause the kernel to set aside memory.

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>