### PR TITLE
Fix for catching exceptions in profile loader.

### DIFF
--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -100,7 +100,7 @@ class Loader(object):
 			config_obj.optionxform=str
 			with open(file_name) as f:
 				config_obj.read_file(f, file_name)
-		except Error as e:
+		except Error.__bases__ as e:
 			raise InvalidProfileException("Cannot parse '%s'." % file_name, e)
 
 		config = collections.OrderedDict()


### PR DESCRIPTION
This was caused by wrong inheritance of exceptions.

Resolves: rhbz#2071418

Signed-off-by: Jan Zerdik <jzerdik@redhat.com>