### PR TITLE
add 'tuned-adm delete' command

### DIFF
--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -83,6 +83,10 @@ if __name__ == "__main__":
 	parser_profile_info.set_defaults(action="profile_info")
 	parser_profile_info.add_argument("profile", metavar="profile", type=str, nargs="?", default="", help="profile name, current profile if not specified")
 
+        parser_profile_delete = subparsers.add_parser("delete", help="delete a profile")
+        parser_profile_delete.set_defaults(action="profile_delete")
+        parser_profile_delete.add_argument("profile", metavar="profile", type=str, nargs="?", default="", help="profile name, only choose the user profile")
+
 	if config.get(consts.CFG_RECOMMEND_COMMAND, consts.CFG_DEF_RECOMMEND_COMMAND):
 		parser_off = subparsers.add_parser("recommend", help="recommend profile")
 		parser_off.set_defaults(action="recommend_profile")

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -13,6 +13,7 @@ import errno
 import time
 import threading
 import logging
+import shutil
 
 class Admin(object):
 	def __init__(self, dbus = True, debug = False, asynco = False,

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -178,6 +178,28 @@ class Admin(object):
 				return False
 		return self._print_profile_info(profile, self._profiles_locator.get_profile_attrs(profile, [consts.PROFILE_ATTR_SUMMARY, consts.PROFILE_ATTR_DESCRIPTION], ["", ""]))
 
+        def _action_profile_delete(self, profile = ""):
+                if profile == "":
+                        print("No set profile to delete.")
+                        return False
+                try:
+                        profile_list = os.listdir(consts.USER_PROFILE_DIR)
+                        if profile not in profile_list:
+                                print("File '%s' does not exists." % profile)
+                                return False
+                        else:
+                                shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+
+                except TunedException as e:
+                        self._error(str(e))
+                        return False
+                return True
+
+        def _dbus_action_profile_delete(self, profile = ""):
+                if profile != "":
+                        ret = self._controller.profile_delete(profile)
+                        res = True
+                return self._controller.exit(res)
 	def _print_profile_name(self, profile_name):
 		if profile_name is None:
 			print("No current active profile.")

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -190,6 +190,7 @@ class Admin(object):
                                 return False
                         else:
                                 shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+				print("Profile '%s' delete successfully" % profile)
 
                 except TunedException as e:
                         self._error(str(e))
@@ -199,8 +200,8 @@ class Admin(object):
         def _dbus_action_profile_delete(self, profile = ""):
                 if profile != "":
                         ret = self._controller.profile_delete(profile)
-                        res = True
-                return self._controller.exit(res)
+                return self._controller.exit(ret)
+		
 	def _print_profile_name(self, profile_name):
 		if profile_name is None:
 			print("No current active profile.")

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -153,8 +153,7 @@ class Admin(object):
 	def _dbus_action_profile_delete(self, profile = ""):
 		if profile != "":
 			ret = self._controller.profile_delete(profile)
-			res = True
-		return self._controller.exit(res)
+		return self._controller.exit(ret)
 
 	def _dbus_get_post_loaded_profile(self):
 		profile_name = self._controller.post_loaded_profile()

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -132,6 +132,30 @@ class Admin(object):
 			manual = profile is not None
 		return consts.ACTIVE_PROFILE_MANUAL if manual else consts.ACTIVE_PROFILE_AUTO
 
+	def _action_profile_delete(self, profile = ""):
+		if profile == "":
+			print("No set profile to delete.")
+			return False
+		try:
+			profile_list = os.listdir(consts.USER_PROFILE_DIR)
+			if profile not in profile_list:
+				print("File '%s' does not exists." % profile)
+				return False
+			else:
+				shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+				print("Profile '%s' delete successfully" % profile)
+			
+		except TunedException as e:
+			self._error(str(e))
+			return False
+		return True
+
+	def _dbus_action_profile_delete(self, profile = ""):
+		if profile != "":
+			ret = self._controller.profile_delete(profile)
+			res = True
+		return self._controller.exit(res)
+
 	def _dbus_get_post_loaded_profile(self):
 		profile_name = self._controller.post_loaded_profile()
 		if profile_name == "":
@@ -179,29 +203,6 @@ class Admin(object):
 				return False
 		return self._print_profile_info(profile, self._profiles_locator.get_profile_attrs(profile, [consts.PROFILE_ATTR_SUMMARY, consts.PROFILE_ATTR_DESCRIPTION], ["", ""]))
 
-        def _action_profile_delete(self, profile = ""):
-                if profile == "":
-                        print("No set profile to delete.")
-                        return False
-                try:
-                        profile_list = os.listdir(consts.USER_PROFILE_DIR)
-                        if profile not in profile_list:
-                                print("File '%s' does not exists." % profile)
-                                return False
-                        else:
-                                shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
-				print("Profile '%s' delete successfully" % profile)
-
-                except TunedException as e:
-                        self._error(str(e))
-                        return False
-                return True
-
-        def _dbus_action_profile_delete(self, profile = ""):
-                if profile != "":
-                        ret = self._controller.profile_delete(profile)
-                return self._controller.exit(ret)
-		
 	def _print_profile_name(self, profile_name):
 		if profile_name is None:
 			print("No current active profile.")

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -19,6 +19,7 @@ PLUGIN_MAIN_UNIT_NAME = "main"
 # Magic section header because ConfigParser does not support "headerless" config
 MAGIC_HEADER_NAME = "this_is_some_magic_section_header_because_of_compatibility"
 RECOMMEND_DIRECTORIES = ["/usr/lib/tuned/recommend.d", "/etc/tuned/recommend.d"]
+USER_PROFILE_DIR = "/etc/tuned"
 
 TMP_FILE_SUFFIX = ".tmp"
 # max. number of consecutive errors to give up

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -252,6 +252,26 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			profile_name = self.active_profile()
 		return tuple(self._daemon.profile_loader.profile_locator.get_profile_attrs(profile_name, [consts.PROFILE_ATTR_SUMMARY, consts.PROFILE_ATTR_DESCRIPTION], [""]))
 
+        @exports.export("s", "(bsss)")
+        def profile_delete(self, profile, caller = None):
+                if caller == "":
+                        return ""
+                if profile == "":
+                        print("No set profile to delete.")
+                        return False
+                try:
+                        profile_list = os.listdir(consts.USER_PROFILE_DIR)
+                        if profile not in profile_list:
+                                print("File '%s' does not exists." % profile)
+                                return False
+                        else:
+                                shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+
+                except TunedException as e:
+                        self._error(str(e))
+                        return False
+                return True
+
 	@exports.export("", "s")
 	def recommend_profile(self, caller = None):
 		if caller == "":

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -5,6 +5,8 @@ from tuned.exceptions import TunedException
 import threading
 import tuned.consts as consts
 from tuned.utils.commands import commands
+import os
+import shutil
 
 __all__ = ["Controller"]
 

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -254,26 +254,26 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			profile_name = self.active_profile()
 		return tuple(self._daemon.profile_loader.profile_locator.get_profile_attrs(profile_name, [consts.PROFILE_ATTR_SUMMARY, consts.PROFILE_ATTR_DESCRIPTION], [""]))
 
-        @exports.export("s", "(bsss)")
-        def profile_delete(self, profile, caller = None):
-                if caller == "":
-                        return ""
-                if profile == "":
-                        print("No set profile to delete.")
-                        return False
-                try:
-                        profile_list = os.listdir(consts.USER_PROFILE_DIR)
-                        if profile not in profile_list:
-                                print("File '%s' does not exists." % profile)
-                                return False
-                        else:
-                                shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+	@exports.export("s", "(bsss)")
+	def profile_delete(self, profile, caller = None):
+		if caller == "":
+			return ""
+		if profile == "":
+			print("No set profile to delete.")
+			return False
+		try:
+			profile_list = os.listdir(consts.USER_PROFILE_DIR)
+			if profile not in profile_list:
+				print("File '%s' does not exists." % profile)
+				return False
+			else:
+				shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
 				print("Profile '%s' delete successfully" % profile)
 
-                except TunedException as e:
-                        self._error(str(e))
-                        return False
-                return True
+		except TunedException as e:
+			self._error(str(e))
+			return False
+		return True
 
 	@exports.export("", "s")
 	def recommend_profile(self, caller = None):

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -268,6 +268,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
                                 return False
                         else:
                                 shutil.rmtree(os.path.join(consts.USER_PROFILE_DIR, profile))
+				print("Profile '%s' delete successfully" % profile)
 
                 except TunedException as e:
                         self._error(str(e))

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -254,7 +254,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			profile_name = self.active_profile()
 		return tuple(self._daemon.profile_loader.profile_locator.get_profile_attrs(profile_name, [consts.PROFILE_ATTR_SUMMARY, consts.PROFILE_ATTR_DESCRIPTION], [""]))
 
-	@exports.export("s", "(bsss)")
+	@exports.export("s", "b")
 	def profile_delete(self, profile, caller = None):
 		if caller == "":
 			return ""


### PR DESCRIPTION
Signed-off-by: lilinjie <lilinjie@uniontech.com>
add 'tuned-adm delete' command
Convenient for users to delete their own generated profile. (dir: /etc/tuned/)