### PR TITLE
chore: remove use of deprecated Logger.warn()

### DIFF
--- a/tuned/daemon/application.py
+++ b/tuned/daemon/application.py
@@ -211,7 +211,7 @@ class Application(object):
 		if daemon:
 			self.config.set(consts.CFG_DAEMON, True)
 		if not self.config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON):
-			log.warn("Using one shot no daemon mode, most of the functionality will be not available, it can be changed in global config")
+			log.warning("Using one shot no daemon mode, most of the functionality will be not available, it can be changed in global config")
 		result = self._controller.run()
 		if self.config.get_bool(consts.CFG_DAEMON, consts.CFG_DEF_DAEMON):
 			exports.stop()

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -178,7 +178,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 		finally:
 			if was_running:
 				if reapply:
-					log.warn("Applying previously applied (possibly out-dated) profile '%s'." % profile_name)
+					log.warning("Applying previously applied (possibly out-dated) profile '%s'." % profile_name)
 				elif not success:
 					log.info("Applying previously applied profile.")
 				self._daemon.start()

--- a/tuned/exports/dbus_exporter.py
+++ b/tuned/exports/dbus_exporter.py
@@ -139,12 +139,12 @@ class DBusExporter(interfaces.ExporterInterface):
 			if ret == 1:
 					log.debug("action '%s' requested by caller '%s' was successfully authorized by polkit" % (action_id, caller))
 			elif ret == 2:
-					log.warn("polkit error, but action '%s' requested by caller '%s' was successfully authorized by fallback method" % (action_id, caller))
+					log.warning("polkit error, but action '%s' requested by caller '%s' was successfully authorized by fallback method" % (action_id, caller))
 			elif ret == 0:
 					log.info("action '%s' requested by caller '%s' wasn't authorized, ignoring the request" % (action_id, caller))
 					args_copy = list(args[:-1]) + [""]
 			elif ret == -1:
-				log.warn("polkit error and action '%s' requested by caller '%s' wasn't authorized by fallback method, ignoring the request" % (action_id, caller))
+				log.warning("polkit error and action '%s' requested by caller '%s' wasn't authorized by fallback method, ignoring the request" % (action_id, caller))
 				args_copy = list(args[:-1]) + [""]
 			else:
 				log.error("polkit error and unable to use fallback method to authorize action '%s' requested by caller '%s', ignoring the request" % (action_id, caller))

--- a/tuned/hardware/inventory.py
+++ b/tuned/hardware/inventory.py
@@ -28,7 +28,7 @@ class Inventory(object):
 			try:
 				self._udev_monitor.set_receive_buffer_size(buffer_size)
 			except EnvironmentError:
-				log.warn("cannot set udev monitor receive buffer size, we are probably running inside " +
+				log.warning("cannot set udev monitor receive buffer size, we are probably running inside " +
 					 "container or with limited capabilites, TuneD functionality may be limited")
 
 		if monitor_observer_factory is None:

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -80,7 +80,7 @@ class Plugin(object):
 			if key in effective or self._has_dynamic_options:
 				effective[key] = options[key]
 			else:
-				log.warn("Unknown option '%s' for plugin '%s'." % (key, self.__class__.__name__))
+				log.warning("Unknown option '%s' for plugin '%s'." % (key, self.__class__.__name__))
 		return effective
 
 	def _option_bool(self, value):
@@ -172,7 +172,7 @@ class Plugin(object):
 		to_assign = self._get_matching_devices(instance, self._free_devices)
 		instance.active = len(to_assign) > 0
 		if not instance.active:
-			log.warn("instance %s: no matching devices available" % instance.name)
+			log.warning("instance %s: no matching devices available" % instance.name)
 		else:
 			name = instance.name
 			if instance.name != self.name:
@@ -217,7 +217,7 @@ class Plugin(object):
 		if script is None:
 			return None
 		if len(devices) == 0:
-			log.warn("Instance '%s': no device to call script '%s' for." % (instance.name, script))
+			log.warning("Instance '%s': no device to call script '%s' for." % (instance.name, script))
 			return None
 		if not script.startswith("/"):
 			log.error("Relative paths cannot be used in script_pre or script_post. " \
@@ -489,7 +489,7 @@ class Plugin(object):
 					else:
 						return None
 			except ValueError:
-				log.warn("cannot compare new value '%s' with current value '%s' by operator '%s', using '%s' directly as new value" % (val, current_value, op, new_value))
+				log.warning("cannot compare new value '%s' with current value '%s' by operator '%s', using '%s' directly as new value" % (val, current_value, op, new_value))
 		return new_value
 
 	def _get_current_value(self, command, device = None, ignore_missing=False):

--- a/tuned/plugins/plugin_acpi.py
+++ b/tuned/plugins/plugin_acpi.py
@@ -69,7 +69,7 @@ class ACPIPlugin(base.Plugin):
 					self._cmd.write_to_file(self._platform_profile_path(), profile, \
 						no_error=[errno.ENOENT] if remove else False)
 				return profile
-			log.warn("Requested platform_profile '%s' unavailable" % profile)
+			log.warning("Requested platform_profile '%s' unavailable" % profile)
 		log.error("Failed to set platform_profile. Is the value in the profile correct?")
 		return None
 

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -251,7 +251,7 @@ class BootloaderPlugin(base.Plugin):
 			return None
 		splited = out.split()
 		if len(splited) < 2 or splited[0] != "State:":
-			log.warn("Exceptional format of rpm-ostree status result:\n%s" % out)
+			log.warning("Exceptional format of rpm-ostree status result:\n%s" % out)
 			return None
 		return splited[1]
 
@@ -328,7 +328,7 @@ class BootloaderPlugin(base.Plugin):
 			elif key in effective:
 				effective[key] = options[key]
 			else:
-				log.warn("Unknown option '%s' for plugin '%s'." % (key, self.__class__.__name__))
+				log.warning("Unknown option '%s' for plugin '%s'." % (key, self.__class__.__name__))
 		cmdline = ""
 		for key in cmdline_keys:
 			val = options[key]
@@ -524,7 +524,7 @@ class BootloaderPlugin(base.Plugin):
 		l = ["%s=%s" % (str(option), str(value)) for option, value in d.items()]
 		(rc, out) = self._cmd.execute(["grub2-editenv", "-", "set"] + l)
 		if rc != 0:
-			log.warn("cannot update grubenv: '%s'" % out)
+			log.warning("cannot update grubenv: '%s'" % out)
 			return False
 		return True
 
@@ -535,7 +535,7 @@ class BootloaderPlugin(base.Plugin):
 		log.debug("running kernel update hook '%s' to patch BLS entries" % consts.KERNEL_UPDATE_HOOK_FILE)
 		(rc, out) = self._cmd.execute([consts.KERNEL_UPDATE_HOOK_FILE, "add"], env = {"KERNEL_INSTALL_MACHINE_ID" : machine_id})
 		if rc != 0:
-			log.warn("cannot patch BLS entries: '%s'" % out)
+			log.warning("cannot patch BLS entries: '%s'" % out)
 			return False
 		return True
 
@@ -556,10 +556,10 @@ class BootloaderPlugin(base.Plugin):
 
 	def _install_initrd(self, img):
 		if self._rpm_ostree:
-			log.warn("Detected rpm-ostree which doesn't support initrd overlays.")
+			log.warning("Detected rpm-ostree which doesn't support initrd overlays.")
 			return False
 		if self._check_petitboot():
-			log.warn("Detected Petitboot which doesn't support initrd overlays. The initrd overlay will be ignored by bootloader.")
+			log.warning("Detected Petitboot which doesn't support initrd overlays. The initrd overlay will be ignored by bootloader.")
 		log.info("installing initrd image as '%s'" % self._initrd_dst_img_val)
 		img_name = os.path.basename(self._initrd_dst_img_val)
 		if not self._cmd.copy(img, self._initrd_dst_img_val):
@@ -691,9 +691,9 @@ class BootloaderPlugin(base.Plugin):
 	def _instance_post_static(self, instance, enabling):
 		if enabling and self._skip_grub_config_val:
 			if len(self._initrd_val) > 0:
-				log.warn("requested changes to initrd will not be applied!")
+				log.warning("requested changes to initrd will not be applied!")
 			if len(self._cmdline_val) > 0:
-				log.warn("requested changes to cmdline will not be applied!")
+				log.warning("requested changes to cmdline will not be applied!")
 			# ensure that the desired cmdline is always written to BOOT_CMDLINE_FILE (/etc/tuned/bootcmdline)
 			self._patch_bootcmdline({consts.BOOT_CMDLINE_TUNED_VAR : self._cmdline_val, consts.BOOT_CMDLINE_INITRD_ADD_VAR : self._initrd_val})
 		elif enabling and self.update_grub2_cfg:

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -535,7 +535,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 				log.debug("Ignoring governor '%s' on cpu '%s', it is not supported"
 						% (governor, device))
 		else:
-			log.warn("None of the scaling governors is supported: %s"
+			log.warning("None of the scaling governors is supported: %s"
 					% ", ".join(governors))
 			governor = None
 		return governor
@@ -765,7 +765,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 						log.info("Setting energy_performance_preference value '%s' for cpu '%s'" % (val, device))
 						break
 					else:
-						log.warn("energy_performance_preference value '%s' unavailable for cpu '%s'" % (val, device))
+						log.warning("energy_performance_preference value '%s' unavailable for cpu '%s'" % (val, device))
 				else:
 					log.error("Failed to set energy_performance_preference on cpu '%s'. Is the value in the profile correct?"
 							  % device)

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -117,7 +117,7 @@ class DiskPlugin(hotplug.Plugin):
 		(rc, out, err_msg) = self._cmd.execute(["hdparm", "-C", "/dev/%s" % device], \
 				no_errors = [errno.ENOENT], return_err=True)
 		if rc == -errno.ENOENT:
-			log.warn("hdparm command not found, ignoring for other devices")
+			log.warning("hdparm command not found, ignoring for other devices")
 			self._use_hdparm = False
 			return False
 		elif rc:
@@ -214,7 +214,7 @@ class DiskPlugin(hotplug.Plugin):
 			cnt = 0
 		elif rc == -errno.ENOENT:
 			self._spindown_errcnt = self._apm_errcnt = consts.ERROR_THRESHOLD + 1
-			log.warn("hdparm command not found, ignoring future set_apm / set_spindown commands")
+			log.warning("hdparm command not found, ignoring future set_apm / set_spindown commands")
 			return
 		else:
 			cnt += 1

--- a/tuned/plugins/plugin_irqbalance.py
+++ b/tuned/plugins/plugin_irqbalance.py
@@ -52,7 +52,7 @@ class IrqbalancePlugin(base.Plugin):
 				return f.read()
 		except IOError as e:
 			if e.errno == errno.ENOENT:
-				log.warn("irqbalance sysconfig file is missing. Is irqbalance installed?")
+				log.warning("irqbalance sysconfig file is missing. Is irqbalance installed?")
 			else:
 				log.error("Failed to read irqbalance sysconfig file: %s" % e)
 			return None
@@ -83,7 +83,7 @@ class IrqbalancePlugin(base.Plugin):
 			["systemctl", "try-restart", "irqbalance"],
 			no_errors=[5])
 		if retcode != 0:
-			log.warn("Failed to restart irqbalance. Is it installed?")
+			log.warning("Failed to restart irqbalance. Is it installed?")
 
 	def _set_banned_cpus(self, banned_cpumask):
 		content = self._read_irqbalance_sysconfig()

--- a/tuned/plugins/plugin_modules.py
+++ b/tuned/plugins/plugin_modules.py
@@ -65,13 +65,13 @@ class ModulesPlugin(base.Plugin):
 		for module in modules:
 			retcode, out = self._cmd.execute(["modprobe", "-r", module])
 			if retcode < 0:
-				log.warn("'modprobe' command not found, cannot reload kernel modules, reboot is required")
+				log.warning("'modprobe' command not found, cannot reload kernel modules, reboot is required")
 				return
 			elif retcode > 0:
 				log.debug("cannot remove kernel module '%s': %s" % (module, out.strip()))
 			retcode, out = self._cmd.execute(["modprobe", module])
 			if retcode != 0:
-				log.warn("cannot insert/reinsert module '%s', reboot is required: %s" % (module, out.strip()))
+				log.warning("cannot insert/reinsert module '%s', reboot is required: %s" % (module, out.strip()))
 
 	def _instance_apply_static(self, instance):
 		self._clear_modprobe_file()
@@ -86,7 +86,7 @@ class ModulesPlugin(base.Plugin):
 				retcode, out = self._cmd.execute(["modinfo", module])
 				if retcode < 0:
 					skip_check = True
-					log.warn("'modinfo' command not found, not checking kernel modules")
+					log.warning("'modinfo' command not found, not checking kernel modules")
 				elif retcode > 0:
 					log.error("kernel module '%s' not found, skipping it" % module)
 			if skip_check or retcode == 0:
@@ -126,7 +126,7 @@ class ModulesPlugin(base.Plugin):
 				for item in l:
 					arg = item.split("=", 1)
 					if len(arg) != 2:
-						log.warn("unrecognized module option for module '%s': %s" % (module, item))
+						log.warning("unrecognized module option for module '%s': %s" % (module, item))
 					else:
 						if self._verify_value(arg[0], arg[1],
 							self._cmd.read_file(mpath + "/parameters/" + self._unquote_path(arg[0]), err_ret = None, no_error = True),

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -387,7 +387,7 @@ class NetTuningPlugin(hotplug.Plugin):
 		# see man ethtool for possible wol values, 0 added as an alias for 'd'
 		value = re.sub(r"0", "d", str(value));
 		if not re.match(r"^[" + WOL_VALUES + r"]+$", value):
-			log.warn("Incorrect 'wake_on_lan' value.")
+			log.warning("Incorrect 'wake_on_lan' value.")
 			return None
 
 		if not sim:
@@ -432,7 +432,7 @@ class NetTuningPlugin(hotplug.Plugin):
 		args = ["ip", "link"] + args
 		(rc, out, err_msg) = self._cmd.execute(args, no_errors=[errno.ENOENT], return_err=True)
 		if rc == -errno.ENOENT:
-			log.warn("ip command not found, ignoring for other devices")
+			log.warning("ip command not found, ignoring for other devices")
 			self._use_ip = False
 			return None
 		elif rc:
@@ -454,13 +454,13 @@ class NetTuningPlugin(hotplug.Plugin):
 		try:
 			int(value)
 		except ValueError:
-			log.warn("txqueuelen value '%s' is not integer" % value)
+			log.warning("txqueuelen value '%s' is not integer" % value)
 			return None
 		if not sim:
 			# there is inconsistency in "ip", where "txqueuelen" is set as it, but is shown as "qlen"
 			res = self._call_ip_link(["set", "dev", device, "txqueuelen", value])
 			if res is None:
-				log.warn("Cannot set txqueuelen for device '%s'" % device)
+				log.warning("Cannot set txqueuelen for device '%s'" % device)
 				return None
 		return value
 
@@ -494,12 +494,12 @@ class NetTuningPlugin(hotplug.Plugin):
 		try:
 			int(value)
 		except ValueError:
-			log.warn("mtu value '%s' is not integer" % value)
+			log.warning("mtu value '%s' is not integer" % value)
 			return None
 		if not sim:
 			res = self._call_ip_link(["set", "dev", device, "mtu", value])
 			if res is None:
-				log.warn("Cannot set mtu for device '%s'" % device)
+				log.warning("Cannot set mtu for device '%s'" % device)
 				return None
 		return value
 

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -660,7 +660,7 @@ class SchedulerPlugin(base.Plugin):
 					log.debug("Affinity of kernel thread with PID %d cannot be changed, the task's affinity mask is fixed."
 							% pid)
 				else:
-					log.warn("Affinity of task with PID %d cannot be changed, the task's affinity mask is fixed."
+					log.warning("Affinity of task with PID %d cannot be changed, the task's affinity mask is fixed."
 							% pid)
 				return 0
 			else:
@@ -1003,7 +1003,7 @@ class SchedulerPlugin(base.Plugin):
 					self._cmd.write_to_file("%s/%s" % (self._cgroup_mount_point, "tasks"), l, no_error = True)
 			cnt -= 1
 		if cnt == 0:
-			log.warn("Unable to cleanup tasks from cgroup '%s'" % cgroup)
+			log.warning("Unable to cleanup tasks from cgroup '%s'" % cgroup)
 
 	def _cgroup_cleanup_tasks(self):
 		if self._cgroup is not None and not self._cgroup in self._cgroups:

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -142,7 +142,7 @@ class VideoPlugin(base.Plugin):
 								return v
 			else:
 				if not sim:
-					log.warn("Invalid option for radeon_powersave.")
+					log.warning("Invalid option for radeon_powersave.")
 				return None
 		return None
 
@@ -168,12 +168,12 @@ class VideoPlugin(base.Plugin):
 		try:
 			value = int(value, 10)
 		except ValueError:
-			log.warn("Invalid value %s for panel_power_savings" % value)
+			log.warning("Invalid value %s for panel_power_savings" % value)
 			return None
 		if value in range(0, 5):
 			return self.apply_panel_power_saving_target(device, value, sim)
 		else:
-			log.warn("Invalid value %s for panel_power_savings" % value)
+			log.warning("Invalid value %s for panel_power_savings" % value)
 		return None
 
 	@command_get("panel_power_savings")

--- a/tuned/plugins/plugin_vm.py
+++ b/tuned/plugins/plugin_vm.py
@@ -61,7 +61,7 @@ class VMPlugin(base.Plugin):
 	def _set_transparent_hugepages(self, value, sim, remove):
 		if value not in ["always", "never", "madvise"]:
 			if not sim:
-				log.warn("Incorrect 'transparent_hugepages' value '%s'." % str(value))
+				log.warning("Incorrect 'transparent_hugepages' value '%s'." % str(value))
 			return None
 
 		cmdline = cmd.read_file("/proc/cmdline", no_error = True)
@@ -78,7 +78,7 @@ class VMPlugin(base.Plugin):
 			return value
 		else:
 			if not sim:
-				log.warn("Option 'transparent_hugepages' is not supported on current hardware.")
+				log.warning("Option 'transparent_hugepages' is not supported on current hardware.")
 			return None
 
         # just an alias to transparent_hugepages
@@ -109,7 +109,7 @@ class VMPlugin(base.Plugin):
 			return value
 		else:
 			if not sim:
-				log.warn("Option 'transparent_hugepage.defrag' is not supported on current hardware.")
+				log.warning("Option 'transparent_hugepage.defrag' is not supported on current hardware.")
 			return None
 
 	@command_get("transparent_hugepage.defrag")

--- a/tuned/profiles/functions/function_check_net_queue_count.py
+++ b/tuned/profiles/functions/function_check_net_queue_count.py
@@ -18,5 +18,5 @@ class check_net_queue_count(base.Function):
 		if args[0].isdigit():
 			return args[0]
 		(ret, out) = self._cmd.execute(["nproc"])
-		log.warn("net-dev queue count is not correctly specified, setting it to HK CPUs %s" % (out))
+		log.warning("net-dev queue count is not correctly specified, setting it to HK CPUs %s" % (out))
 		return out

--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -148,7 +148,7 @@ class ProfileRecommender:
 		except IndexError:
 			log.error("Unknown chassis type id read from dmi sysfs: %d" % chassis_type_id)
 		except (OSError, IOError) as e:
-			log.warn("error accessing dmi sysfs file: %s" % e)
+			log.warning("error accessing dmi sysfs file: %s" % e)
 
 		if self._chassis_type:
 			log.debug("chassis type - %s" % self._chassis_type)
@@ -167,7 +167,7 @@ class ProfileRecommender:
 			else:
 				self._chassis_type = dmi_output.strip().decode()
 		except (OSError, IOError) as e:
-			log.warn("error executing dmidecode tool : %s" % e)
+			log.warning("error executing dmidecode tool : %s" % e)
 
 		if not self._chassis_type:
 			log.debug("could not determine chassis type.")


### PR DESCRIPTION
Always use warning(), as warn() has been removed from Python with v3.13.