### PR TITLE
Add `functions` to the files copied by the release-cp Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ release-cp: release-dir
 		tuned-adm.bash dbus.conf recommend.conf tuned-main.conf 00_tuned \
 		92-tuned.install bootcmdline modules.conf com.redhat.tuned.policy \
 		tuned-gui.py tuned-gui.glade tuned-ppd.py \
-		tuned-gui.desktop $(VERSIONED_NAME)
+		tuned-gui.desktop functions $(VERSIONED_NAME)
 	cp -a doc experiments libexec man profiles systemtap tuned contrib icons \
 		tests $(VERSIONED_NAME)
 


### PR DESCRIPTION
This change was forgotten during #644, therefore causing errors when running `make rpm`.