### PR TITLE
tuned-ppd: Support the new UPower PPD namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ TUNED_USER_PROFILES_DIR = $(TUNED_CFG_DIR)/profiles
 TUNED_RECOMMEND_DIR = $(TUNED_SYSTEM_DIR)/recommend.d
 TUNED_USER_RECOMMEND_DIR = $(TUNED_CFG_DIR)/recommend.d
 BASH_COMPLETIONS = $(DATADIR)/bash-completion/completions
+PPD_BUS_NAMES = org.freedesktop.UPower.PowerProfiles net.hadess.PowerProfiles
 
 copy_executable = install -Dm 0755 $(1) $(2)
 rewrite_shebang = sed -i -r -e $(SHEBANG_REWRITE_REGEX) $(1)
@@ -244,10 +245,14 @@ install: install-dirs
 install-ppd:
 	$(call install_python_script,tuned-ppd.py,$(DESTDIR)/usr/sbin/tuned-ppd)
 	install -Dpm 0644 tuned/ppd/tuned-ppd.service $(DESTDIR)$(UNITDIR)/tuned-ppd.service
-	install -Dpm 0644 tuned/ppd/tuned-ppd.dbus.service $(DESTDIR)$(DATADIR)/dbus-1/system-services/net.hadess.PowerProfiles.service
-	install -Dpm 0644 tuned/ppd/dbus.conf $(DESTDIR)$(DATADIR)/dbus-1/system.d/net.hadess.PowerProfiles.conf
-	install -Dpm 0644 tuned/ppd/tuned-ppd.policy $(DESTDIR)$(DATADIR)/polkit-1/actions/net.hadess.PowerProfiles.policy
 	install -Dpm 0644 tuned/ppd/ppd.conf $(DESTDIR)$(SYSCONFDIR)/tuned/ppd.conf
+	$(foreach bus, $(PPD_BUS_NAMES), \
+		install -Dpm 0644 tuned/ppd/tuned-ppd.dbus.service $(DESTDIR)$(DATADIR)/dbus-1/system-services/$(bus).service; \
+		sed -i 's/?name?/$(bus)/g' $(DESTDIR)$(DATADIR)/dbus-1/system-services/$(bus).service; \
+		install -Dpm 0644 tuned/ppd/dbus.conf $(DESTDIR)$(DATADIR)/dbus-1/system.d/$(bus).conf; \
+		sed -i 's/?name?/$(bus)/g' $(DESTDIR)$(DATADIR)/dbus-1/system.d/$(bus).conf; \
+		install -Dpm 0644 tuned/ppd/tuned-ppd.policy $(DESTDIR)$(DATADIR)/polkit-1/actions/$(bus).policy; \
+		sed -i 's/?name?/$(bus)/g' $(DESTDIR)$(DATADIR)/polkit-1/actions/$(bus).policy;)
 
 clean: clean-html
 	find -name "*.pyc" | xargs rm -f

--- a/tuned-ppd.py
+++ b/tuned-ppd.py
@@ -56,10 +56,10 @@ if __name__ == "__main__":
     handle_signal(signal.SIGTERM, controller.terminate)
     handle_signal(signal.SIGHUP, controller.initialize)
 
-    dbus_exporter = exports.dbus_with_properties.DBusExporterWithProperties(
-        consts.PPD_DBUS_BUS, consts.PPD_DBUS_INTERFACE, consts.PPD_DBUS_OBJECT, consts.PPD_NAMESPACE
-    )
+    for name_dict in consts.PPD_DBUS_NAMES:
+        dbus_exporter = exports.dbus_with_properties.DBusExporterWithProperties(
+            name_dict["bus"], name_dict["interface"], name_dict["object"], name_dict["namespace"])
+        exports.register_exporter(dbus_exporter)
 
-    exports.register_exporter(dbus_exporter)
     exports.register_object(controller)
     controller.run()

--- a/tuned.spec
+++ b/tuned.spec
@@ -630,6 +630,9 @@ fi
 %{_datadir}/dbus-1/system-services/net.hadess.PowerProfiles.service
 %{_datadir}/dbus-1/system.d/net.hadess.PowerProfiles.conf
 %{_datadir}/polkit-1/actions/net.hadess.PowerProfiles.policy
+%{_datadir}/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service
+%{_datadir}/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf
+%{_datadir}/polkit-1/actions/org.freedesktop.UPower.PowerProfiles.policy
 %config(noreplace) %{_sysconfdir}/tuned/ppd.conf
 
 %changelog

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -97,13 +97,25 @@ PREFIX_PROFILE_FACTORY = "System"
 PREFIX_PROFILE_USER = "User"
 
 # PPD-to-tuned API translation daemon configuration
-PPD_NAMESPACE = "net.hadess.PowerProfiles"
-PPD_DBUS_BUS = PPD_NAMESPACE
-PPD_DBUS_OBJECT = "/net/hadess/PowerProfiles"
-PPD_DBUS_INTERFACE = PPD_DBUS_BUS
 PPD_CONFIG_FILE = "/etc/tuned/ppd.conf"
 PPD_BASE_PROFILE_FILE = "/etc/tuned/ppd_base_profile"
 PPD_API_COMPATIBILITY = "0.23"
+PPD_DBUS_BUS = "org.freedesktop.UPower.PowerProfiles"
+PPD_DBUS_BUS_LEGACY = "net.hadess.PowerProfiles"
+PPD_DBUS_NAMES = [
+    {
+        "bus": PPD_DBUS_BUS,
+        "namespace": PPD_DBUS_BUS,
+        "interface": PPD_DBUS_BUS,
+        "object": "/org/freedesktop/UPower/PowerProfiles"
+	},
+    {
+        "bus": PPD_DBUS_BUS_LEGACY,
+        "namespace": PPD_DBUS_BUS_LEGACY,
+        "interface": PPD_DBUS_BUS_LEGACY,
+        "object": "/net/hadess/PowerProfiles"
+	}
+]
 
 # After adding new option to tuned-main.conf add here its name with CFG_ prefix
 # and eventually default value with CFG_DEF_ prefix (default is None)

--- a/tuned/ppd/dbus.conf
+++ b/tuned/ppd/dbus.conf
@@ -4,13 +4,13 @@
 
 <busconfig>
   <policy user="root">
-    <allow own="net.hadess.PowerProfiles"/>
+    <allow own="?name?"/>
   </policy>
 
   <policy context="default">
-    <allow send_destination="net.hadess.PowerProfiles" send_interface="net.hadess.PowerProfiles"/>
-    <allow send_destination="net.hadess.PowerProfiles" send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="net.hadess.PowerProfiles" send_interface="org.freedesktop.DBus.Properties"/>
-    <allow send_destination="net.hadess.PowerProfiles" send_interface="org.freedesktop.DBus.Peer"/>
+    <allow send_destination="?name?" send_interface="?name?"/>
+    <allow send_destination="?name?" send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="?name?" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="?name?" send_interface="org.freedesktop.DBus.Peer"/>
   </policy>
 </busconfig>

--- a/tuned/ppd/tuned-ppd.dbus.service
+++ b/tuned/ppd/tuned-ppd.dbus.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
-Name=net.hadess.PowerProfiles
+Name=?name?
 Exec=/bin/false
 User=root
 SystemdService=tuned-ppd.service

--- a/tuned/ppd/tuned-ppd.policy
+++ b/tuned/ppd/tuned-ppd.policy
@@ -6,7 +6,7 @@
   <vendor>TuneD</vendor>
   <vendor_url>https://tuned-project.org/</vendor_url>
 
-  <action id="net.hadess.PowerProfiles.HoldProfile">
+  <action id="?name?.HoldProfile">
     <description>Hold power profile</description>
     <message>Authentication is required to hold power profiles.</message>
     <defaults>
@@ -16,7 +16,7 @@
     </defaults>
   </action>
   
-  <action id="net.hadess.PowerProfiles.ReleaseProfile">
+  <action id="?name?.ReleaseProfile">
     <description>Release power profile</description>
     <message>Authentication is required to release power profiles.</message>
     <defaults>

--- a/tuned/ppd/tuned-ppd.service
+++ b/tuned/ppd/tuned-ppd.service
@@ -6,6 +6,7 @@ Before=multi-user.target display-manager.target
 
 [Service]
 Type=dbus
+BusName=org.freedesktop.UPower.PowerProfiles
 BusName=net.hadess.PowerProfiles
 ExecStart=/usr/sbin/tuned-ppd -l
 


### PR DESCRIPTION
Since version 0.20, power-profiles-daemon exposes
its DBus interface under "org.freedesktop.UPower.PowerProfiles" alongside the previous name. To be compatible with PPD, this commit implements the same change into tuned-ppd.

Resolves: #683