### PR TITLE
Added intel_recommended_pstate builtin function.

### DIFF
--- a/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/ref_built-in-functions-available-in-tuned-profiles.adoc
@@ -55,3 +55,6 @@ Unpacks a CPU list in the form of `1-3,4` to `1,2,3,4`.
 
 `cpulist_pack`::
 Packs a CPU list in the form of `1,2,3,5` to `1-3,5`.
+
+`intel_recommended_pstate`::
+Returns recommended intel_pstate CPUFreq driver mode based on processor generation.

--- a/tuned/profiles/functions/function_intel_recommended_pstate.py
+++ b/tuned/profiles/functions/function_intel_recommended_pstate.py
@@ -1,0 +1,38 @@
+from . import base
+
+PROCESSOR_NAME = ("sandybridge",
+        "ivybridge",
+        "haswell",
+        "broadwell",
+        "skylake")
+
+PMU_PATH = "/sys/devices/cpu/caps/pmu_name"
+ACTIVE = "active"
+DISABLE = "disable"
+
+class intel_recommended_pstate(base.Function):
+    """
+    Checks the processor code name and return the recommended
+    intel_pstate CPUFreq driver mode. Active is returned for the
+    newer generation of processors not in the PROCESSOR_NAME list.
+
+    Intel recommends to use the intel_pstate CPUFreq driver
+    in active mode with HWP enabled on Ice Lake and later 
+    generations processors. This function allows dynamically 
+    setting intel_pstate based on the processor's model.
+    For pre-IceLake processors setting pstate to active
+    can introduce jitters which were historically seen around
+    and tested with RHEL-7.4. From IceLake generation, intel 
+    has fixed these issues. 
+    """
+    def __init__(self):
+        super(intel_recommended_pstate, self).__init__("intel_recommended_pstate", 0)
+
+    def execute(self, args):
+        if not super(intel_recommended_pstate, self).execute(args):
+            return None
+
+        current_processor_name = self._cmd.read_file(PMU_PATH).strip()
+        if current_processor_name == "" or current_processor_name in PROCESSOR_NAME:
+            return DISABLE
+        return ACTIVE


### PR DESCRIPTION
## What?
Added intel_recommended_pstate builtin function which reads the processor name from pmu file under `/sys/devices`, and returns correct pstate value.

## Why?

Intel recommends to use the intel_pstate CPUFreq driver in active mode with HWP enabled on Ice Lake and later generations processors.This feature allows dynamically setting intel_pstate based on the processor's model. Currently, users need to create a tuned override if they want to set intel_pstate to active even for newer generation processors. For older generation processors setting pstate to active can introduce jitters which were historically seen around and tested with RHEL-7.4.From IceLake generation, intel has fixed these issues.

## How this works?

- With this builtin function it is possible to write now:
```
[variables]
pstate=${f:intel_recommended_pstate}

[bootloader]
cmdline_pstate=+intel_pstate=${pstate}
```
 The builtin function will return value: disable|active based on the processor model and pass the proper intel_pstate value to kernel command line in boot time. The return values are stricter to only disable and active
