### PR TITLE
Allow equal characters in kernel module parameter value

### DIFF
--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -124,7 +124,7 @@ class ModulesPlugin(base.Plugin):
 				log.info(consts.STR_VERIFY_PROFILE_OK % "module '%s' is loaded" % module)
 				l = r.split(v)
 				for item in l:
-					arg = item.split("=")
+					arg = item.split("=", 1)
 					if len(arg) != 2:
 						log.warn("unrecognized module option for module '%s': %s" % (module, item))
 					else:


### PR DESCRIPTION
this fixes tuned verification when configuring module parameters such as:

    onload=cplane_server_params=--affinity=0x100000000

Tuned correctly sets them like this:

    $ cat /etc/modprobe.d/tuned.conf
    options onload cplane_server_params=--affinity=0x100000000
    $ cat /sys/module/onload/parameters/cplane_server_params
    --affinity=0x100000000

However, before this change tuned reports verification failure whenever a parameter value contains an equal sign.