### PR TITLE
Clear plugin repository when stopping tuning

### DIFF
--- a/tuned/units/manager.py
+++ b/tuned/units/manager.py
@@ -135,7 +135,7 @@ class Manager(object):
 		for plugin in self._plugins:
 			log.debug("cleaning plugin '%s'" % plugin.name)
 			self._try_call("destroy_all", None, plugin.cleanup)
-
+		self._plugins_repository.plugins.clear()
 		del self._plugins[:]
 		del self._instances[:]
 


### PR DESCRIPTION
Not clearing it before a profile switch would
result in never deleting the original plugin
objects - those would accumulate in memory with
each profile switch.

TBH, I believe we could get rid of the plugin repository
class altogether, I'm not quite sure what's its responsibility
and why we need it when we have the plugin manager.