### PR TITLE
hpc-compute profile: Remove vm.hugepages_treat_as_movable

### DIFF
--- a/profiles/hpc-compute/tuned.conf
+++ b/profiles/hpc-compute/tuned.conf
@@ -16,9 +16,6 @@ transparent_hugepages=always
 readahead=>4096
 
 [sysctl]
-# Forces hugepages to be allocated on non-hotpluggable memory
-vm.hugepages_treat_as_movable=0
-
 # Keep a reasonable amount of memory free to support large mem requests
 vm.min_free_kbytes=135168
 


### PR DESCRIPTION
In the old kernels, `vm.hugepages_treat_as_movable tunable` was aimed at reducing memory fragmentation.  Things have changed since then and this tunable is no longer present in recent kernels:
https://lore.kernel.org/lkml/20171003072619.8654-1-mhocko@kernel.org/t/

Its presence in the hpc-compute profile causes TuneD to log errors. Remove it.

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>