### PR TITLE
Add EPP settings to various configurations

### DIFF
--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -12,6 +12,7 @@ cpufreq_conservative=+r
 priority=10
 governor=conservative|powersave
 energy_perf_bias=normal
+energy_performance_preference=balance_performance
 
 [audio]
 timeout=10

--- a/profiles/desktop-powersave/tuned.conf
+++ b/profiles/desktop-powersave/tuned.conf
@@ -6,6 +6,9 @@
 summary=Optmize for the desktop use-case with power saving
 include=server-powersave
 
+[cpu]
+energy_performance_preference=balance_power
+
 [video]
 radeon_powersave=dpm-battery, auto
 

--- a/profiles/latency-performance/tuned.conf
+++ b/profiles/latency-performance/tuned.conf
@@ -9,6 +9,7 @@ summary=Optimize for deterministic performance at the cost of increased power co
 force_latency=cstate.id_no_zero:1|3
 governor=performance
 energy_perf_bias=performance
+energy_performance_preference=performance
 min_perf_pct=100
 
 [sysctl]

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -8,6 +8,7 @@ summary=Optimize for low power consumption
 [cpu]
 governor=ondemand|powersave
 energy_perf_bias=powersave|power
+energy_performance_preference=power
 
 [eeepc_she]
 

--- a/profiles/server-powersave/tuned.conf
+++ b/profiles/server-powersave/tuned.conf
@@ -6,6 +6,7 @@
 summary=Optimize for server power savings
 
 [cpu]
+energy_performance_preference=balance_power
 
 [disk]
 

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -12,6 +12,7 @@ amd_cpuinfo_regex=model name\s+:.*\bAMD\b
 [cpu]
 governor=performance
 energy_perf_bias=performance
+energy_performance_preference=performance
 min_perf_pct=100
 
 # Marvell ThunderX


### PR DESCRIPTION
Resolves https://github.com/redhat-performance/tuned/issues/563
Supersedes https://github.com/redhat-performance/tuned/pull/565

This PR adds energy_performance_preference tunings to various configurations.

Let me know if there are any more configurations that could benefit from this setting CC @yarda 

Setting EPP hints on systems that support `intel-pstate` and `amd-pstate` drivers can significantly reduce power consumption.

See https://www.reddit.com/r/linux/comments/15p4bfs/amd_pstate_and_amd_pstate_epp_scaling_driver/ for a quick explanation of `energy_performance_preference`