### PR TITLE
Fixed sysvinit path

### DIFF
--- a/contrib/sysvinit/tuned
+++ b/contrib/sysvinit/tuned
@@ -24,7 +24,7 @@ TUNED_OPT1=--log
 TUNED_OPT2=--pid
 TUNED_OPT3=--daemon
 
-SCRIPTNAME=/etc/init.d/$NAME
+SCRIPTNAME=/etc/rc.d/init.d/$NAME
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0

--- a/profiles/functions
+++ b/profiles/functions
@@ -218,7 +218,7 @@ CPUSPEED_SAVE_FILE="${STORAGE}/cpuspeed${STORAGE_SUFFIX}"
 CPUSPEED_ORIG_GOV="${STORAGE}/cpuspeed-governor-%s${STORAGE_SUFFIX}"
 CPUSPEED_STARTED="${STORAGE}/cpuspeed-started"
 CPUSPEED_CFG="/etc/sysconfig/cpuspeed"
-CPUSPEED_INIT="/etc/init.d/cpuspeed"
+CPUSPEED_INIT="/etc/rc.d/init.d/cpuspeed"
 # do not use cpuspeed
 CPUSPEED_USE="0"
 CPUS="$(ls -d1 /sys/devices/system/cpu/cpu* | sed 's;^.*/;;' |  grep "cpu[0-9]\+")"


### PR DESCRIPTION
It's kept for legacy purposes, but the path should be correct.

Resolves: rhbz#2118301

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>