### PR TITLE
realtime-virtual-*: Tune priority of new ktimers threads

### DIFF
--- a/profiles/realtime-virtual-guest/tuned.conf
+++ b/profiles/realtime-virtual-guest/tuned.conf
@@ -25,6 +25,7 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 # group.group_name=rule_priority:scheduler_policy:scheduler_priority:core_affinity_in_hex:process_name_regex
 # for i in `pgrep ksoftirqd` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.ksoftirqd=0:f:2:*:^\[ksoftirqd
+group.ktimers=0:f:2:*:^\[ktimers
 
 # for i in `pgrep rcuc` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.rcuc=0:f:4:*:^\[rcuc
@@ -35,7 +36,7 @@ group.rcub=0:f:4:*:^\[rcub
 # for i in `pgrep ktimersoftd` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.ktimersoftd=0:f:3:*:^\[ktimersoftd
 
-ps_blacklist=^\[ksoftirqd;^\[rcuc;^\[rcub;^\[ktimersoftd
+ps_blacklist=^\[ksoftirqd;^\[ktimers;^\[rcuc;^\[rcub;^\[ktimersoftd
 
 [sysfs]
 # Perform lockless check for timer softirq on isolated CPUs.

--- a/profiles/realtime-virtual-host/tuned.conf
+++ b/profiles/realtime-virtual-host/tuned.conf
@@ -30,6 +30,7 @@ assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_exp
 # group.group_name=rule_priority:scheduler_policy:scheduler_priority:core_affinity_in_hex:process_name_regex
 # for i in `pgrep ksoftirqd` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.ksoftirqd=0:f:2:*:^\[ksoftirqd
+group.ktimers=0:f:2:*:^\[ktimers
 
 # for i in `pgrep rcuc` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.rcuc=0:f:4:*:^\[rcuc
@@ -40,7 +41,7 @@ group.rcub=0:f:4:*:^\[rcub
 # for i in `pgrep ktimersoftd` ; do grep Cpus_allowed_list /proc/$i/status ; done
 group.ktimersoftd=0:f:3:*:^\[ktimersoftd
 
-ps_blacklist=^\[ksoftirqd;^\[rcuc;^\[rcub;^\[ktimersoftd;pmd;PMD;^DPDK;qemu-kvm
+ps_blacklist=^\[ksoftirqd;^\[ktimers;^\[rcuc;^\[rcub;^\[ktimersoftd;pmd;PMD;^DPDK;qemu-kvm
 
 [sysfs]
 # Stop kernel same page merge (KSM) daemon, it may introduce latencies.


### PR DESCRIPTION
The PREEMPT_RT upstream tree [1] is reintroducing a per-CPU kthread for handling timer expiry named ktimers/${cpu}, and RHEL-RT is following this approach [2].

The recommended priority tuning for that kthread is to simply match that of ksoftirqd, which is what is implemented here.

Note that ktimersoftd is the predecessor of ktimers, and isn't present on RT kernels newer than v5.0.19-rt11 / RHEL-RT 7.

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-rt-devel.git
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2122220

Resolves: rhbz#2122220
Signed-off-by: Valentin Schneider <vschneid@redhat.com>