### PR TITLE
bootloader: create bootcmdline even when skip_grub_config=true

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -690,6 +690,8 @@ class BootloaderPlugin(base.Plugin):
 				log.warn("requested changes to initrd will not be applied!")
 			if len(self._cmdline_val) > 0:
 				log.warn("requested changes to cmdline will not be applied!")
+			# ensure that the desired cmdline is always written to BOOT_CMDLINE_FILE (/etc/tuned/bootcmdline)
+			self._patch_bootcmdline({consts.BOOT_CMDLINE_TUNED_VAR : self._cmdline_val, consts.BOOT_CMDLINE_INITRD_ADD_VAR : self._initrd_val})
 		elif enabling and self.update_grub2_cfg:
 			if self._rpm_ostree:
 				self._rpm_ostree_update()


### PR DESCRIPTION
Even when we instruct TuneD to not apply changes to the bootloader config (skip_grub_config=true) it's useful to expose the generated cmdline. External tools could then read TuneD's desired cmdline, and adapt configurations of (so far) unsupported bootloaders like systemd-boot.

Signed-off-by: Adriaan Schmidt <adriaan.schmidt@siemens.com>