### PR TITLE
plugin_cpu: decrease the severity of _has_pm_qos==False

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -325,7 +325,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 			try:
 				self._cpu_latency_fd = os.open(consts.PATH_CPU_DMA_LATENCY, os.O_WRONLY)
 			except OSError:
-				log.error("Unable to open '%s', disabling PM_QoS control" % consts.PATH_CPU_DMA_LATENCY)
+				log.info("Unable to open '%s', disabling PM_QoS control" % consts.PATH_CPU_DMA_LATENCY)
 				self._has_pm_qos = False
 			self._latency = None
 


### PR DESCRIPTION
The feature depends on kernel configuration (CONFIG_CPU_IDLE). While this seems to be commonly enabled on x86, we've seen ARM systems where it's disabled, and in this case it's perfectly valid for /dev/cpu_dma_latency to be missing.
Since we cannot opt-out of the PM QoS feature in the cpu plugin, this case should not be an error.