### PR TITLE
update RECOMMEND_DIRECTORIES const for profile migration

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -18,7 +18,7 @@ PERSISTENT_STORAGE_DIR = "/var/lib/tuned"
 PLUGIN_MAIN_UNIT_NAME = "main"
 # Magic section header because ConfigParser does not support "headerless" config
 MAGIC_HEADER_NAME = "this_is_some_magic_section_header_because_of_compatibility"
-RECOMMEND_DIRECTORIES = ["/usr/lib/tuned/recommend.d", "/etc/tuned/recommend.d"]
+RECOMMEND_DIRECTORIES = ["/usr/lib/tuned/profiles/recommend.d", "/etc/tuned/recommend.d"]
 
 TMP_FILE_SUFFIX = ".tmp"
 # max. number of consecutive errors to give up


### PR DESCRIPTION
The installation was updated, but the consts were missing.

Fixes: 6d3aa949b3a7019bbb70f9bd3b34cb4a9381e8fb