### PR TITLE
functions: added 'log' which helps with debugging

### DIFF
--- a/tuned/profiles/functions/function_log.py
+++ b/tuned/profiles/functions/function_log.py
@@ -1,0 +1,19 @@
+import tuned.logs
+from . import base
+
+log = tuned.logs.get()
+
+class execute(base.Function):
+	"""
+	Expands to concatenation of arguments and logs the result, useful for debugging.
+	"""
+	def __init__(self):
+		# unlimited number of arguments, min 1 argument (the value to log)
+		super(execute, self).__init__("log", 0, 1)
+
+	def execute(self, args):
+		if not super(execute, self).execute(args):
+			return None
+		s = "".join(args)
+		log.info(s)
+		return s

--- a/tuned/profiles/functions/functions.py
+++ b/tuned/profiles/functions/functions.py
@@ -56,6 +56,7 @@ class Functions():
 			log.error("function '%s' not implemented" % sl[1])
 			return
 		s = f.execute(sl[2:])
+		log.debug("${f:%s} expands to: '%s'" % (":".join(sl[1:]), s))
 		if s is None:
 			return
 		self._sub(_from, self._cnt, s)


### PR DESCRIPTION
E.g.:
[variables]
dummy=${f:log:${f:exec:uname}}

Logs the output of the 'uname' command to the TuneD log.

Also added more verbose debug output which can help with functions debugging. Enable with 'tuned -D'.