### PR TITLE
API: add support for moving devices between instances

### DIFF
--- a/com.redhat.tuned.policy
+++ b/com.redhat.tuned.policy
@@ -216,4 +216,15 @@
       <allow_active>yes</allow_active>
     </defaults>
   </action>
+
+  <action id="com.redhat.tuned.instance_acquire_devices">
+    <description>Acquire devices from other instances and assign them to the instance</description>
+    <message>Authentication is required to get hints for parameters of TuneD plugin</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>

--- a/tuned/plugins/hotplug.py
+++ b/tuned/plugins/hotplug.py
@@ -17,10 +17,10 @@ class Plugin(base.Plugin):
 		self._hardware_events_cleanup()
 
 	def _hardware_events_init(self):
-		raise NotImplementedError()
+		pass
 
 	def _hardware_events_cleanup(self):
-		raise NotImplementedError()
+		pass
 
 	def _init_devices(self):
 		self._hardware_events_init()
@@ -28,48 +28,78 @@ class Plugin(base.Plugin):
 	def _hardware_events_callback(self, event, device):
 		if event == "add":
 			log.info("device '%s' added" % device.sys_name)
-			self._add_device(device)
+			self._add_device(device.sys_name)
 		elif event == "remove":
 			log.info("device '%s' removed" % device.sys_name)
-			self._remove_device(device)
+			self._remove_device(device.sys_name)
 
-	def _add_device(self, device):
-		device_name = device.sys_name
+	def _add_device_process(self, instance, device_name):
+		log.info("instance %s: adding new device %s" % (instance.name, device_name))
+		self._assigned_devices.add(device_name)
+		self._call_device_script(instance, instance.script_pre, "apply", [device_name])
+		self._added_device_apply_tuning(instance, device_name)
+		self._call_device_script(instance, instance.script_post, "apply", [device_name])
+		instance.processed_devices.add(device_name)
+
+	def _add_device(self, device_name):
 		if device_name in (self._assigned_devices | self._free_devices):
 			return
 
 		for instance_name, instance in list(self._instances.items()):
 			if len(self._get_matching_devices(instance, [device_name])) == 1:
-				log.info("instance %s: adding new device %s" % (instance_name, device_name))
-				self._assigned_devices.add(device_name)
-				self._call_device_script(instance, instance.script_pre, "apply", [device_name])
-				self._added_device_apply_tuning(instance, device_name)
-				self._call_device_script(instance, instance.script_post, "apply", [device_name])
-				instance.processed_devices.add(device_name)
+				self._add_device_process(instance, device_name)
 				break
 		else:
 			log.debug("no instance wants %s" % device_name)
 			self._free_devices.add(device_name)
 
-	def _remove_device(self, device):
-		device_name = device.sys_name
+	def _add_devices_nocheck(self, instance, device_names):
+		"""
+		Add devices specified by the set to the instance, no check is performed.
+		"""
+		for dev in device_names:
+			self._add_device_process(instance, dev)
+		# This can be a bit racy (we can overcount),
+		# but it shouldn't affect the boolean result
+		instance.active = len(instance.processed_devices) \
+				+ len(instance.assigned_devices) > 0
+
+	def _remove_device_process(self, instance, device_name):
+		if device_name in instance.processed_devices:
+			self._call_device_script(instance, instance.script_post, "unapply", [device_name])
+			self._removed_device_unapply_tuning(instance, device_name)
+			self._call_device_script(instance, instance.script_pre, "unapply", [device_name])
+			instance.processed_devices.remove(device_name)
+			# This can be a bit racy (we can overcount),
+			# but it shouldn't affect the boolean result
+			instance.active = len(instance.processed_devices) \
+					+ len(instance.assigned_devices) > 0
+			self._assigned_devices.remove(device_name)
+			return True
+		return False
+
+	def _remove_device(self, device_name):
+		"""Remove device from the instance
+
+		Parameters:
+		device_name -- name of the device
+
+		"""
 		if device_name not in (self._assigned_devices | self._free_devices):
 			return
 
 		for instance in list(self._instances.values()):
-			if device_name in instance.processed_devices:
-				self._call_device_script(instance, instance.script_post, "unapply", [device_name])
-				self._removed_device_unapply_tuning(instance, device_name)
-				self._call_device_script(instance, instance.script_pre, "unapply", [device_name])
-				instance.processed_devices.remove(device_name)
-				# This can be a bit racy (we can overcount),
-				# but it shouldn't affect the boolean result
-				instance.active = len(instance.processed_devices) \
-						+ len(instance.assigned_devices) > 0
-				self._assigned_devices.remove(device_name)
+			if self._remove_device_process(instance, device_name):
 				break
 		else:
 			self._free_devices.remove(device_name)
+
+	def _remove_devices_nocheck(self, instance, device_names):
+		"""
+		Remove devices specified by the set from the instance, no check is performed.
+		"""
+		for dev in device_names:
+			self._remove_device_process(instance, dev)
 
 	def _added_device_apply_tuning(self, instance, device_name):
 		self._execute_all_device_commands(instance, [device_name])

--- a/tuned/plugins/plugin_audio.py
+++ b/tuned/plugins/plugin_audio.py
@@ -1,4 +1,4 @@
-from . import base
+from . import hotplug
 from .decorators import *
 import tuned.logs
 from tuned.utils.commands import commands
@@ -10,7 +10,7 @@ import glob
 log = tuned.logs.get()
 cmd = commands()
 
-class AudioPlugin(base.Plugin):
+class AudioPlugin(hotplug.Plugin):
 	"""
 	`audio`::
 	

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -1,4 +1,4 @@
-from . import base
+from . import hotplug
 from .decorators import *
 import tuned.logs
 from tuned.utils.commands import commands
@@ -14,7 +14,7 @@ log = tuned.logs.get()
 
 cpuidle_states_path = "/sys/devices/system/cpu/cpu0/cpuidle"
 
-class CPULatencyPlugin(base.Plugin):
+class CPULatencyPlugin(hotplug.Plugin):
 	"""
 	`cpu`::
 	

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -1,5 +1,5 @@
 import errno
-from . import base
+from . import hotplug
 from .decorators import *
 import tuned.logs
 from tuned.utils.nettool import ethcard
@@ -11,7 +11,7 @@ log = tuned.logs.get()
 
 WOL_VALUES = "pumbagsd"
 
-class NetTuningPlugin(base.Plugin):
+class NetTuningPlugin(hotplug.Plugin):
 	"""
 	`net`::
 	

--- a/tuned/profiles/functions/function_cpulist2devs.py
+++ b/tuned/profiles/functions/function_cpulist2devs.py
@@ -1,0 +1,17 @@
+import tuned.logs
+from . import base
+
+log = tuned.logs.get()
+
+class cpulist2devs(base.Function):
+	"""
+	Conversion function: converts CPU list to device strings
+	"""
+	def __init__(self):
+		# arbitrary number of arguments
+		super(cpulist2devs, self).__init__("cpulist2devs", 0)
+
+	def execute(self, args):
+		if not super(cpulist2devs, self).execute(args):
+			return None
+		return self._cmd.cpulist2string(self._cmd.cpulist_unpack(",".join(args)), prefix = "cpu")

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -414,8 +414,20 @@ class commands:
 			m |= pow(2, v)
 		return m
 
-	def cpulist2string(self, l):
-		return ",".join(str(v) for v in l)
+	def cpulist2string(self, l, prefix = ""):
+		return ",".join((prefix + str(v)) for v in l)
+
+	# Converts string s consisting of "dev1,dev2,dev3,..." to list ["dev1", "dev2, "dev3", ...],
+	# whitespaces are ignored, cpu lists are supported with the prefix "cpulist:", e.g.
+	# "cpulist:0-2,4" is converted to ["cpu0", "cpu1", "cpu2", "cpu4"]. If device name starts
+	# with "cpulist:" write it as "cpulist:cpulist:". Escape commas in name with the "\,".
+	def devstr2devs(self, s):
+		if s[0:8].lower() == "cpulist:":
+			s = s[8:]
+			if s[0:8].lower() != "cpulist:":
+				return [("cpu" + str(v)) for v in self.cpulist_unpack(s)]
+		l = re.split(r"\s*(?<!\\),\s*", s)
+		return [str(v).replace("\,", ",") for v in l]
 
 	# Do not make balancing on patched Python 2 interpreter (rhbz#1028122).
 	# It means less CPU usage on patchet interpreter. On non-patched interpreter


### PR DESCRIPTION
Extends the runtime API by the method:
```
  instance_acquire_devices(devices, instance_name)
```
E.g. consider the following TuneD profile:
```
[cpus_perf]
type=cpu
devices=cpu0, cpu1
governor=performance

[cpus_idle]
type=cpu
devices=${f:cpulist2devs:2-3}
governor=ondemand

[cpus_idle2]
type=cpu
devices=${f:cpulist2devs:4-5,7}
governor=ondemand
```
Notice that it's possible to use internal function 'cpulist2devs' to easily
specify cpulists.

After the following API call:
```
  instance_acquire_devices("cpulist:2-5,7", "cpus_perf")
```
It will result in cpu0 - cpu5 and cpu7 having the "performance" governor.

It's also possible to specify full device names in the API instead of the
cpulist, e.g.:
```
  instance_acquire_devices("cpu2,cpu3,cpu4,cpu5,cpu7", "cpus_perf")
```
In case the comma is part of the device name, it can be escaped by "\,".

In case the device name starts with the string "cpulist:", e.g. there is
by accident device named "cpulist:abcd", it's possible to use
"cpulist:cpulist:abcd" to escape it and don't recognize it as the cpulist.

The cpulist expand feature also supports bitmasks variant prefixed by the
0x and written as a string, e.g. "0xffffffff", i.e. all the standard
TuneD cpulist syntaxes are supported.

Resolves: rhbz#2113925

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
