### PR TITLE
plugin_net: expand variables properly

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -329,6 +329,8 @@ class NetTuningPlugin(hotplug.Plugin):
 	# parse features/coalesce config parameters (those defined in profile configuration)
 	# context is for error message
 	def _parse_config_parameters(self, value, context):
+		# expand config variables
+		value = self._variables.expand(value)
 		# split supporting various dellimeters
 		v = str(re.sub(r"(:\s*)|(\s+)|(\s*;\s*)|(\s*,\s*)", " ", value)).split()
 		lv = len(v)


### PR DESCRIPTION
plugin_net: expand variables properly
When attempting verification for the realtime profile, the following error was observed:
ERROR    tuned.plugins.plugin_net: unknown channels parameter(s): {'check_net_queue_count'}

This seems to be because this line:
channels=combined ${f:check_net_queue_count:${netdev_queue_count}} in /usr/lib/tuned/realtime/tuned.conf is not correctly parsed.

This should be evaluated out to "channels=combined N", where "${f:check_net_queue_count:${netdev_queue_count}}" is replaced by the value of netdev_queue_count in /etc/tuned/realtime-variables.conf.

However, the observed error is becaused this line is split on delimiters such as ':', and the whole thing gets jumbled up - instead of evaluating the function to a number.

We fix can this issue by properly evaluating config file functions in plugin_net.py.