### PR TITLE
tuned-ppd: Unify polkit policy with power-profiles-daemon

### DIFF
--- a/tuned/exports/dbus_exporter_with_properties.py
+++ b/tuned/exports/dbus_exporter_with_properties.py
@@ -11,50 +11,62 @@ class DBusExporterWithProperties(DBusExporter):
         self._property_setters = {}
         self._property_getters = {}
 
-        def Get(_, interface_name, property_name):
+        def Get(_, interface_name, property_name, caller):
             if interface_name != self._interface_name:
                 raise DBusException("Unknown interface: %s" % interface_name)
             if property_name not in self._property_getters:
                 raise DBusException("No such property: %s" % property_name)
             getter = self._property_getters[property_name]
-            return getter()
+            return getter(caller)
 
-        def Set(_, interface_name, property_name, value):
+        def Set(_, interface_name, property_name, value, caller):
             if interface_name != self._interface_name:
                 raise DBusException("Unknown interface: %s" % interface_name)
             if property_name not in self._property_setters:
                 raise DBusException("No such property: %s" % property_name)
             setter = self._property_setters[property_name]
-            setter(value)
+            setter(value, caller)
 
-        def GetAll(_, interface_name):
+        def GetAll(_, interface_name, caller):
             if interface_name != self._interface_name:
                 raise DBusException("Unknown interface: %s" % interface_name)
-            return {name: getter() for name, getter in self._property_getters.items()}
+            return {name: getter(caller) for name, getter in self._property_getters.items()}
 
         def PropertiesChanged(_, interface_name, changed_properties, invalidated_properties):
             if interface_name != self._interface_name:
                 raise DBusException("Unknown interface: %s" % interface_name)
 
-        self._dbus_methods["Get"] = method(PROPERTIES_IFACE, in_signature="ss", out_signature="v")(Get)
-        self._dbus_methods["Set"] = method(PROPERTIES_IFACE, in_signature="ssv")(Set)
-        self._dbus_methods["GetAll"] = method(PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}")(GetAll)
+        self._dbus_methods["Get"] = method(PROPERTIES_IFACE, in_signature="ss", out_signature="v", sender_keyword="caller")(Get)
+        self._dbus_methods["Set"] = method(PROPERTIES_IFACE, in_signature="ssv", sender_keyword="caller")(Set)
+        self._dbus_methods["GetAll"] = method(PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}", sender_keyword="caller")(GetAll)
         self._dbus_methods["PropertiesChanged"] = signal(PROPERTIES_IFACE, signature="sa{sv}as")(PropertiesChanged)
         self._signals.add("PropertiesChanged")
+
+    def _auth_wrapper(self, method, action_name):
+        def wrapper(*args, **kwargs):
+            new_args = self._polkit_auth(action_name, *args)
+            if new_args[-1] == "":
+                raise DBusException("Unauthorized")
+            return method(*new_args, **kwargs)
+        return wrapper
 
     def property_changed(self, property_name, value):
         self.send_signal("PropertiesChanged", self._interface_name, {property_name: value}, {})
 
-    def property_getter(self, method, property_name):
+    def property_getter(self, method, property_name, action_name=None):
         if not ismethod(method):
             raise Exception("Only bound methods can be exported.")
         if property_name in self._property_getters:
             raise Exception("A getter for this property is already registered.")
+        if action_name is not None:
+            method = self._auth_wrapper(method, action_name)
         self._property_getters[property_name] = method
 
-    def property_setter(self, method, property_name):
+    def property_setter(self, method, property_name, action_name=None):
         if not ismethod(method):
             raise Exception("Only bound methods can be exported.")
         if property_name in self._property_setters:
             raise Exception("A setter for this property is already registered.")
+        if action_name is not None:
+            method = self._auth_wrapper(method, action_name)
         self._property_setters[property_name] = method

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -408,7 +408,7 @@ class Controller(exports.interfaces.ExportableInterface):
             self._active_profile = profile
         return True
 
-    @exports.export("sss", "u")
+    @exports.export("sss", "u", "hold-profile")
     def HoldProfile(self, profile, reason, app_id, caller):
         """
         Initiates a profile hold and returns a cookie for referring to it.
@@ -419,7 +419,7 @@ class Controller(exports.interfaces.ExportableInterface):
             )
         return self._profile_holds.add(profile, reason, app_id, caller)
 
-    @exports.export("u", "")
+    @exports.export("u", "", "release-profile")
     def ReleaseProfile(self, cookie, caller):
         """
         Releases a held profile with the given cookie.
@@ -435,8 +435,8 @@ class Controller(exports.interfaces.ExportableInterface):
         """
         pass
 
-    @exports.property_setter("ActiveProfile")
-    def set_active_profile(self, profile):
+    @exports.property_setter("ActiveProfile", "switch-profile")
+    def set_active_profile(self, profile, caller):
         """
         Sets the base profile to the given one and also makes it active.
         If there are any active profile holds, these are cancelled.
@@ -451,14 +451,14 @@ class Controller(exports.interfaces.ExportableInterface):
         self._save_base_profile(profile)
 
     @exports.property_getter("ActiveProfile")
-    def get_active_profile(self):
+    def get_active_profile(self, caller):
         """
         Returns the currently active PPD profile.
         """
         return self._active_profile
 
     @exports.property_getter("Profiles")
-    def get_profiles(self):
+    def get_profiles(self, caller):
         """
         Returns a DBus array of all available PPD profiles.
         """
@@ -468,26 +468,26 @@ class Controller(exports.interfaces.ExportableInterface):
         )
 
     @exports.property_getter("Actions")
-    def get_actions(self):
+    def get_actions(self, caller):
         """
         Returns a DBus array of all available actions (currently there are none).
         """
         return dbus.Array([], signature="s")
 
     @exports.property_getter("PerformanceDegraded")
-    def get_performance_degraded(self):
+    def get_performance_degraded(self, caller):
         """
         Returns the current performance degradation status.
         """
         return self._performance_degraded
 
     @exports.property_getter("ActiveProfileHolds")
-    def get_active_profile_holds(self):
+    def get_active_profile_holds(self, caller):
         """
         Returns a DBus array of active profile holds.
         """
         return self._profile_holds.as_dbus_array()
 
     @exports.property_getter("Version")
-    def version(self):
+    def version(self, caller):
         return PPD_API_COMPATIBILITY

--- a/tuned/ppd/tuned-ppd.policy
+++ b/tuned/ppd/tuned-ppd.policy
@@ -6,7 +6,17 @@
   <vendor>TuneD</vendor>
   <vendor_url>https://tuned-project.org/</vendor_url>
 
-  <action id="?name?.HoldProfile">
+  <action id="?name?.switch-profile">
+    <description>Switch power profile</description>
+    <message>Authentication is required to switch power profiles.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="?name?.hold-profile">
     <description>Hold power profile</description>
     <message>Authentication is required to hold power profiles.</message>
     <defaults>
@@ -16,7 +26,7 @@
     </defaults>
   </action>
   
-  <action id="?name?.ReleaseProfile">
+  <action id="?name?.release-profile">
     <description>Release power profile</description>
     <message>Authentication is required to release power profiles.</message>
     <defaults>


### PR DESCRIPTION
Rename HoldProfile/ReleaseProfile polkit actions to hold-profile/release-profile.

Add the switch-profile action and check against it when switching the profile using the ActiveProfile DBus property.

The changes require some refactoring of the DBusExporter class, mainly because we need to be able to supply a custom polkit action name instead of deriving it from the DBus method name.