### PR TITLE
set the icon in the about dialog

### DIFF
--- a/tuned-gui.py
+++ b/tuned-gui.py
@@ -834,6 +834,7 @@ class Base(object):
 
 	def _build_about_dialog(self):
 		self.about_dialog = Gtk.AboutDialog.new()
+		self.about_dialog.set_logo_icon_name(NAME)
 		self.about_dialog.set_name(NAME)
 		self.about_dialog.set_version(VERSION)
 		self.about_dialog.set_license(LICENSE)


### PR DESCRIPTION
otherwise we just get the "image missing" icon