### PR TITLE
Disable dynamic tuning by default

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -7,7 +7,7 @@
 daemon = 1
 
 # Dynamicaly tune devices, if disabled only static tuning will be used.
-dynamic_tuning = 1
+dynamic_tuning = 0
 
 # How long to sleep before checking for events (in seconds)
 # higher number means lower overhead but longer response time.


### PR DESCRIPTION
Dynamic tuning is PoC implementation and it can cause many problems especially with some networks drivers where it can interrupt network connections and also with modern CPUs where it can worsen power consumption by limiting CPUs from entering deeper C-states. Now, when TuneD is going to replace power-profiles-daemon these problems can accumulate and cause bad user experience.

RHEL disables dynamic tuning downstream for a long time, so follow it and also disable it by default upstream. People who knows what they are doing can still enable it.

Fixes #588