### PR TITLE
systemd: relax polkit requirement

### DIFF
--- a/tuned.service
+++ b/tuned.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Dynamic System Tuning Daemon
-After=systemd-sysctl.service network.target dbus.service
-Requires=dbus.service polkit.service
+After=systemd-sysctl.service network.target dbus.service polkit.service
+Requires=dbus.service
 Conflicts=cpupower.service auto-cpufreq.service tlp.service power-profiles-daemon.service
 Documentation=man:tuned(8) man:tuned.conf(5) man:tuned-adm(8)
 


### PR DESCRIPTION
The polkit has D-bus activation thus it will be activated on demand and we don't need to explicitly activate it.

Resolves: rhbz#2065591

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>