### PR TITLE
Report reapplied sysctls only on different values

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -151,7 +151,7 @@ def _apply_sysctl_config_line(path, lineno, line, instance_sysctl):
 				% (path, lineno))
 		return
 	value = value.strip()
-	if option in instance_sysctl:
+	if option in instance_sysctl and instance_sysctl[option] != value:
 		log.info("Overriding sysctl parameter '%s' from '%s' to '%s'"
 				% (option, instance_sysctl[option], value))
 


### PR DESCRIPTION
PR492 introduced reporting on reapplied sysctls.  While it is a useful functionality to get notified about potential conflicts between filesystem-level and TuneD-level settings, it can generate a lot of noise when these settings are equal.  Report reapplied sysctls only when filesystem-level and TuneD-level settings differ.

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>