### PR TITLE
Add new cpu-partitioning-powersave profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ install: install-dirs
 		$(DESTDIR)$(SYSCONFDIR)/tuned/realtime-virtual-host-variables.conf
 	mv $(DESTDIR)$(TUNED_PROFILESDIR)/cpu-partitioning/cpu-partitioning-variables.conf \
 		$(DESTDIR)$(SYSCONFDIR)/tuned/cpu-partitioning-variables.conf
+	mv $(DESTDIR)$(TUNED_PROFILESDIR)/cpu-partitioning-powersave/cpu-partitioning-powersave-variables.conf \
+		$(DESTDIR)$(SYSCONFDIR)/tuned/cpu-partitioning-powersave-variables.conf
 	install -pm 0644 recommend.conf $(DESTDIR)$(TUNED_RECOMMEND_DIR)/50-tuned.conf
 
 	# bash completion

--- a/man/tuned-profiles-cpu-partitioning-powersave.7
+++ b/man/tuned-profiles-cpu-partitioning-powersave.7
@@ -1,0 +1,67 @@
+.\"/*
+.\" * All rights reserved
+.\" * Copyright (C) 2022 Red Hat, Inc.
+.\" * Authors: Christophe Fontaine
+.\" *
+.\" * This program is free software; you can redistribute it and/or
+.\" * modify it under the terms of the GNU General Public License
+.\" * as published by the Free Software Foundation; either version 2
+.\" * of the License, or (at your option) any later version.
+.\" *
+.\" * This program is distributed in the hope that it will be useful,
+.\" * but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" * GNU General Public License for more details.
+.\" *
+.\" * You should have received a copy of the GNU General Public License
+.\" * along with this program; if not, write to the Free Software
+.\" * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+.\" */
+.\"
+.TH TUNED_PROFILES_CPU_PARTITIONING "7" "22 Nov 2022" "TuneD"
+.SH NAME
+tuned\-profiles\-cpu\-partitioning\-powersave - Partition CPUs into isolated and housekeeping with C-States enabled
+
+.SH DESCRIPTION
+The cpu\-partitioning\-powersave profile is similar to cpu\-partitioning profile,
+but gives more flexibility on the C-States configuration.
+
+.SH CONFIGURATION
+The cpu-partitioning-powersave profile is configured by editing the
+.I /etc/tuned/cpu-partitioning-powersave-variables.conf
+file. There are three configuration options:
+
+.TP
+.B isolated_cores=<CPU\-LIST>
+List of CPUs to isolate. This option is mandatory. Any CPUs not in this list
+is automatically considered a housekeeping CPU.
+.TP
+.B no_balance_cores=<CPU\-LIST>
+List of CPUs not be considered by the kernel when doing system wide
+process load\-balancing. Usually, this list should be the same as
+isolated_cores=. This option is optional.
+.TP
+.B max_power_state=<MAX_CSTATE>
+Maximum c-state the cores are allowed to enter. Can be expressed as it's name (C1E)
+or minimum wake-up latency, in micro-seconds.
+This parameter is provided as-is to `force_latency`.
+Default is set to "cstate.name:C1|10" to behave as cpu\-partitioning profile.
+
+
+.SH IMPORTANT NOTES
+
+.IP *
+Same recommendations as tuned\-profiles\-cpu\-partitioning (7) apply.
+
+.SH "FILES"
+.nf
+.I /etc/tuned/cpu\-partitioning\-variables.conf
+.I /etc/tuned/tuned\-main.conf
+
+.SH "SEE ALSO"
+.BR tuned (8)
+.BR tuned\-adm (8)
+.BR tuned\-profiles\-cpu\-partitioning (7)
+.SH AUTHOR
+.nf
+Christophe Fontaine <cfontain@redhat.com>

--- a/profiles/cpu-partitioning-powersave/cpu-partitioning-powersave-variables.conf
+++ b/profiles/cpu-partitioning-powersave/cpu-partitioning-powersave-variables.conf
@@ -1,0 +1,14 @@
+# Examples:
+# isolated_cores=2,4-7
+# isolated_cores=2-23
+#
+# Reserve 1 core per socket for housekeeping, isolate the rest.
+isolated_cores=${f:calc_isolated_cores:1}
+
+# To disable the kernel load balancing in certain isolated CPUs:
+# no_balance_cores=5-10
+
+# Specifies the maximum powerstate for idling cores.
+# given to force_latency tuned parameter. To have the same behavior
+# as cpu-partitioning profile, set to "cstate.name:C1|10"
+max_power_state=cstate.name:C1|10

--- a/profiles/cpu-partitioning-powersave/tuned.conf
+++ b/profiles/cpu-partitioning-powersave/tuned.conf
@@ -1,0 +1,31 @@
+# tuned configuration
+#
+
+[main]
+summary=Optimize for CPU partitioning with additional powersave
+include=cpu-partitioning
+
+[variables]
+# User is responsible for updating variables.conf with variable content such as isolated_cores=X-Y
+include=/etc/tuned/cpu-partitioning-powersave-variables.conf
+
+isolated_cores_assert_check = \\${isolated_cores}
+# Make sure isolated_cores is defined before any of the variables that
+# use it (such as assert1) are defined, so that child profiles can set
+# isolated_cores directly in the profile (tuned.conf)
+isolated_cores = ${isolated_cores}
+# Fail if isolated_cores are not set
+assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
+
+max_power_state_assert_check = \\${max_power_state}
+max_power_state = ${max_power_state}
+
+# Fail if max_power_state is not set
+assert2=${f:assertion_non_equal:max_power_state is set:${max_power_state}:${max_power_state_assert_check}}
+
+[cpu]
+force_latency=${max_power_state}
+no_turbo=true
+
+[bootloader]
+cmdline_cpu_part=+nohz=on${cmd_isolcpus} nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=passive nosoftlockup

--- a/tuned.spec
+++ b/tuned.spec
@@ -406,6 +406,7 @@ fi
 %exclude %{_sysconfdir}/tuned/realtime-virtual-guest-variables.conf
 %exclude %{_sysconfdir}/tuned/realtime-virtual-host-variables.conf
 %exclude %{_sysconfdir}/tuned/cpu-partitioning-variables.conf
+%exclude %{_sysconfdir}/tuned/cpu-partitioning-powersave-variables.conf
 %exclude %{_prefix}/lib/tuned/default
 %exclude %{_prefix}/lib/tuned/desktop-powersave
 %exclude %{_prefix}/lib/tuned/laptop-ac-powersave
@@ -423,6 +424,7 @@ fi
 %exclude %{_prefix}/lib/tuned/realtime-virtual-guest
 %exclude %{_prefix}/lib/tuned/realtime-virtual-host
 %exclude %{_prefix}/lib/tuned/cpu-partitioning
+%exclude %{_prefix}/lib/tuned/cpu-partitioning-powersave
 %exclude %{_prefix}/lib/tuned/spectrumscale-ece
 %exclude %{_prefix}/lib/tuned/postgresql
 %exclude %{_prefix}/lib/tuned/openshift
@@ -524,8 +526,11 @@ fi
 
 %files profiles-cpu-partitioning
 %config(noreplace) %{_sysconfdir}/tuned/cpu-partitioning-variables.conf
+%config(noreplace) %{_sysconfdir}/tuned/cpu-partitioning-powersave-variables.conf
 %{_prefix}/lib/tuned/cpu-partitioning
+%{_prefix}/lib/tuned/cpu-partitioning-powersave
 %{_mandir}/man7/tuned-profiles-cpu-partitioning.7*
+%{_mandir}/man7/tuned-profiles-cpu-partitioning-powersave.7*
 
 %files profiles-spectrumscale
 %{_prefix}/lib/tuned/spectrumscale-ece


### PR DESCRIPTION
The new profile sets the intel_acpi driver to passive mode to be able to set the standard acpi governors (ondemand/userspace) and provides more flexibility on the C-states, as it is exposed as a new variable.

Signed-off-by: Christophe Fontaine <cfontain@redhat.com>