### PR TITLE
Re-check dbus when (re)starting TuneD from tuned-adm profile

### DIFF
--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -125,7 +125,8 @@ if __name__ == "__main__":
 	result = False
 
 	profile_dirs = config.get_list(consts.CFG_PROFILE_DIRS, consts.CFG_DEF_PROFILE_DIRS)
-	dbus = config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON)
+	daemon = config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON)
+	dbus = daemon and config.get_bool(consts.CFG_ENABLE_DBUS, consts.CFG_DEF_ENABLE_DBUS)
 
 	try:
 		admin = tuned.admin.Admin(profile_dirs, dbus, debug, asynco, timeout, log_level)


### PR DESCRIPTION
When TuneD is off, and a profile is applied using `tuned-adm profile`, the command attempts to start it. Before this change, the profile would always be applied via the `active_profile` file.

When TuneD supports DBus, we can change the profile via a DBus call instead, and thus get information about the result. After the restart, I therefore added a new check which determines whether TuneD is on the dbus. If it's not, we fallback to the original profile activation.

The only disadvantage of this approach is that TuneD is restarted twice in the unlikely scenario that both `enable_dbus` and `daemon` are turned on, but TuneD does not become active on the DBus after a restart. This would, however, signalize some misconfiguration because if the TuneD service unit has `type=dbus` set, restarting the service hangs until it becomes active on the DBus. 

Resolves #623.