### PR TITLE
Tuned ppd adjustments

### DIFF
--- a/tuned-ppd.py
+++ b/tuned-ppd.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     handle_signal(signal.SIGINT, controller.terminate)
     handle_signal(signal.SIGTERM, controller.terminate)
-    handle_signal(signal.SIGHUP, controller.load_config)
+    handle_signal(signal.SIGHUP, controller.initialize)
 
     dbus_exporter = exports.dbus_with_properties.DBusExporterWithProperties(
         consts.PPD_DBUS_BUS, consts.PPD_DBUS_INTERFACE, consts.PPD_DBUS_OBJECT, consts.PPD_NAMESPACE

--- a/tuned-ppd.py
+++ b/tuned-ppd.py
@@ -3,8 +3,10 @@ import sys
 import os
 import dbus
 import signal
+import argparse
+import logging
 from dbus.mainloop.glib import DBusGMainLoop
-from tuned import exports
+from tuned import exports, logs
 from tuned.ppd import controller
 import tuned.consts as consts
 
@@ -16,6 +18,25 @@ def handle_signal(signal_number, handler):
     signal.signal(signal_number, handler_wrapper)
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="PPD compatibility daemon.")
+    parser.add_argument("--debug", "-D", action="store_true", help="log debugging messages")
+    parser.add_argument(
+        "--log",
+        "-l",
+        nargs="?",
+        const=consts.PPD_LOG_FILE,
+        help="log to a file, default is " + consts.PPD_LOG_FILE,
+    )
+    args = parser.parse_args()
+
+    log = logs.get()
+
+    if args.debug:
+        log.setLevel(logging.DEBUG)
+
+    if args.log:
+        log.switch_to_file(args.log)
+
     if os.geteuid() != 0:
         print("Superuser permissions are required to run the daemon.", file=sys.stderr)
         sys.exit(1)

--- a/tuned.spec
+++ b/tuned.spec
@@ -338,6 +338,11 @@ for f in %{_sysconfdir}/tuned/*; do
 done
 %endif
 
+
+%post ppd
+%systemd_post tuned-ppd.service
+
+
 %preun
 %systemd_preun tuned.service
 if [ "$1" == 0 ]; then
@@ -346,6 +351,10 @@ if [ "$1" == 0 ]; then
 # clear temporal storage
   rm -f /run/tuned/*
 fi
+
+
+%preun ppd
+%systemd_preun tuned-ppd.service
 
 
 %postun
@@ -385,6 +394,10 @@ if [ "$1" == 0 ]; then
     done
   fi
 fi
+
+
+%postun ppd
+%systemd_postun_with_restart tuned-ppd.service
 
 
 %triggerun -- tuned < 2.0-0

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -76,6 +76,7 @@ SYSFS_CPUS_PATH = "/sys/devices/system/cpu"
 LOG_FILE_COUNT = 2
 LOG_FILE_MAXBYTES = 100*1000
 LOG_FILE = "/var/log/tuned/tuned.log"
+PPD_LOG_FILE = "/var/log/tuned/tuned-ppd.log"
 PID_FILE = "/run/tuned/tuned.pid"
 SYSTEM_RELEASE_FILE = "/etc/system-release-cpe"
 # prefix for functions plugins

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -12,6 +12,7 @@ log = logs.get()
 DRIVER = "tuned"
 NO_TURBO_PATH = "/sys/devices/system/cpu/intel_pstate/no_turbo"
 LAP_MODE_PATH = "/sys/bus/platform/devices/thinkpad_acpi/dytc_lapmode"
+UNKNOWN_PROFILE = "unknown"
 
 UPOWER_DBUS_NAME = "org.freedesktop.UPower"
 UPOWER_DBUS_PATH = "/org/freedesktop/UPower"
@@ -169,7 +170,7 @@ class Controller(exports.interfaces.ExportableInterface):
 
     def active_profile(self):
         tuned_profile = self._tuned_interface.active_profile()
-        return self._config.tuned_to_ppd.get(tuned_profile, "unknown")
+        return self._config.tuned_to_ppd.get(tuned_profile, UNKNOWN_PROFILE)
 
     @exports.export("sss", "u")
     def HoldProfile(self, profile, reason, app_id, caller):

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -108,8 +108,8 @@ class Controller(exports.interfaces.ExportableInterface):
     def upower_changed(self, interface, changed, invalidated):
         properties = dbus.Interface(self.proxy, dbus.PROPERTIES_IFACE)
         self._on_battery = bool(properties.Get(UPOWER_DBUS_INTERFACE, "OnBattery"))
+        log.info("Battery status: " + ("DC (battery)" if self._on_battery else "AC (charging)"))
         tuned_profile = self._config.ppd_to_tuned_battery[self._base_profile] if self._on_battery else self._config.ppd_to_tuned[self._base_profile]
-        log.info("Switching to profile '%s' due to battery %s" % (tuned_profile, self._on_battery))
         self._tuned_interface.switch_profile(tuned_profile)
 
     def setup_battery_signaling(self):

--- a/tuned/ppd/tuned-ppd.service
+++ b/tuned/ppd/tuned-ppd.service
@@ -6,7 +6,6 @@ Before=multi-user.target display-manager.target
 
 [Service]
 Type=dbus
-PIDFile=/run/tuned/tuned-ppd.pid
 BusName=net.hadess.PowerProfiles
 ExecStart=/usr/sbin/tuned-ppd -l
 

--- a/tuned/ppd/tuned-ppd.service
+++ b/tuned/ppd/tuned-ppd.service
@@ -8,7 +8,7 @@ Before=multi-user.target display-manager.target
 Type=dbus
 PIDFile=/run/tuned/tuned-ppd.pid
 BusName=net.hadess.PowerProfiles
-ExecStart=/usr/sbin/tuned-ppd
+ExecStart=/usr/sbin/tuned-ppd -l
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
This PR introduces small changes in and related to `tuned-ppd`:
- The daemon now has the option to log output into a file (the default is `/var/log/tuned/tuned-ppd.log`).
- The PID option was removed from the systems service file: the daemon currently does not write its PID anywhere.
- The spec file is adjusted to include standard systems scriptlet macros according to [Fedora guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd).
- When swapping `power-profiles-daemon` for `tuned-ppd`, scriptlets now check whether PPD is running and if yes, `tuned-ppd` is also started right away.