### PR TITLE
configparser: use no strict parser to mimic old behavior

### DIFF
--- a/tuned/gtk/gui_plugin_loader.py
+++ b/tuned/gtk/gui_plugin_loader.py
@@ -76,7 +76,7 @@ class GuiPluginLoader():
         """
 
         try:
-            config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+            config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
             config_parser.optionxform = str
             with open(file_name) as f:
                 config_parser.read_string("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read(), file_name)

--- a/tuned/gtk/gui_profile_loader.py
+++ b/tuned/gtk/gui_profile_loader.py
@@ -62,7 +62,7 @@ class GuiProfileLoader(object):
 
         if profilePath == tuned.consts.LOAD_DIRECTORIES[1]:
             file_path = profilePath + '/' + profile_name + '/' + tuned.consts.PROFILE_FILE
-            config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+            config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
             config_parser.optionxform = str
             config_parser.read_string(config)
 
@@ -84,7 +84,7 @@ class GuiProfileLoader(object):
 
     def load_profile_config(self, profile_name, path):
         conf_path = path + '/' + profile_name + '/' + tuned.consts.PROFILE_FILE
-        config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+        config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
         config.optionxform = str
         profile_config = collections.OrderedDict()
         with open(conf_path) as f:

--- a/tuned/gtk/gui_profile_saver.py
+++ b/tuned/gtk/gui_profile_saver.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 	if not os.path.exists(profile_dict['filename']):
 		os.makedirs(os.path.dirname(profile_dict['filename']))
 
-	profile_configobj = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+	profile_configobj = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
 	profile_configobj.optionxform = str
 	for section, options in profile_dict['main'].items():
 		profile_configobj.add_section(section)

--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -96,7 +96,7 @@ class Loader(object):
 
 	def _load_config_data(self, file_name):
 		try:
-			config_obj = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+			config_obj = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
 			config_obj.optionxform=str
 			with open(file_name) as f:
 				config_obj.read_file(f, file_name)

--- a/tuned/profiles/locator.py
+++ b/tuned/profiles/locator.py
@@ -55,7 +55,7 @@ class Locator(object):
 		if config_file is None:
 			return None
 		try:
-			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), allow_no_value=True)
+			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), allow_no_value=True, strict=False)
 			config.optionxform = str
 			with open(config_file) as f:
 				config.read_string("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read())

--- a/tuned/profiles/variables.py
+++ b/tuned/profiles/variables.py
@@ -45,7 +45,7 @@ class Variables():
 			log.error("unable to find variables_file: '%s'" % filename)
 			return
 		try:
-			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), allow_no_value=True)
+			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), allow_no_value=True, strict=False)
 			config.optionxform = str
 			with open(filename) as f:
 				config.read_string("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read(), filename)

--- a/tuned/utils/config_parser.py
+++ b/tuned/utils/config_parser.py
@@ -21,7 +21,7 @@ else:
 
 	class ConfigParser(cp.ConfigParser):
 
-		def __init__(self, delimiters=None, inline_comment_prefixes=None, strict=True, *args, **kwargs):
+		def __init__(self, delimiters=None, inline_comment_prefixes=None, *args, **kwargs):
 			delims = "".join(list(delimiters))
 			# REs taken from the python-2.7 ConfigParser
 			self.OPTCRE = re.compile(

--- a/tuned/utils/global_config.py
+++ b/tuned/utils/global_config.py
@@ -39,7 +39,7 @@ class GlobalConfig():
 		"""
 		log.debug("reading and parsing global configuration file '%s'" % file_name)
 		try:
-			config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+			config_parser = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
 			config_parser.optionxform = str
 			with open(file_name) as f:
 				config_parser.read_string("[" + consts.MAGIC_HEADER_NAME + "]\n" + f.read(), file_name)

--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -60,7 +60,7 @@ class ProfileRecommender:
 		try:
 			if not os.path.isfile(fname):
 				return None
-			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'))
+			config = ConfigParser(delimiters=('='), inline_comment_prefixes=('#'), strict=False)
 			config.optionxform = str
 			with open(fname) as f:
 				config.read_file(f, fname)


### PR DESCRIPTION
Now it should allow duplicate options and sections in the INI files, the latest value is taken, the previous values are ignored, e.g.:

[selinux]
avc_cache_threshold=4096
avc_cache_threshold=8192

The avc_cache_threshold will be set to the 8192.

Related: rhbz#2071418

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>