### PR TITLE
Add rollback_on_exit option

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -75,3 +75,10 @@ log_file_max_size = 1MB
 # Size of connections backlog for listen function on socket
 # Higher value allows to process requests from more clients
 # connections_backlog = 1024
+
+# TuneD daemon rollback strategy. Supported values: auto|not_on_exit
+# - auto: rollbacks are always performed on a profile switch or 
+#   graceful TuneD process exit
+# - not_on_exit: rollbacks are always performed on a profile
+#   switch, but not on any kind of TuneD process exit
+# rollback = auto

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -79,6 +79,9 @@ SYSTEM_RELEASE_FILE = "/etc/system-release-cpe"
 FUNCTION_PREFIX = "function_"
 # prefix for exported environment variables when calling scripts
 ENV_PREFIX = "TUNED_"
+ROLLBACK_NOT_ON_EXIT = 0
+ROLLBACK_SOFT = 1
+ROLLBACK_FULL = 2
 
 # tuned-gui
 PREFIX_PROFILE_FACTORY = "System"
@@ -108,6 +111,7 @@ CFG_UNIX_SOCKET_OWNERSHIP = "unix_socket_ownership"
 CFG_UNIX_SOCKET_PERMISIONS = "unix_socket_permissions"
 CFG_UNIX_SOCKET_CONNECTIONS_BACKLOG = "connections_backlog"
 CFG_CPU_EPP_FLAG = "hwp_epp"
+CFG_ROLLBACK = "rollback"
 
 # no_daemon mode
 CFG_DEF_DAEMON = True
@@ -155,6 +159,8 @@ CFG_DEF_UNIX_SOCKET_PERMISIONS = "0o600"
 # default unix socket conections backlog
 CFG_DEF_UNIX_SOCKET_CONNECTIONS_BACKLOG = "1024"
 CFG_FUNC_UNIX_SOCKET_CONNECTIONS_BACKLOG = "getint"
+# default rollback strategy
+CFG_DEF_ROLLBACK = "auto"
 
 PATH_CPU_DMA_LATENCY = "/dev/cpu_dma_latency"
 

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -117,13 +117,13 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 		return self._daemon.start()
 
 	@exports.export("", "b")
-	def stop(self, caller = None):
+	def stop(self, caller = None, profile_switch = False):
 		if caller == "":
 			return False
 		if not self._daemon.is_running():
 			res = True
 		else:
-			res = self._daemon.stop()
+			res = self._daemon.stop(profile_switch = profile_switch)
 		self._timer_store.cancel_all()
 		return res
 
@@ -132,7 +132,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 		if caller == "":
 			return False
 		if self._daemon.is_running():
-			stop_ok = self.stop()
+			stop_ok = self.stop(profile_switch = True)
 			if not stop_ok:
 				return False
 		try:

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -212,7 +212,7 @@ class Plugin(object):
 	def _instance_post_static(self, instance, enabling):
 		pass
 
-	def _call_device_script(self, instance, script, op, devices, full_rollback = False):
+	def _call_device_script(self, instance, script, op, devices, full_rollback = consts.ROLLBACK_SOFT):
 		if script is None:
 			return None
 		if len(devices) == 0:
@@ -228,7 +228,7 @@ class Plugin(object):
 			environ = os.environ
 			environ.update(self._variables.get_env())
 			arguments = [op]
-			if full_rollback:
+			if full_rollback == consts.ROLLBACK_FULL:
 				arguments.append("full_rollback")
 			arguments.append(dev)
 			log.info("calling script '%s' with arguments '%s'" % (script, str(arguments)))
@@ -298,10 +298,13 @@ class Plugin(object):
 		if instance.has_dynamic_tuning and self._global_cfg.get(consts.CFG_DYNAMIC_TUNING, consts.CFG_DEF_DYNAMIC_TUNING):
 			self._run_for_each_device(instance, self._instance_update_dynamic, instance.processed_devices.copy())
 
-	def instance_unapply_tuning(self, instance, full_rollback = False):
+	def instance_unapply_tuning(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		"""
 		Remove all tunings applied by the plugin instance.
 		"""
+		if full_rollback == consts.ROLLBACK_NOT_ON_EXIT:
+			return
+
 		if instance.has_dynamic_tuning and self._global_cfg.get(consts.CFG_DYNAMIC_TUNING, consts.CFG_DEF_DYNAMIC_TUNING):
 			self._run_for_each_device(instance, self._instance_unapply_dynamic, instance.processed_devices)
 		if instance.has_static_tuning:
@@ -325,7 +328,7 @@ class Plugin(object):
 			ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		self._cleanup_all_device_commands(instance,
 				instance.processed_devices)
 		self._cleanup_all_non_device_commands(instance)

--- a/tuned/plugins/instance/instance.py
+++ b/tuned/plugins/instance/instance.py
@@ -1,3 +1,5 @@
+import tuned.consts as consts
+
 class Instance(object):
 	"""
 	"""
@@ -83,7 +85,7 @@ class Instance(object):
 	def update_tuning(self):
 		self._plugin.instance_update_tuning(self)
 
-	def unapply_tuning(self, full_rollback = False):
+	def unapply_tuning(self, full_rollback = consts.ROLLBACK_SOFT):
 		self._plugin.instance_unapply_tuning(self, full_rollback)
 
 	def destroy(self):

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -391,8 +391,8 @@ class BootloaderPlugin(base.Plugin):
 		self._rpm_ostree_kargs(append=self._options_to_dict(deleted), delete=self._options_to_dict(appended))
 		self._patch_bootcmdline({consts.BOOT_CMDLINE_TUNED_VAR: "", consts.BOOT_CMDLINE_KARGS_DELETED_VAR: ""})
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		if full_rollback and not self._skip_grub_config_val:
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
+		if full_rollback == consts.ROLLBACK_FULL and not self._skip_grub_config_val:
 			if self._rpm_ostree:
 				log.info("removing rpm-ostree tuning previously added by Tuned")
 				self._remove_rpm_ostree_tuning()

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -377,7 +377,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 			self._no_turbo_save = self._getset_intel_pstate_attr(
 				"no_turbo", new_value)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		super(CPULatencyPlugin, self)._instance_unapply_static(instance, full_rollback)
 
 		if instance._first_instance and self._has_intel_pstate:

--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -134,8 +134,8 @@ class ModulesPlugin(base.Plugin):
 								ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		if full_rollback:
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
+		if full_rollback == consts.ROLLBACK_FULL:
 			self._clear_modprobe_file()
 
 	def _clear_modprobe_file(self):

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -1003,7 +1003,7 @@ class SchedulerPlugin(base.Plugin):
 		for cg in self._cgroups:
 			self._cgroup_cleanup_tasks_one(cg)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		super(SchedulerPlugin, self)._instance_unapply_static(instance, full_rollback)
 		if self._daemon and instance._runtime_tuning:
 			instance._terminate.set()

--- a/tuned/plugins/plugin_script.py
+++ b/tuned/plugins/plugin_script.py
@@ -113,9 +113,9 @@ class ScriptPlugin(base.Plugin):
 			ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		args = ["stop"]
-		if full_rollback:
+		if full_rollback == consts.ROLLBACK_FULL:
 			args = args + ["full_rollback"]
 		self._call_scripts(reversed(instance._scripts), args)
 		super(ScriptPlugin, self)._instance_unapply_static(instance, full_rollback)

--- a/tuned/plugins/plugin_service.py
+++ b/tuned/plugins/plugin_service.py
@@ -313,7 +313,7 @@ class ServicePlugin(base.Plugin):
 				ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		for name, value in list(instance._services_original.items()):
 			if value.cfg_file:
 				self._init_handler.cfg_uninstall(name, value.cfg_file)

--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -98,7 +98,7 @@ class SysctlPlugin(base.Plugin):
 					ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		for option, value in list(instance._sysctl_original.items()):
 			_write_sysctl(option, value)
 

--- a/tuned/plugins/plugin_sysfs.py
+++ b/tuned/plugins/plugin_sysfs.py
@@ -4,6 +4,7 @@ import re
 import os.path
 from .decorators import *
 import tuned.logs
+import tuned.consts as consts
 from subprocess import *
 from tuned.utils.commands import commands
 
@@ -71,7 +72,7 @@ class SysfsPlugin(base.Plugin):
 						ret = False
 		return ret
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
 		for key, value in list(instance._sysfs_original.items()):
 			self._write_sysfs(key, value)
 

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -111,8 +111,8 @@ class SystemdPlugin(base.Plugin):
 				conf = self._add_keyval(conf, consts.SYSTEMD_CPUAFFINITY_VAR, cpu_affinity_saved)
 			self._write_systemd_system_conf(conf)
 
-	def _instance_unapply_static(self, instance, full_rollback = False):
-		if full_rollback:
+	def _instance_unapply_static(self, instance, full_rollback = consts.ROLLBACK_SOFT):
+		if full_rollback == consts.ROLLBACK_FULL:
 			log.info("removing '%s' systemd tuning previously added by TuneD" % consts.SYSTEMD_CPUAFFINITY_VAR)
 			self._remove_systemd_tuning()
 			log.console("you may need to manualy run 'dracut -f' to update the systemd configuration in initrd image")

--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -161,15 +161,15 @@ class Manager(object):
 			self._try_call("update_tuning", None,
 					instance.update_tuning)
 
-	# full_rollback is a helper telling plugins whether soft or full roll
-	# back is needed, e.g. for bootloader plugin we need e.g grub.cfg
+	# full_rollback is a helper telling plugins whether soft or full
+	# rollback is needed, e.g. for bootloader plugin we need grub.cfg
 	# tuning to persist across reboots and restarts of the daemon, so in
-	# this case the full_rollback is usually set to False,  but we also
-	# need to clean it all up when TuneD is disabled or the profile is
-	# changed. In this case the full_rollback is set to True. In practice
-	# it means to remove all temporal or helper files, unpatch third
-	# party config files, etc.
-	def stop_tuning(self, full_rollback = False):
+	# this case the full_rollback is usually set to consts.ROLLBACK_SOFT,
+	# but we also need to clean it all up when TuneD is disabled or the
+	# profile is changed. In this case the full_rollback is set to
+	# consts.ROLLBACK_FULL. In practice it means to remove all temporal
+	# or helper files, unpatch third party config files, etc.
+	def stop_tuning(self, full_rollback = consts.ROLLBACK_SOFT):
 		self._hardware_inventory.stop_processing_events()
 		for instance in reversed(self._instances):
 			self._try_call("stop_tuning", None,


### PR DESCRIPTION
Add rollback option to tuned-main.conf file.  The option specifies how
TuneD should perform rollbacks.  By default, the old behaviour is
preserved (rollback=auto) and settings are rolled back on TuneD daemon
exit and profile switches.  Using rollback=not_on_exit will result in
TuneD not performing any rollbacks on the daemon exit, however, on
profile switches, settings rollbacks will still be performed.

Resolves: rhbz#2203142