### PR TITLE
Fixed REs escape sequences not to trigger SyntaxWarning

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -373,7 +373,7 @@ class BootloaderPlugin(base.Plugin):
 			log.info("cannot find grub.cfg to patch")
 			return
 		for f in self._grub2_cfg_file_names:
-			self._cmd.add_modify_option_in_file(f, {"set\s+" + consts.GRUB2_TUNED_VAR : "", "set\s+" + consts.GRUB2_TUNED_INITRD_VAR : ""}, add = False)
+			self._cmd.add_modify_option_in_file(f, {r"set\s+" + consts.GRUB2_TUNED_VAR : "", r"set\s+" + consts.GRUB2_TUNED_INITRD_VAR : ""}, add = False)
 		if self._initrd_dst_img_val is not None:
 			log.info("removing initrd image '%s'" % self._initrd_dst_img_val)
 			self._cmd.unlink(self._initrd_dst_img_val)
@@ -403,9 +403,9 @@ class BootloaderPlugin(base.Plugin):
 
 	def _grub2_cfg_unpatch(self, grub2_cfg):
 		log.debug("unpatching grub.cfg")
-		cfg = re.sub(r"^\s*set\s+" + consts.GRUB2_TUNED_VAR + "\s*=.*\n", "", grub2_cfg, flags = re.MULTILINE)
+		cfg = re.sub(r"^\s*set\s+" + consts.GRUB2_TUNED_VAR + "\\s*=.*\n", "", grub2_cfg, flags = re.MULTILINE)
 		grub2_cfg = re.sub(r" *\$" + consts.GRUB2_TUNED_VAR, "", cfg, flags = re.MULTILINE)
-		cfg = re.sub(r"^\s*set\s+" + consts.GRUB2_TUNED_INITRD_VAR + "\s*=.*\n", "", grub2_cfg, flags = re.MULTILINE)
+		cfg = re.sub(r"^\s*set\s+" + consts.GRUB2_TUNED_INITRD_VAR + "\\s*=.*\n", "", grub2_cfg, flags = re.MULTILINE)
 		grub2_cfg = re.sub(r" *\$" + consts.GRUB2_TUNED_INITRD_VAR, "", cfg, flags = re.MULTILINE)
 		cfg = re.sub(consts.GRUB2_TEMPLATE_HEADER_BEGIN + r"\n", "", grub2_cfg, flags = re.MULTILINE)
 		return re.sub(consts.GRUB2_TEMPLATE_HEADER_END + r"\n+", "", cfg, flags = re.MULTILINE)
@@ -480,7 +480,7 @@ class BootloaderPlugin(base.Plugin):
 			grub2_cfg_new = grub2_cfg
 			patch_initial = False
 			for opt in d:
-				(grub2_cfg_new, nsubs) = re.subn(r"\b(set\s+" + opt + "\s*=).*$", r"\1" + "\"" + self._cmd.escape(d[opt]) + "\"", grub2_cfg_new, flags = re.MULTILINE)
+				(grub2_cfg_new, nsubs) = re.subn(r"\b(set\s+" + opt + r"\s*=).*$", r"\1" + "\"" + self._cmd.escape(d[opt]) + "\"", grub2_cfg_new, flags = re.MULTILINE)
 				if nsubs < 1 or re.search(r"\$" + opt, grub2_cfg, flags = re.MULTILINE) is None:
 					patch_initial = True
 

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -349,7 +349,7 @@ class NetTuningPlugin(hotplug.Plugin):
 		# (rhbz#1225375)
 		value = self._cmd.multiple_re_replace({
 			"Adaptive RX:": "adaptive-rx:",
-			"\s+TX:": "\nadaptive-tx:",
+			"\\s+TX:": "\nadaptive-tx:",
 			"rx-frame-low:": "rx-frames-low:",
 			"rx-frame-high:": "rx-frames-high:",
 			"tx-frame-low:": "tx-frames-low:",
@@ -368,7 +368,7 @@ class NetTuningPlugin(hotplug.Plugin):
 			"receive-hashing:": "rxhash:",
 		}, value)
 		# remove empty lines, remove fixed parameters (those with "[fixed]")
-		vl = [v for v in value.split('\n') if len(str(v)) > 0 and not re.search("\[fixed\]$", str(v))]
+		vl = [v for v in value.split('\n') if len(str(v)) > 0 and not re.search(r"\[fixed\]$", str(v))]
 		if len(vl) < 2:
 			return None
 		# skip first line (device name), split to key/value,

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -135,7 +135,7 @@ class SchedulerUtilsSchedutils(SchedulerUtils):
 		return schedutils.get_priority_max(sched)
 
 class SchedulerPlugin(base.Plugin):
-	"""
+	r"""
 	`scheduler`::
 	
 	Allows tuning of scheduling priorities, process/thread/IRQ

--- a/tuned/profiles/functions/functions.py
+++ b/tuned/profiles/functions/functions.py
@@ -46,7 +46,7 @@ class Functions():
 		sl = re.split(r'(?<!\\):', self._str[_from:self._cnt])
 		if sl[0] != "${f":
 			return
-		sl = [str(v).replace("\:", ":") for v in sl]
+		sl = [str(v).replace(r"\:", ":") for v in sl]
 		if not re.match(r'\w+$', sl[1]):
 			log.error("invalid function name '%s'" % sl[1])
 			return

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -29,7 +29,7 @@ class commands:
 		return {"Y":"1", "YES":"1", "T":"1", "TRUE":"1", "N":"0", "NO":"0", "F":"0", "FALSE":"0"}.get(v, value)
 
 	def remove_ws(self, s):
-		return re.sub('\s+', ' ', str(s)).strip()
+		return re.sub(r'\s+', ' ', str(s)).strip()
 
 	def unquote(self, v):
 		return re.sub("^\"(.*)\"$", r"\1", v)
@@ -427,7 +427,7 @@ class commands:
 			if s[0:8].lower() != "cpulist:":
 				return [("cpu" + str(v)) for v in self.cpulist_unpack(s)]
 		l = re.split(r"\s*(?<!\\),\s*", s)
-		return [str(v).replace("\,", ",") for v in l]
+		return [str(v).replace(r"\,", ",") for v in l]
 
 	# Do not make balancing on patched Python 2 interpreter (rhbz#1028122).
 	# It means less CPU usage on patchet interpreter. On non-patched interpreter

--- a/tuned/utils/config_parser.py
+++ b/tuned/utils/config_parser.py
@@ -25,19 +25,19 @@ else:
 			delims = "".join(list(delimiters))
 			# REs taken from the python-2.7 ConfigParser
 			self.OPTCRE = re.compile(
-				r'(?P<option>[^' + delims + '\s][^' + delims + ']*)'
-				r'\s*(?P<vi>[' + delims + '])\s*'
+				r'(?P<option>[^' + delims + r'\s][^' + delims + ']*)'
+				r'\s*(?P<vi>[' + delims + r'])\s*'
 				r'(?P<value>.*)$'
 			)
 			self.OPTCRE_NV = re.compile(
-				r'(?P<option>[^' + delims + '\s][^' + delims + ']*)'
+				r'(?P<option>[^' + delims + r'\s][^' + delims + ']*)'
 				r'\s*(?:'
-				r'(?P<vi>[' + delims + '])\s*'
+				r'(?P<vi>[' + delims + r'])\s*'
 				r'(?P<value>.*))?$'
 			)
 			cp.ConfigParser.__init__(self, *args, **kwargs)
 			self._inline_comment_prefixes = inline_comment_prefixes or []
-			self._re = re.compile("\s+(%s).*" % ")|(".join(list(self._inline_comment_prefixes)))
+			self._re = re.compile(r"\s+(%s).*" % ")|(".join(list(self._inline_comment_prefixes)))
 
 		def read_string(self, string, source="<string>"):
 			sfile = StringIO(string)

--- a/tuned/utils/nettool.py
+++ b/tuned/utils/nettool.py
@@ -116,7 +116,7 @@ class Nettool:
 		p_ethtool = Popen(["ethtool", self._interface], \
 				stdout=PIPE, stderr=PIPE, close_fds=True, \
 				universal_newlines = True)
-		p_filter = Popen(["sed", "s/^\s*//;s/:\s*/:\\n/g"], \
+		p_filter = Popen(["sed", r"s/^\s*//;s/:\s*/:\n/g"], \
 				stdin=p_ethtool.stdout, stdout=PIPE, \
 				universal_newlines = True, \
 				close_fds=True)


### PR DESCRIPTION
Python 3.12 is more strict about correct escaping and outputs SyntaxWarning for invalid escape sequences that were previously silently corrected.