### PR TITLE
Drop `-s` from the launch script shebangs

### DIFF
--- a/tuned-ppd.py
+++ b/tuned-ppd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -Es
+#!/usr/bin/python3 -E
 import sys
 import os
 import dbus

--- a/tuned.py
+++ b/tuned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -Es
+#!/usr/bin/python3 -E
 #
 # tuned: daemon for monitoring and adaptive tuning of system devices
 #


### PR DESCRIPTION
Running `make install` as suggested by `INSTALL`  will place all the python modules in /usr/local which won't be included in the search path when `-s` is used in the shebang.

Closes: https://github.com/redhat-performance/tuned/issues/599