### PR TITLE
Beakerlib tests adjustments

### DIFF
--- a/tests/beakerlib/error-messages/runtest.sh
+++ b/tests/beakerlib/error-messages/runtest.sh
@@ -50,6 +50,7 @@ rlJournalStart
     rlPhaseStartCleanup
         tunedDisableSystemdRateLimitingEnd
         tunedProfileRestore
+        rlServiceRestore "tuned"
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd

--- a/tests/beakerlib/variables-support-in-profiles/runtest.sh
+++ b/tests/beakerlib/variables-support-in-profiles/runtest.sh
@@ -24,7 +24,7 @@ rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm $PACKAGE
         rlImport "tuned/basic"
-        rlRun "tunedDisableSystemdRateLimitingStart"
+        tunedDisableSystemdRateLimitingStart
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
         rlServiceStart "tuned"


### PR DESCRIPTION
Some minor test adjustments:
- All other tests run `tunedDisableSystemdRateLimitingStart` without `rlRun`, so stick to it in `variables-support-in-profiles`, too.
- Add a missing `rlServiceRestore` to the `error-messages` test. This fixes [recent test failures](https://artifacts.dev.testing-farm.io/e67c22b9-4ea9-4be6-8cf1-ad060d839fd3/) in Rawhide, most likely triggered by the recent [addition of TuneD to systemd presets](https://src.fedoraproject.org/rpms/fedora-release/pull-request/335).