### PR TITLE
Allow to skip channels parameter in realtime profiles just by changing variables config.

### DIFF
--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -18,5 +18,6 @@ isolate_managed_irq=Y
 # below. Ideally this should be set to the number of housekeeping CPUs i.e.,
 # in the example given below it is assumed that the system has 4 housekeeping
 # (non-isolated) CPUs.
+# When set to "None" the parameter is skipped.
 #
 # netdev_queue_count=4

--- a/profiles/realtime/tuned.conf
+++ b/profiles/realtime/tuned.conf
@@ -36,7 +36,7 @@ isolate_managed_irq = ${isolate_managed_irq}
 managed_irq=${f:regex_search_ternary:${isolate_managed_irq}:\b[y,Y,1,t,T]\b:managed_irq,domain,:}
 
 [net]
-channels=combined ${f:check_net_queue_count:${netdev_queue_count}}
+channels=${f:regex_search_ternary:${netdev_queue_count}:^[Nn][Oo][Nn][Ee]$::combined ${f:check_net_queue_count:${netdev_queue_count}}}
 
 [sysctl]
 kernel.hung_task_timeout_secs = 600

--- a/tuned/profiles/functions/function_check_net_queue_count.py
+++ b/tuned/profiles/functions/function_check_net_queue_count.py
@@ -17,6 +17,9 @@ class check_net_queue_count(base.Function):
 			return None
 		if args[0].isdigit():
 			return args[0]
+		# Check for none to get rid of WARN log
+		if args[0].lower() == "none":
+			return None
 		(ret, out) = self._cmd.execute(["nproc"])
 		log.warn("net-dev queue count is not correctly specified, setting it to HK CPUs %s" % (out))
 		return out


### PR DESCRIPTION
Related: rhbz#2148990