### PR TITLE
Skip calling rpm-ostree kargs in no-op case

### DIFF
--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -304,6 +304,10 @@ class BootloaderPlugin(base.Plugin):
 			kargs.setdefault(k, []).extend(val)
 			appended[k] = val
 
+		if append_params == delete_params:
+			log.info("skipping rpm-ostree kargs - append == deleting (%s)" % append_params)
+			return kargs, appended, deleted
+
 		log.info("rpm-ostree kargs - appending: '%s'; deleting: '%s'" % (append_params, delete_params))
 		(rc, _, err) = self._cmd.execute(['rpm-ostree', 'kargs'] +
 										 ['--append=%s' % v for v in append_params] +


### PR DESCRIPTION
If delete and append kargs args are the same in the same order there is no functional differences so we can safely skip calling rpm-ostree kargs and avoid creating a new rpm-ostree deployment.

Resolves: RHEL-20767
Fixes #585 