### PR TITLE
throughput-performance: set net.core.somaxconn to at least 2048

### DIFF
--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -58,6 +58,11 @@ vm.dirty_background_ratio = 10
 # and move them to swap cache
 vm.swappiness=10
 
+# The default kernel value 128 was over twenty years old default,
+# kernel-5.4 increased it to 4096, thus do not have it lower than 2048
+# on older kernels
+net.core.somaxconn=>2048
+
 # Marvell ThunderX
 [sysctl.thunderx]
 type=sysctl


### PR DESCRIPTION
Resolves: rhbz#1998310

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>