### PR TITLE
Enable controller reset for audio by default

### DIFF
--- a/tuned/plugins/plugin_audio.py
+++ b/tuned/plugins/plugin_audio.py
@@ -64,7 +64,7 @@ class AudioPlugin(hotplug.Plugin):
 	def _get_config_options(cls):
 		return {
 			"timeout":          0,
-			"reset_controller": False,
+			"reset_controller": True,
 		}
 
 	def _timeout_path(self, device):


### PR DESCRIPTION
It fixes Nvidia suspension for laptops.

https://linrunner.de/tlp/settings/audio.html#sound-power-save-on-ac-bat