### PR TITLE
cpu-partitioning-powersave no_turbo fix

### DIFF
--- a/profiles/cpu-partitioning-powersave/tuned.conf
+++ b/profiles/cpu-partitioning-powersave/tuned.conf
@@ -25,7 +25,7 @@ assert2=${f:assertion_non_equal:max_power_state is set:${max_power_state}:${max_
 
 [cpu]
 force_latency=${max_power_state}
-no_turbo=true
+no_turbo=1
 
 [bootloader]
 cmdline_cpu_part=+nohz=on${cmd_isolcpus} nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=passive nosoftlockup


### PR DESCRIPTION
Fix 'no_turbo' from bool (true) to int (1).
The current codes throws an error as it doesn't understand a string bool value, only an int.