### PR TITLE
Allow shared service drop-in directory

### DIFF
--- a/tuned/plugins/plugin_service.py
+++ b/tuned/plugins/plugin_service.py
@@ -135,7 +135,7 @@ class SystemdHandler(InitHandler):
 			return
 		dirpath = consts.SERVICE_SYSTEMD_CFG_PATH % name
 		try:
-			os.makedirs(dirpath, consts.DEF_SERVICE_CFG_DIR_MODE)
+			os.makedirs(dirpath, consts.DEF_SERVICE_CFG_DIR_MODE, exist_ok=True)
 		except OSError as e:
 			log.error("Unable to create directory '%s': %s" % (dirpath, e))
 			return


### PR DESCRIPTION
Systemd reads all conf files from a service drop-in directory and merges them.

This change enables the following use case:

Tuning unrelated but local changes can be put into - say:

    /etc/systemd/system/sfptpd.service.d/local.conf

while a simple tuning such as the process affinity mask is rolled out via a tuned profile, like this:

`tuned.conf` snippet:

```
[service]
service.sfptpd=,file:${i:PROFILE_DIR}/tuned-sfptpd.conf
```

`tuned-sfptpd.conf`:

```
[Service]
CPUAffinity=32
```

---

Arguably, this is a natural change, i.e. it establishes symmetry in `cfg_install()` to `cfg_uninstall()`, because `cfg_uninstall()` already allows for the service drop-in directory not being empty.