### PR TITLE
Add a tuned-adm command for moving devices between plugin instances

### DIFF
--- a/man/tuned-adm.8
+++ b/man/tuned-adm.8
@@ -24,7 +24,7 @@
 tuned\-adm - command line tool for switching between different tuning profiles
 .SH SYNOPSIS
 .B tuned\-adm
-.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | " auto_profile " | " profile_mode " | " "verify \fI[\-i | \-\-ignore\-missing]\fP" " | " recommend ]
+.RB [ list " | " active " | " "profile \fI[profile]\fP..." " | " "profile_info \fI[profile]\fP..." " | " off " | " auto_profile " | " profile_mode " | " "verify \fI[\-i | \-\-ignore\-missing]\fP" " | " recommend " | " "instance_acquire_devices \fIdevices\fP \fIinstance\fP" ]
 
 .SH DESCRIPTION
 This command line utility allows you to switch between user definable tuning
@@ -109,6 +109,15 @@ Enable automatic profile selection mode, switch to the recommended profile.
 .TP
 .B profile_mode
 Show current profile selection mode.
+
+.TP
+.B "instance_acquire_devices \fIdevices\fP \fIinstance\fP"
+Move all provided \fIdevices\fP under the given plugin \fIinstance\fP. The plugin
+instance is identified using its name from the TuneD profile.
+
+The devices are specified using a comma-separated list. When moving a set of CPUs,
+it is possible to use the cpulist syntax by including the 'cpulist:' prefix.
+For instance, 'cpulist:0,2-4' will move the devices cpu0, cpu1, cpu2, and cpu4.
 
 .TP
 .B off

--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -97,6 +97,11 @@ if __name__ == "__main__":
 	parser_profile_mode = subparsers.add_parser("profile_mode", help="show current profile selection mode")
 	parser_profile_mode.set_defaults(action="profile_mode")
 
+	parser_instance_acquire_devices = subparsers.add_parser("instance_acquire_devices", help="acquire devices from other instances and assign them to the given instance")
+	parser_instance_acquire_devices.set_defaults(action="instance_acquire_devices")
+	parser_instance_acquire_devices.add_argument("devices", metavar="devices", type=str, help="comma-separated list of device names; may use the cpulist syntax if prefixed with 'cpulist:'")
+	parser_instance_acquire_devices.add_argument("instance", metavar="instance", type=str, help="name of the plugin instance which should acquire the devices")
+
 	args = parser.parse_args(sys.argv[1:])
 
 	options = vars(args)

--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -439,3 +439,13 @@ class Admin(object):
 	def _action_list_plugins(self, verbose=False):
 		print("Not supported in no_daemon mode.")
 		return False
+
+	def _action_dbus_instance_acquire_devices(self, devices, instance):
+		(ret, msg) = self._controller.instance_acquire_devices(devices, instance)
+		if not ret:
+			self._error("Unable to acquire devices: %s" % msg)
+		return self._controller.exit(ret)
+
+	def _action_instance_acquire_devices(self, devices, instance):
+		print("Not supported in no_daemon mode.")
+		return False

--- a/tuned/admin/dbus_controller.py
+++ b/tuned/admin/dbus_controller.py
@@ -163,6 +163,9 @@ class DBusController(object):
 		"""
 		return self._call("get_plugin_hints", plugin_name)
 
+	def instance_acquire_devices(self, devices, instance):
+		return self._call("instance_acquire_devices", devices, instance)
+
 	def exit(self, ret):
 		self.set_action(None)
 		self._ret = ret


### PR DESCRIPTION
Resolves: RHEL-15141

Until now, this was only possible by manually sending a message to TuneD via the DBus API.