### PR TITLE
fix: expand variables in Plugin._verify_all_device_commands

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -460,7 +460,7 @@ class Plugin(object):
 	def _verify_all_device_commands(self, instance, devices, ignore_missing):
 		ret = True
 		for command in [command for command in list(self._commands.values()) if command["per_device"]]:
-			new_value = instance.options.get(command["name"], None)
+			new_value = self._variables.expand(instance.options.get(command["name"], None))
 			if new_value is None:
 				continue
 			for device in devices:


### PR DESCRIPTION
Need to expand variables before calling the `@command` function. This is actually done for `_execute_all[_non]_device_commands` and `_verify_all_non_device_commands`, but not in `_verify_all_device_commands`.
This adds the missing expansion.