### PR TITLE
style: fix inconsistent whitespace in plugin_cpu.py

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -240,15 +240,15 @@ class CPULatencyPlugin(hotplug.Plugin):
 		self._arch = platform.machine()
 
 		if self._arch in intel_archs:
-                        # Possible other x86 vendors (from arch/x86/kernel/cpu/*):
-                        # "CentaurHauls", "CyrixInstead", "Geode by NSC", "HygonGenuine", "GenuineTMx86",
-                        # "TransmetaCPU", "UMC UMC UMC"
+			# Possible other x86 vendors (from arch/x86/kernel/cpu/*):
+			# "CentaurHauls", "CyrixInstead", "Geode by NSC", "HygonGenuine", "GenuineTMx86",
+			# "TransmetaCPU", "UMC UMC UMC"
 			cpu = procfs.cpuinfo()
 			vendor = cpu.tags.get("vendor_id")
 			if vendor == "GenuineIntel":
-			        self._is_intel = True
+				self._is_intel = True
 			elif vendor == "AuthenticAMD" or vendor == "HygonGenuine":
-			        self._is_amd = True
+				self._is_amd = True
 			else:
 				# We always assign Intel, unless we know better
 				self._is_intel = True


### PR DESCRIPTION
Mixed indentation, tabs and spaces. Python does not mind, but Code/Pylance complains about it:

![image](https://github.com/redhat-performance/tuned/assets/9947351/3b110fae-e91c-4a47-b4d9-527695b7473b)
