### PR TITLE
Expand sysctl plugin options when reporting overrides

### DIFF
--- a/tuned/plugins/plugin_sysctl.py
+++ b/tuned/plugins/plugin_sysctl.py
@@ -150,10 +150,11 @@ class SysctlPlugin(base.Plugin):
 					% (path, lineno))
 			return
 		value = value.strip()
-		if option in instance_sysctl and instance_sysctl[option] != value:
-			log.info("Overriding sysctl parameter '%s' from '%s' to '%s'"
-					% (option, instance_sysctl[option], value))
-
+		if option in instance_sysctl:
+			instance_value = self._variables.expand(instance_sysctl[option])
+			if instance_value != value:
+				log.info("Overriding sysctl parameter '%s' from '%s' to '%s'"
+						% (option, instance_value, value))
 		self._write_sysctl(option, value, ignore_missing = True)
 
 	def _get_sysctl_path(self, option):


### PR DESCRIPTION
When applying system sysctl options, we log when the applied option overrides an option from a TuneD config. The overrided option may be provided as a variable, so we have to expand it before comparing it with the applied option.

Resolves: RHEL-18972