### PR TITLE
throughput-performance: dropped unused AMD related variable

### DIFF
--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -7,7 +7,6 @@ summary=Broadly applicable tuning that provides excellent performance across a v
 
 [variables]
 thunderx_cpuinfo_regex=CPU part\s+:\s+(0x0?516)|(0x0?af)|(0x0?a[0-3])|(0x0?b8)\b
-amd_cpuinfo_regex=model name\s+:.*\bAMD\b
 
 [cpu]
 governor=performance


### PR DESCRIPTION
Leftover from c6d6fdcc4c944df9998e0ebe75f31cc8aed452c1