### PR TITLE
tuned-adm: better error message for unauthorized switch_profile

### DIFF
--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -249,7 +249,7 @@ class Admin(object):
 				self._error("Cannot enable the tuning.")
 				ret = False
 		else:
-			self._error(msg)
+			self._error("Unable to switch profile: %s" % msg)
 		return ret
 
 	def _action_dbus_wait_profile(self, profile_name):


### PR DESCRIPTION
As a sideeffect of 08b348b7a4b1a5d94bea160fecea4a2759b01a9d we got strange error messages for unauthorized switch_profile requests. This commit tries to improve it.