### PR TITLE
Obsolete power-profiles-daemon

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -267,6 +267,9 @@ Additional TuneD profile(s) optimized for OpenShift.
 %package ppd
 Summary: PPD compatibility daemon
 Requires: %{name} = %{version}
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+Obsoletes: power-profiles-daemon < 0.23-2
+%endif
 # The compatibility daemon is swappable for power-profiles-daemon
 Provides: ppd-service
 Conflicts: ppd-service


### PR DESCRIPTION
Set an Obsoletes: tag to remove power-profiles-daemon package.

Resolves: #2293628