### PR TITLE
plugin_scheduler: make perf support optional

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -83,7 +83,7 @@ BuildRequires: %{_py}-mock
 %endif
 BuildRequires: %{_py}-pyudev
 Requires: %{_py}-pyudev
-Requires: %{_py}-linux-procfs, %{_py}-perf
+Requires: %{_py}-linux-procfs
 Requires: %{_py}-inotify
 %if %{without python3}
 Requires: %{_py}-schedutils
@@ -93,9 +93,6 @@ Requires: %{_py}-schedutils
 # BuildRequires for 'make test'
 BuildRequires: python3-dbus, python3-gobject-base
 Requires: python3-dbus, python3-gobject-base
-%if 0%{?fedora} > 22 || 0%{?rhel} > 7
-Recommends: dmidecode
-%endif
 %else
 # BuildRequires for 'make test'
 BuildRequires: dbus-python, pygobject3-base
@@ -105,11 +102,15 @@ Requires: virt-what, ethtool, gawk
 Requires: util-linux, dbus, polkit
 %if 0%{?fedora} > 22 || 0%{?rhel} > 7
 Recommends: dmidecode
+# https://src.fedoraproject.org/rpms/tuned/pull-request/8
+Recommends: %{_py}-perf
 # i686 excluded
 Recommends: kernel-tools
 Requires: hdparm
 Requires: kmod
 Requires: iproute
+%else
+Requires: %{_py}-perf
 %endif
 # syspurpose
 %if 0%{?rhel} > 8

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -77,6 +77,9 @@ ACPI_DIR = "/sys/firmware/acpi"
 # built-in functions configuration
 SYSFS_CPUS_PATH = "/sys/devices/system/cpu"
 
+# present CPUs
+SYSFS_CPUS_PRESENT_PATH = "%s/present" % SYSFS_CPUS_PATH
+
 # number of backups
 LOG_FILE_COUNT = 2
 LOG_FILE_MAXBYTES = 100*1000


### PR DESCRIPTION
Requested in: https://src.fedoraproject.org/rpms/tuned/pull-request/8