### PR TITLE
Add support for controlling amd-pstate core performance boost

### DIFF
--- a/profiles/balanced-battery/tuned.conf
+++ b/profiles/balanced-battery/tuned.conf
@@ -8,6 +8,7 @@ include=balanced
 
 [cpu]
 energy_performance_preference=balance_power
+boost=1
 
 [video]
 panel_power_savings=1

--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -13,6 +13,7 @@ priority=10
 governor=conservative|powersave
 energy_perf_bias=normal
 energy_performance_preference=balance_performance
+boost=1
 
 [acpi]
 platform_profile=balanced

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -9,6 +9,7 @@ summary=Optimize for low power consumption
 governor=ondemand|powersave
 energy_perf_bias=powersave|power
 energy_performance_preference=power
+boost=0
 
 [acpi]
 platform_profile=low-power|quiet


### PR DESCRIPTION
Core performance boost control is added to kernel 6.11. This sets up the policy to turn it off while in the power saver profile.

Link: https://lore.kernel.org/linux-pm/1a78eeaa-fadd-4734-aaeb-2fe11e96e198@amd.com/T/#m4a0c8917ea8fb033504055bd61512c80c85410c8