### PR TITLE
More tuned-ppd adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ install: install-dirs
 	echo -n > $(DESTDIR)$(TUNED_CFG_DIR)/active_profile
 	echo -n > $(DESTDIR)$(TUNED_CFG_DIR)/profile_mode
 	echo -n > $(DESTDIR)$(TUNED_CFG_DIR)/post_loaded_profile
+	echo -n > $(DESTDIR)$(TUNED_CFG_DIR)/ppd_base_profile
 	install -Dpm 0644 bootcmdline $(DESTDIR)$(TUNED_CFG_DIR)/bootcmdline
 	install -Dpm 0644 modules.conf $(DESTDIR)$(SYSCONFDIR)/modprobe.d/tuned.conf
 

--- a/tuned.spec
+++ b/tuned.spec
@@ -504,6 +504,7 @@ fi
 %config(noreplace) %verify(not size mtime md5) %{_sysconfdir}/tuned/active_profile
 %config(noreplace) %verify(not size mtime md5) %{_sysconfdir}/tuned/profile_mode
 %config(noreplace) %verify(not size mtime md5) %{_sysconfdir}/tuned/post_loaded_profile
+%config(noreplace) %verify(not size mtime md5) %{_sysconfdir}/tuned/ppd_base_profile
 %config(noreplace) %{_sysconfdir}/tuned/tuned-main.conf
 %config(noreplace) %verify(not size mtime md5) %{_sysconfdir}/tuned/bootcmdline
 %verify(not size mtime md5) %{_sysconfdir}/modprobe.d/tuned.conf

--- a/tuned.spec
+++ b/tuned.spec
@@ -84,6 +84,7 @@ BuildRequires: %{_py}-mock
 BuildRequires: %{_py}-pyudev
 Requires: %{_py}-pyudev
 Requires: %{_py}-linux-procfs, %{_py}-perf
+Requires: %{_py}-inotify
 %if %{without python3}
 Requires: %{_py}-schedutils
 %endif

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -103,6 +103,7 @@ PPD_DBUS_OBJECT = "/net/hadess/PowerProfiles"
 PPD_DBUS_INTERFACE = PPD_DBUS_BUS
 PPD_CONFIG_FILE = "/etc/tuned/ppd.conf"
 PPD_BASE_PROFILE_FILE = "/etc/tuned/ppd_base_profile"
+PPD_API_COMPATIBILITY = "0.23"
 
 # After adding new option to tuned-main.conf add here its name with CFG_ prefix
 # and eventually default value with CFG_DEF_ prefix (default is None)

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -102,6 +102,7 @@ PPD_DBUS_BUS = PPD_NAMESPACE
 PPD_DBUS_OBJECT = "/net/hadess/PowerProfiles"
 PPD_DBUS_INTERFACE = PPD_DBUS_BUS
 PPD_CONFIG_FILE = "/etc/tuned/ppd.conf"
+PPD_BASE_PROFILE_FILE = "/etc/tuned/ppd_base_profile"
 
 # After adding new option to tuned-main.conf add here its name with CFG_ prefix
 # and eventually default value with CFG_DEF_ prefix (default is None)

--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -3,6 +3,7 @@ from tuned.exceptions import TunedException
 import os
 
 PPD_POWER_SAVER = "power-saver"
+PPD_BALANCED = "balanced"
 PPD_PERFORMANCE = "performance"
 
 MAIN_SECTION = "main"
@@ -92,13 +93,17 @@ class PPDConfig:
         if PPD_POWER_SAVER not in profile_dict_ac:
             raise TunedException("Missing power-saver profile in the configuration file '%s'" % config_file)
 
+        if PPD_BALANCED not in profile_dict_ac:
+            raise TunedException("Missing balanced profile in the configuration file '%s'" % config_file)
+
         if PPD_PERFORMANCE not in profile_dict_ac:
             raise TunedException("Missing performance profile in the configuration file '%s'" % config_file)
 
         if MAIN_SECTION not in cfg or DEFAULT_PROFILE_OPTION not in cfg[MAIN_SECTION]:
-            raise TunedException("Missing default profile in the configuration file '%s'" % config_file)
+            self._default_profile = PPD_BALANCED
+        else:
+            self._default_profile = cfg[MAIN_SECTION][DEFAULT_PROFILE_OPTION]
 
-        self._default_profile = cfg[MAIN_SECTION][DEFAULT_PROFILE_OPTION]
         if self._default_profile not in profile_dict_ac:
             raise TunedException("Default profile '%s' missing in the profile mapping" % self._default_profile)
 

--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -11,6 +11,7 @@ PROFILES_SECTION = "profiles"
 BATTERY_SECTION = "battery"
 DEFAULT_PROFILE_OPTION = "default"
 BATTERY_DETECTION_OPTION = "battery_detection"
+THINKPAD_FUNCTION_KEYS_OPTION = "thinkpad_function_keys"
 
 
 class ProfileMap:
@@ -73,6 +74,15 @@ class PPDConfig:
         """
         return self._tuned_to_ppd
 
+    @property
+    def thinkpad_function_keys(self):
+        """
+        Whether to react to changes of ACPI platform profile
+        done via function keys (e.g., Fn-L) on newer Thinkpad
+        machines. Experimental feature.
+        """
+        return self._thinkpad_function_keys
+
     def load_from_file(self, config_file):
         """
         Loads the configuration from the provided file.
@@ -130,3 +140,5 @@ class PPDConfig:
 
         self._ppd_to_tuned = ProfileMap(profile_dict_ac, profile_dict_dc)
         self._tuned_to_ppd = ProfileMap({v: k for k, v in profile_dict_ac.items()}, {v: k for k, v in profile_dict_dc.items()})
+
+        self._thinkpad_function_keys = cfg.getboolean(MAIN_SECTION, THINKPAD_FUNCTION_KEYS_OPTION, fallback=False)

--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -12,8 +12,23 @@ DEFAULT_PROFILE_OPTION = "default"
 BATTERY_DETECTION_OPTION = "battery_detection"
 
 
+class ProfileMap:
+    def __init__(self, ac_map, dc_map):
+        self._ac_map = ac_map
+        self._dc_map = dc_map
+
+    def get(self, profile, on_battery):
+        profile_map = self._dc_map if on_battery else self._ac_map
+        return profile_map[profile]
+
+    def keys(self, on_battery):
+        profile_map = self._dc_map if on_battery else self._ac_map
+        return profile_map.keys()
+
+
 class PPDConfig:
-    def __init__(self, config_file):
+    def __init__(self, config_file, tuned_interface):
+        self._tuned_interface = tuned_interface
         self.load_from_file(config_file)
 
     @property
@@ -32,10 +47,6 @@ class PPDConfig:
     def tuned_to_ppd(self):
         return self._tuned_to_ppd
 
-    @property
-    def ppd_to_tuned_battery(self):
-        return self._ppd_to_tuned_battery
-
     def load_from_file(self, config_file):
         cfg = ConfigParser()
 
@@ -48,38 +59,41 @@ class PPDConfig:
 
         if PROFILES_SECTION not in cfg:
             raise TunedException("Missing profiles section in the configuration file '%s'" % config_file)
-        self._ppd_to_tuned = dict(cfg[PROFILES_SECTION])
+        profile_dict_ac = dict(cfg[PROFILES_SECTION])
 
-        if not all(isinstance(mapped_profile, str) for mapped_profile in self._ppd_to_tuned.values()):
-            raise TunedException("Invalid profile mapping in the configuration file '%s'" % config_file)
-
-        if len(set(self._ppd_to_tuned.values())) != len(self._ppd_to_tuned):
-            raise TunedException("Duplicate profile mapping in the configuration file '%s'" % config_file)
-        self._tuned_to_ppd = {v: k for k, v in self._ppd_to_tuned.items()}
-
-        if PPD_POWER_SAVER not in self._ppd_to_tuned:
+        if PPD_POWER_SAVER not in profile_dict_ac:
             raise TunedException("Missing power-saver profile in the configuration file '%s'" % config_file)
 
-        if PPD_PERFORMANCE not in self._ppd_to_tuned:
+        if PPD_PERFORMANCE not in profile_dict_ac:
             raise TunedException("Missing performance profile in the configuration file '%s'" % config_file)
 
         if MAIN_SECTION not in cfg or DEFAULT_PROFILE_OPTION not in cfg[MAIN_SECTION]:
             raise TunedException("Missing default profile in the configuration file '%s'" % config_file)
 
         self._default_profile = cfg[MAIN_SECTION][DEFAULT_PROFILE_OPTION]
-        if self._default_profile not in self._ppd_to_tuned:
-            raise TunedException("Unknown default profile '%s'" % self._default_profile)
+        if self._default_profile not in profile_dict_ac:
+            raise TunedException("Default profile '%s' missing in the profile mapping" % self._default_profile)
 
-        if BATTERY_DETECTION_OPTION not in cfg[MAIN_SECTION]:
-            raise TunedException("Missing battery detection option in the configuration file '%s'" % config_file)
-        self._ppd_to_tuned_battery = self._ppd_to_tuned
-        self._battery_detection = cfg.getboolean(MAIN_SECTION, BATTERY_DETECTION_OPTION)
-        if self._battery_detection:
-            if BATTERY_SECTION not in cfg:
-                raise TunedException("Missing battery section in the configuration file '%s'" % config_file)
-            for k, _v in dict(cfg[PROFILES_SECTION]).items():
-                if k in cfg[BATTERY_SECTION].keys():
-                    self._tuned_to_ppd = self._tuned_to_ppd | {cfg[BATTERY_SECTION][k]:k}
-            for k, v in dict(cfg[BATTERY_SECTION]).items():
-                if k in cfg[PROFILES_SECTION].keys():
-                    self._ppd_to_tuned_battery = self._ppd_to_tuned_battery | {k:v}
+        self._battery_detection = cfg.getboolean(MAIN_SECTION, BATTERY_DETECTION_OPTION, fallback=BATTERY_SECTION in cfg)
+
+        if self._battery_detection and BATTERY_SECTION not in cfg:
+            raise TunedException("Missing battery section in the configuration file '%s'" % config_file)
+
+        profile_dict_dc = profile_dict_ac | dict(cfg[BATTERY_SECTION]) if self._battery_detection else profile_dict_ac
+
+        # Make sure all of the TuneD profiles specified in the configuration file actually exist
+        unknown_tuned_profiles = (set(profile_dict_ac.values()) | set(profile_dict_dc.values())) - set(self._tuned_interface.profiles())
+        if unknown_tuned_profiles:
+            raise TunedException("Unknown TuneD profiles in the configuration file: " + ", ".join(unknown_tuned_profiles))
+
+        # Make sure there are no PPD profiles appearing in the battery section which are not defined before
+        unknown_battery_profiles = set(profile_dict_dc.keys()) - set(profile_dict_ac.keys())
+        if unknown_battery_profiles:
+            raise TunedException("Unknown PPD profiles in the battery section: " + ", ".join(unknown_battery_profiles))
+
+        # Make sure the profile mapping is injective so it can be reverted
+        if len(set(profile_dict_ac.values())) != len(profile_dict_ac) or len(set(profile_dict_dc.values())) != len(profile_dict_dc):
+            raise TunedException("Duplicate profile mapping in the configuration file '%s'" % config_file)
+
+        self._ppd_to_tuned = ProfileMap(profile_dict_ac, profile_dict_dc)
+        self._tuned_to_ppd = ProfileMap({v: k for k, v in profile_dict_ac.items()}, {v: k for k, v in profile_dict_dc.items()})

--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -13,41 +13,69 @@ BATTERY_DETECTION_OPTION = "battery_detection"
 
 
 class ProfileMap:
+    """
+    Mapping of PPD profiles to TuneD profiles or vice versa.
+    """
     def __init__(self, ac_map, dc_map):
         self._ac_map = ac_map
         self._dc_map = dc_map
 
     def get(self, profile, on_battery):
+        """
+        Returns a TuneD profile corresponding to the given
+        PPD profile and power supply status (or vice versa).
+        """
         profile_map = self._dc_map if on_battery else self._ac_map
         return profile_map[profile]
 
     def keys(self, on_battery):
+        """
+        Returns the supported PPD or TuneD profiles.
+        """
         profile_map = self._dc_map if on_battery else self._ac_map
         return profile_map.keys()
 
 
 class PPDConfig:
+    """
+    Configuration for the tuned-ppd daemon.
+    """
     def __init__(self, config_file, tuned_interface):
         self._tuned_interface = tuned_interface
         self.load_from_file(config_file)
 
     @property
     def battery_detection(self):
+        """
+        Whether battery detection is enabled.
+        """
         return self._battery_detection
 
     @property
     def default_profile(self):
+        """
+        Default PPD profile to set during initialization.
+        """
         return self._default_profile
 
     @property
     def ppd_to_tuned(self):
+        """
+        Mapping of PPD profiles to TuneD profiles.
+        """
         return self._ppd_to_tuned
 
     @property
     def tuned_to_ppd(self):
+        """
+        Mapping of TuneD profiles to PPD profiles.
+        """
         return self._tuned_to_ppd
 
     def load_from_file(self, config_file):
+        """
+        Loads the configuration from the provided file.
+        """
         cfg = ConfigParser()
 
         if not os.path.isfile(config_file):

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -1,6 +1,6 @@
 from tuned import exports, logs
 from tuned.utils.commands import commands
-from tuned.consts import PPD_CONFIG_FILE
+from tuned.consts import PPD_CONFIG_FILE, PPD_BASE_PROFILE_FILE
 from tuned.ppd.config import PPDConfig, PPD_PERFORMANCE, PPD_POWER_SAVER
 from enum import StrEnum
 import threading
@@ -105,13 +105,30 @@ class Controller(exports.interfaces.ExportableInterface):
         self._terminate = threading.Event()
         self._battery_handler = None
         self._on_battery = False
+        self._tuned_interface.connect_to_signal("profile_changed", self._tuned_profile_changed)
         self.initialize()
 
     def _upower_changed(self, interface, changed, invalidated):
         self._on_battery = bool(self._upower_properties.Get(UPOWER_DBUS_INTERFACE, "OnBattery"))
         log.info("Battery status changed: " + ("DC (battery)" if self._on_battery else "AC (charging)"))
-        tuned_profile = self._config.ppd_to_tuned_battery[self._base_profile] if self._on_battery else self._config.ppd_to_tuned[self._base_profile]
-        self.switch_profile(tuned_profile)
+        self.switch_profile(self._active_profile)
+
+    def _tuned_profile_changed(self, tuned_profile, result, errstr):
+        if not result:
+            return
+        self._profile_holds.clear()
+        try:
+            ppd_profile = self._config.tuned_to_ppd.get(tuned_profile, self._on_battery)
+        except KeyError:
+            ppd_profile = UNKNOWN_PROFILE
+            log.warning("TuneD profile changed to an unknown profile '%s'" % tuned_profile)
+        if self._active_profile != ppd_profile:
+            log.info("Profile changed to '%s'" % ppd_profile)
+            self._active_profile = ppd_profile
+            exports.property_changed("ActiveProfile", self._active_profile)
+            if ppd_profile != UNKNOWN_PROFILE:
+                self._base_profile = ppd_profile
+                self._save_base_profile(ppd_profile)
 
     def _setup_battery_signaling(self):
         self._on_battery = False
@@ -140,14 +157,31 @@ class Controller(exports.interfaces.ExportableInterface):
             self._performance_degraded = performance_degraded
             exports.property_changed("PerformanceDegraded", performance_degraded)
 
+    def _load_base_profile(self):
+        return self._cmd.read_file(PPD_BASE_PROFILE_FILE, no_error=True).strip() or None
+
+    def _save_base_profile(self, profile):
+        self._cmd.write_to_file(PPD_BASE_PROFILE_FILE, profile + "\n")
+
+    def _set_tuned_profile(self, tuned_profile):
+        active_tuned_profile = self._tuned_interface.active_profile()
+        if active_tuned_profile == tuned_profile:
+            return True
+        log.info("Setting TuneD profile to '%s'" % tuned_profile)
+        ok, error_msg = self._tuned_interface.switch_profile(tuned_profile)
+        if not ok:
+            log.error(str(error_msg))
+        return bool(ok)
+
     def initialize(self):
+        self._active_profile = None
         self._profile_holds = ProfileHoldManager(self)
         self._performance_degraded = PerformanceDegraded.NONE
-        self._config = PPDConfig(PPD_CONFIG_FILE)
+        self._config = PPDConfig(PPD_CONFIG_FILE, self._tuned_interface)
         self._setup_battery_signaling()
-        active_profile = self.active_profile()
-        self._base_profile = active_profile if active_profile != UNKNOWN_PROFILE else self._config.default_profile
+        self._base_profile = self._load_base_profile() or self._config.default_profile
         self.switch_profile(self._base_profile)
+        self._save_base_profile(self._base_profile)
 
     def run(self):
         exports.start()
@@ -167,16 +201,12 @@ class Controller(exports.interfaces.ExportableInterface):
         self._terminate.set()
 
     def switch_profile(self, profile):
-        if self.active_profile() == profile:
-            return
-        tuned_profile = self._config.ppd_to_tuned_battery[profile] if self._on_battery else self._config.ppd_to_tuned[profile]
-        log.info("Switching to profile '%s'" % tuned_profile)
-        self._tuned_interface.switch_profile(tuned_profile)
-        exports.property_changed("ActiveProfile", profile)
-
-    def active_profile(self):
-        tuned_profile = self._tuned_interface.active_profile()
-        return self._config.tuned_to_ppd.get(tuned_profile, UNKNOWN_PROFILE)
+        if not self._set_tuned_profile(self._config.ppd_to_tuned.get(profile, self._on_battery)):
+            return False
+        if self._active_profile != profile:
+            exports.property_changed("ActiveProfile", profile)
+            self._active_profile = profile
+        return True
 
     @exports.export("sss", "u")
     def HoldProfile(self, profile, reason, app_id, caller):
@@ -198,21 +228,23 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @exports.property_setter("ActiveProfile")
     def set_active_profile(self, profile):
-        if profile not in self._config.ppd_to_tuned:
+        if profile not in self._config.ppd_to_tuned.keys(self._on_battery):
             raise dbus.exceptions.DBusException("Invalid profile '%s'" % profile)
         log.debug("Setting base profile to %s" % profile)
-        self._base_profile = profile
         self._profile_holds.clear()
-        self.switch_profile(profile)
+        if not self.switch_profile(profile):
+            raise dbus.exceptions.DBusException("Error setting profile %s'" % profile)
+        self._base_profile = profile
+        self._save_base_profile(profile)
 
     @exports.property_getter("ActiveProfile")
     def get_active_profile(self):
-        return self.active_profile()
+        return self._active_profile
 
     @exports.property_getter("Profiles")
     def get_profiles(self):
         return dbus.Array(
-            [{"Profile": profile, "Driver": DRIVER} for profile in self._config.ppd_to_tuned.keys()],
+            [{"Profile": profile, "Driver": DRIVER} for profile in self._config.ppd_to_tuned.keys(self._on_battery)],
             signature="a{sv}",
         )
 

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -1,6 +1,6 @@
 from tuned import exports, logs
 from tuned.utils.commands import commands
-from tuned.consts import PPD_CONFIG_FILE, PPD_BASE_PROFILE_FILE
+from tuned.consts import PPD_CONFIG_FILE, PPD_BASE_PROFILE_FILE, PPD_API_COMPATIBILITY
 from tuned.ppd.config import PPDConfig, PPD_PERFORMANCE, PPD_POWER_SAVER
 from enum import StrEnum
 import threading
@@ -373,3 +373,7 @@ class Controller(exports.interfaces.ExportableInterface):
         Returns a DBus array of active profile holds.
         """
         return self._profile_holds.as_dbus_array()
+
+    @exports.property_getter("Version")
+    def version(self):
+        return PPD_API_COMPATIBILITY

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -19,12 +19,19 @@ UPOWER_DBUS_PATH = "/org/freedesktop/UPower"
 UPOWER_DBUS_INTERFACE = "org.freedesktop.UPower"
 
 class PerformanceDegraded(StrEnum):
+    """
+    Possible reasons for performance degradation.
+    """
     NONE = ""
     LAP_DETECTED = "lap-detected"
     HIGH_OPERATING_TEMPERATURE = "high-operating-temperature"
 
 
 class ProfileHold(object):
+    """
+    Class holding information about a single profile hold,
+    i.e., a temporary profile switch requested by a process.
+    """
     def __init__(self, profile, reason, app_id, watch):
         self.profile = profile
         self.reason = reason
@@ -32,6 +39,9 @@ class ProfileHold(object):
         self.watch = watch
 
     def as_dict(self):
+        """
+        Returns the hold information as a Python dictionary.
+        """
         return {
             "Profile": self.profile,
             "Reason": self.reason,
@@ -40,12 +50,21 @@ class ProfileHold(object):
 
 
 class ProfileHoldManager(object):
+    """
+    Manager of profile holds responsible for their creation/deletion
+    and for choosing the effective one. Holds are identified using
+    integer cookies which are distributed to the hold-requesting processes.
+    """
     def __init__(self, controller):
         self._holds = {}
         self._cookie_counter = 0
         self._controller = controller
 
-    def _callback(self, cookie, app_id):
+    def _removal_callback(self, cookie, app_id):
+        """
+        Returns the callback to invoke when the process with the given ID
+        (which requested a hold with the given cookie) disappears.
+        """
         def callback(name):
             if name == "":
                 log.info("Application '%s' disappeared, releasing hold '%s'" % (app_id, cookie))
@@ -54,11 +73,17 @@ class ProfileHoldManager(object):
         return callback
 
     def _effective_hold_profile(self):
+        """
+        Returns the hold to use from the set of all active ones.
+        """
         if any(hold.profile == PPD_POWER_SAVER for hold in self._holds.values()):
             return PPD_POWER_SAVER
         return PPD_PERFORMANCE
 
     def _cancel(self, cookie):
+        """
+        Cancels the hold saved under the provided cookie.
+        """
         if cookie not in self._holds:
             return
         hold = self._holds.pop(cookie)
@@ -68,12 +93,18 @@ class ProfileHoldManager(object):
         log.info("Releasing hold '%s': profile '%s' by application '%s'" % (cookie, hold.profile, hold.app_id))
 
     def as_dbus_array(self):
+        """
+        Returns the information about current holds as a DBus-compatible array.
+        """
         return dbus.Array([hold.as_dict() for hold in self._holds.values()], signature="a{sv}")
 
     def add(self, profile, reason, app_id, caller):
+        """
+        Adds a new profile hold.
+        """
         cookie = self._cookie_counter
         self._cookie_counter += 1
-        watch = self._controller.bus.watch_name_owner(caller, self._callback(cookie, app_id))
+        watch = self._controller.bus.watch_name_owner(caller, self._removal_callback(cookie, app_id))
         log.info("Adding hold '%s': profile '%s' by application '%s'" % (cookie, profile, app_id))
         self._holds[cookie] = ProfileHold(profile, reason, app_id, watch)
         exports.property_changed("ActiveProfileHolds", self.as_dbus_array())
@@ -81,9 +112,16 @@ class ProfileHoldManager(object):
         return cookie
 
     def has(self, cookie):
+        """
+        Returns True if there is a hold under the given cookie.
+        """
         return cookie in self._holds
 
     def remove(self, cookie):
+        """
+        Releases the hold saved under the provided cookie and
+        sets the next profile.
+        """
         self._cancel(cookie)
         if len(self._holds) != 0:
             new_profile = self._effective_hold_profile()
@@ -92,11 +130,17 @@ class ProfileHoldManager(object):
         self._controller.switch_profile(new_profile)
 
     def clear(self):
+        """
+        Releases all profile holds.
+        """
         for cookie in list(self._holds.keys()):
             self._cancel(cookie)
 
 
 class Controller(exports.interfaces.ExportableInterface):
+    """
+    The main tuned-ppd controller, exporting its DBus interface.
+    """
     def __init__(self, bus, tuned_interface):
         super(Controller, self).__init__()
         self._bus = bus
@@ -109,11 +153,17 @@ class Controller(exports.interfaces.ExportableInterface):
         self.initialize()
 
     def _upower_changed(self, interface, changed, invalidated):
+        """
+        The callback to invoke when the power supply changes.
+        """
         self._on_battery = bool(self._upower_properties.Get(UPOWER_DBUS_INTERFACE, "OnBattery"))
         log.info("Battery status changed: " + ("DC (battery)" if self._on_battery else "AC (charging)"))
         self.switch_profile(self._active_profile)
 
     def _tuned_profile_changed(self, tuned_profile, result, errstr):
+        """
+        The callback to invoke when TuneD signals a profile change.
+        """
         if not result:
             return
         self._profile_holds.clear()
@@ -131,6 +181,9 @@ class Controller(exports.interfaces.ExportableInterface):
                 self._save_base_profile(ppd_profile)
 
     def _setup_battery_signaling(self):
+        """
+        Sets up handling of power supply changes.
+        """
         self._on_battery = False
         if not self._config.battery_detection:
             if self._battery_handler is not None:
@@ -147,6 +200,9 @@ class Controller(exports.interfaces.ExportableInterface):
             log.debug(error)
 
     def _check_performance_degraded(self):
+        """
+        Checks the current performance degradation status and sends a signal if it changed.
+        """
         performance_degraded = PerformanceDegraded.NONE
         if os.path.exists(NO_TURBO_PATH) and self._cmd.read_file(NO_TURBO_PATH).strip() == "1":
             performance_degraded = PerformanceDegraded.HIGH_OPERATING_TEMPERATURE
@@ -158,12 +214,21 @@ class Controller(exports.interfaces.ExportableInterface):
             exports.property_changed("PerformanceDegraded", performance_degraded)
 
     def _load_base_profile(self):
+        """
+        Loads and returns the saved PPD base profile.
+        """
         return self._cmd.read_file(PPD_BASE_PROFILE_FILE, no_error=True).strip() or None
 
     def _save_base_profile(self, profile):
+        """
+        Saves the given PPD profile into the base profile file.
+        """
         self._cmd.write_to_file(PPD_BASE_PROFILE_FILE, profile + "\n")
 
     def _set_tuned_profile(self, tuned_profile):
+        """
+        Sets the TuneD profile to the given one if not already set.
+        """
         active_tuned_profile = self._tuned_interface.active_profile()
         if active_tuned_profile == tuned_profile:
             return True
@@ -174,6 +239,9 @@ class Controller(exports.interfaces.ExportableInterface):
         return bool(ok)
 
     def initialize(self):
+        """
+        Initializes the controller.
+        """
         self._active_profile = None
         self._profile_holds = ProfileHoldManager(self)
         self._performance_degraded = PerformanceDegraded.NONE
@@ -184,6 +252,9 @@ class Controller(exports.interfaces.ExportableInterface):
         self._save_base_profile(self._base_profile)
 
     def run(self):
+        """
+        Exports the DBus interface and runs the main daemon loop.
+        """
         exports.start()
         while not self._cmd.wait(self._terminate, 1):
             self._check_performance_degraded()
@@ -191,16 +262,31 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @property
     def bus(self):
+        """
+        DBus interface for communication with other services.
+        """
         return self._bus
 
     @property
     def base_profile(self):
+        """
+        The base PPD profile. This is the profile to restore when
+        all profile holds are released or when tuned-ppd is restarted.
+        It may not be equal to the currently active profile.
+        """
         return self._base_profile
 
     def terminate(self):
+        """
+        Stops the main loop of the daemon.
+        """
         self._terminate.set()
 
     def switch_profile(self, profile):
+        """
+        Sets the currently active profile to the given one, if not already set.
+        Does not change the base profile.
+        """
         if not self._set_tuned_profile(self._config.ppd_to_tuned.get(profile, self._on_battery)):
             return False
         if self._active_profile != profile:
@@ -210,6 +296,9 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @exports.export("sss", "u")
     def HoldProfile(self, profile, reason, app_id, caller):
+        """
+        Initiates a profile hold and returns a cookie for referring to it.
+        """
         if profile != PPD_POWER_SAVER and profile != PPD_PERFORMANCE:
             raise dbus.exceptions.DBusException(
                 "Only '%s' and '%s' profiles may be held" % (PPD_POWER_SAVER, PPD_PERFORMANCE)
@@ -218,16 +307,26 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @exports.export("u", "")
     def ReleaseProfile(self, cookie, caller):
+        """
+        Releases a held profile with the given cookie.
+        """
         if not self._profile_holds.has(cookie):
             raise dbus.exceptions.DBusException("No active hold for cookie '%s'" % cookie)
         self._profile_holds.remove(cookie)
 
     @exports.signal("u")
     def ProfileReleased(self, cookie):
+        """
+        The DBus signal sent when a held profile is released.
+        """
         pass
 
     @exports.property_setter("ActiveProfile")
     def set_active_profile(self, profile):
+        """
+        Sets the base profile to the given one and also makes it active.
+        If there are any active profile holds, these are cancelled.
+        """
         if profile not in self._config.ppd_to_tuned.keys(self._on_battery):
             raise dbus.exceptions.DBusException("Invalid profile '%s'" % profile)
         log.debug("Setting base profile to %s" % profile)
@@ -239,10 +338,16 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @exports.property_getter("ActiveProfile")
     def get_active_profile(self):
+        """
+        Returns the currently active PPD profile.
+        """
         return self._active_profile
 
     @exports.property_getter("Profiles")
     def get_profiles(self):
+        """
+        Returns a DBus array of all available PPD profiles.
+        """
         return dbus.Array(
             [{"Profile": profile, "Driver": DRIVER} for profile in self._config.ppd_to_tuned.keys(self._on_battery)],
             signature="a{sv}",
@@ -250,12 +355,21 @@ class Controller(exports.interfaces.ExportableInterface):
 
     @exports.property_getter("Actions")
     def get_actions(self):
+        """
+        Returns a DBus array of all available actions (currently there are none).
+        """
         return dbus.Array([], signature="s")
 
     @exports.property_getter("PerformanceDegraded")
     def get_performance_degraded(self):
+        """
+        Returns the current performance degradation status.
+        """
         return self._performance_degraded
 
     @exports.property_getter("ActiveProfileHolds")
     def get_active_profile_holds(self):
+        """
+        Returns a DBus array of active profile holds.
+        """
         return self._profile_holds.as_dbus_array()


### PR DESCRIPTION
This PR brings another round of tuned-ppd adjustments and bug fixes. The individual commit messages explain why the changes are being made.

The most prominent change is dropping reverse profile mapping, i.e., from TuneD to PPD profiles. Instead, the daemon now keeps track of the currently active profile and the so-called base profile. This improves tuned-ppd in two ways:

1. Profile mappings now don't have to be injective.
2. When tuned-ppd is restarted, the initial profile is not the last active profile as inferred from the restored TuneD profile, but the last base profile, as saved into a file by tuned-ppd. The active and the base profile may differ due to profile holds being active before the restart. These should arguably be released when tuned-ppd is restarted.