### PR TITLE
profiles: Improve 'isolated_cores=' help text

### DIFF
--- a/profiles/cpu-partitioning/cpu-partitioning-variables.conf
+++ b/profiles/cpu-partitioning/cpu-partitioning-variables.conf
@@ -1,8 +1,17 @@
+#
+# Core isolation
+#
+# The 'isolated_cores=' variable below controls which cores should be
+# isolated. By default we reserve 1 core per socket for housekeeping
+# and isolate the rest. But you can isolate any range as shown in the
+# examples below. Just remember to keep only one isolated_cores= line.
+#
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
 # Reserve 1 core per socket for housekeeping, isolate the rest.
+# Change this for a core list or range as shown above.
 isolated_cores=${f:calc_isolated_cores:1}
 
 # To disable the kernel load balancing in certain isolated CPUs:

--- a/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
+++ b/profiles/realtime-virtual-guest/realtime-virtual-guest-variables.conf
@@ -1,12 +1,21 @@
 #
 # Variable settings below override the definitions from the
 # /etc/tuned/realtime-variables.conf file.
+
+#
+# Core isolation
+#
+# The 'isolated_cores=' variable below controls which cores should be
+# isolated. By default we reserve 1 core per socket for housekeeping
+# and isolate the rest. But you can isolate any range as shown in the
+# examples below. Just remember to keep only one isolated_cores= line.
 #
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
 # Reserve 1 core per socket for housekeeping, isolate the rest.
+# Change this for a core list or range as shown above.
 isolated_cores=${f:calc_isolated_cores:1}
 
 #

--- a/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
+++ b/profiles/realtime-virtual-host/realtime-virtual-host-variables.conf
@@ -1,12 +1,21 @@
 #
 # Variable settings below override the definitions from the
 # /etc/tuned/realtime-variables.conf file.
+
+#
+# Core isolation
+#
+# The 'isolated_cores=' variable below controls which cores should be
+# isolated. By default we reserve 1 core per socket for housekeeping
+# and isolate the rest. But you can isolate any range as shown in the
+# examples below. Just remember to keep only one isolated_cores= line.
 #
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
 # Reserve 1 core per socket for housekeeping, isolate the rest.
+# Change this for a core list or range as shown above.
 isolated_cores=${f:calc_isolated_cores:1}
 
 # Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel

--- a/profiles/realtime/realtime-variables.conf
+++ b/profiles/realtime/realtime-variables.conf
@@ -1,8 +1,17 @@
+#
+# Core isolation
+#
+# The 'isolated_cores=' variable below controls which cores should be
+# isolated. By default we reserve 1 core per socket for housekeeping
+# and isolate the rest. But you can isolate any range as shown in the
+# examples below. Just remember to keep only one isolated_cores= line.
+#
 # Examples:
 # isolated_cores=2,4-7
 # isolated_cores=2-23
 #
 # Reserve 1 core per socket for housekeeping, isolate the rest.
+# Change this for a core list or range as shown above.
 isolated_cores=${f:calc_isolated_cores:1}
 
 #


### PR DESCRIPTION
Just explain what isolated_cores= is for and recommend to only have one isolated_cores= line to avoid wrong system configuration.