### PR TITLE
Add new cpu-partitioning-powersave profile

### DIFF
--- a/profiles/cpu-partitioning-powersave/cpu-partitioning-variables.conf
+++ b/profiles/cpu-partitioning-powersave/cpu-partitioning-variables.conf
@@ -1,0 +1,14 @@
+# Examples:
+# isolated_cores=2,4-7
+# isolated_cores=2-23
+#
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
+# To disable the kernel load balancing in certain isolated CPUs:
+# no_balance_cores=5-10
+
+# Specifies the minimum powerstate for idling cores
+# given to force_latency tuned parameter. To have the same behavior
+# as cpu-partitioning profile, set to "cstate.name:C1|10"
+min_power_state=cstate.name:C3|100

--- a/profiles/cpu-partitioning-powersave/tuned.conf
+++ b/profiles/cpu-partitioning-powersave/tuned.conf
@@ -1,0 +1,23 @@
+# tuned configuration
+#
+
+[main]
+summary=Optimize for CPU partitioning with additional powersave
+include=cpu-partitioning
+
+[variables]
+# User is responsible for updating variables.conf with variable content such as isolated_cores=X-Y
+include=/etc/tuned/cpu-partitioning-variables.conf
+
+min_power_state_assert_check = \\${min_power_state}
+min_power_state = ${min_power_state}
+
+# Fail if min_power_state is not set
+assert1=${f:assertion_non_equal:min_power_state is set:${min_power_state}:${min_power_state_assert_check}}
+
+[cpu]
+force_latency=${min_power_state}
+no_turbo=true
+
+[bootloader]
+cmdline_cpu_part=+nohz=on${cmd_isolcpus} nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=passive nosoftlockup


### PR DESCRIPTION
The new profile sets the intel_acpi driver to passive mode to be able to set the standard acpi governors (ondemand/userspace) and provides more flexibility on the C-states, as it is exposed as a new variable.

It relies on the existing cpu-partitioning profile ; this patch is required to enable further power optimisations in OVS-DPDK and OpenStack.

Signed-off-by: Christophe Fontaine <cfontain@redhat.com>