### PR TITLE
controller init: set _on_battery before switching profile

### DIFF
--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -138,8 +138,8 @@ class Controller(exports.interfaces.ExportableInterface):
         self._config = PPDConfig(PPD_CONFIG_FILE)
         active_profile = self.active_profile()
         self._base_profile = active_profile if active_profile != UNKNOWN_PROFILE else self._config.default_profile
-        self.switch_profile(self._base_profile)
         self._on_battery = False
+        self.switch_profile(self._base_profile)
         if self._config.battery_detection:
             self.setup_battery_signaling()
 


### PR DESCRIPTION
Since 6ef5b58e , switch_profile expects self._on_battery to be set, but when it's called in Controller.initialize, it is called before we do self._on_battery = False , and will crash with
AttributeError: 'Controller' object has no attribute '_on_battery' if the requested profile is not the currently active one.

This fixes that by moving the call to switch_profile after self._on_battery is set.