### PR TITLE
tuned-ppd: Detect battery change events

### DIFF
--- a/profiles/balanced-battery/tuned.conf
+++ b/profiles/balanced-battery/tuned.conf
@@ -1,0 +1,10 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Balanced profile biased towards power savings changes for battery
+include=balanced
+
+[cpu]
+energy_performance_preference=balance_power

--- a/tuned/ppd/ppd.conf
+++ b/tuned/ppd/ppd.conf
@@ -1,9 +1,14 @@
 [main]
 # The default PPD profile
 default=balanced
+battery_detection=true
 
 [profiles]
 # PPD = TuneD
 power-saver=powersave
 balanced=balanced
 performance=throughput-performance
+
+[battery]
+# PPD = TuneD
+balanced=balanced-battery


### PR DESCRIPTION
power-profiles-daemon has the ability to detect battery change events using upower and to apply different tuned settings based upon whether plugged into power or not.

In PPD this is used specifically to set the energy performance preference differently in the 'balanced' profile, but there is no reason that this concept can't actually apply to all profiles.

Add support for detecting battery change events and apply a profile specified in `ppd.conf` for battery in the different PPD states.

CC @smallorange
