### PR TITLE
`check_positive` has some contradictions

### DIFF
--- a/tuned-adm.py
+++ b/tuned-adm.py
@@ -34,7 +34,7 @@ def check_positive(value):
 	except ValueError:
 		val = -1
 	if val <= 0:
-		raise argparse.ArgumentTypeError("%s has to be >= 0" % value)
+		raise argparse.ArgumentTypeError("%s has to be > 0" % value)
 	return val
 
 def check_log_level(value):


### PR DESCRIPTION
When the value passed to `--timeout` is 0, the `check_positive` function will check the passed value and still prompt that the passed value needs to be greater than or equal to 0. As shown below：

```bash
ubuntu@VM-24-14-ubuntu:~/github/tuned$ tuned-adm --timeout 0
usage: tuned-adm [-h] [--version] [--debug] [--async] [--timeout TIMEOUT] [--loglevel LOGLEVEL] {list,active,off,profile,profile_info,recommend,verify,auto_profile,profile_mode} ...
tuned-adm: error: argument --timeout/-t: 0 has to be >= 0
```

You can also change `if <= 0` to `if < 0`, but I am not sure whether the `--timeout` value can be 0, so I changed the error message instead of `if <= 0`.