### PR TITLE
RHEL-3689: Print all arguments of failing command in err_msg

### DIFF
--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -235,13 +235,13 @@ class commands:
 				err_out = err[:-1]
 				if len(err_out) == 0:
 					err_out = out[:-1]
-				err_msg = "Executing %s error: %s" % (args[0], err_out)
+				err_msg = "Executing '%s' error: %s" % (' '.join(args), err_out)
 				if not return_err:
 					self._error(err_msg)
 		except (OSError, IOError) as e:
 			retcode = -e.errno if e.errno is not None else -1
 			if not abs(retcode) in no_errors and not 0 in no_errors:
-				err_msg = "Executing %s error: %s" % (args[0], e)
+				err_msg = "Executing '%s' error: %s" % (' '.join(args), e)
 				if not return_err:
 					self._error(err_msg)
 		if return_err:


### PR DESCRIPTION
Improve error log by printing all arguments passed to command. 
This helps in troubleshooting issues where just knowing the command is not enough, we need more details on which settings, devices and options has caused this error.
Without fix:
~~~
ERROR    tuned.utils.commands: Executing ethtool error: netlink error: requested channel count exceeds maximum (offset 40)
~~~

With fix:

~~~
From logs we can easily identify the complete command which failed, this would also show us the device name.

 ERROR    tuned.utils.commands: Executing ethtool -L ens3 combined 2 error: netlink error: requested channel count exceeds maximum (offset 36) netlink error: Invalid argument 

~~~