### PR TITLE
Allow selecting a different pkg-config executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,12 @@ else
 	GIT_PSUFFIX = .$(GIT_SUFFIX)
 	RPM_VERSION = $(NAME)-$(VERSION)-1$(GIT_PSUFFIX)
 endif
+PKG_CONFIG = pkg-config
 UNITDIR_FALLBACK = /usr/lib/systemd/system
-UNITDIR_DETECT = $(shell pkg-config systemd --variable systemdsystemunitdir || rpm --eval '%{_unitdir}' 2>/dev/null || echo $(UNITDIR_FALLBACK))
+UNITDIR_DETECT = $(shell $(PKG_CONFIG) systemd --variable systemdsystemunitdir || rpm --eval '%{_unitdir}' 2>/dev/null || echo $(UNITDIR_FALLBACK))
 UNITDIR = $(UNITDIR_DETECT:%{_unitdir}=$(UNITDIR_FALLBACK))
 TMPFILESDIR_FALLBACK = /usr/lib/tmpfiles.d
-TMPFILESDIR_DETECT = $(shell pkg-config systemd --variable tmpfilesdir || rpm --eval '%{_tmpfilesdir}' 2>/dev/null || echo $(TMPFILESDIR_FALLBACK))
+TMPFILESDIR_DETECT = $(shell $(PKG_CONFIG) systemd --variable tmpfilesdir || rpm --eval '%{_tmpfilesdir}' 2>/dev/null || echo $(TMPFILESDIR_FALLBACK))
 TMPFILESDIR = $(TMPFILESDIR_DETECT:%{_tmpfilesdir}=$(TMPFILESDIR_FALLBACK))
 VERSIONED_NAME = $(NAME)-$(VERSION)$(PRERELEASE)$(GIT_PSUFFIX)
 


### PR DESCRIPTION
Helpful if you have an arch-prefixed pkg-config, e.g. when cross compiling.

Signed-off-by: Heiko Becker <heirecka@exherbo.org>