### PR TITLE
scheduler: Log process info when its affinity cannot be changed and re-check blacklisted cgroups

### DIFF
--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -661,6 +661,9 @@ class SchedulerPlugin(base.Plugin):
 					log.warning("Affinity of task with PID %d cannot be changed, the task's affinity mask is fixed."
 							% pid)
 				return True
+			log.info("Task %d cmdline: %s" % (pid, self._get_cmdline(process)))
+			log.info("Task %d cgroup: %s" % (pid, self._get_stat_cgroup(process)))
+			log.info("Task %d affinity: %s" % (pid, list(self._scheduler_utils.get_affinity(pid))))
 		except (OSError, IOError) as e:
 			if e.errno == errno.ENOENT or e.errno == errno.ESRCH:
 				log.debug("Failed to get task info for PID %d, the task vanished."


### PR DESCRIPTION
Include the current affinity of the process, its cmdline, and its cgroups in the logs. This may help identify issues with tuning, e.g., in cases when the process disappears soon after affining it fails.

Resolves: RHEL-69933

Update: It may happen that a process gets moved into a blacklisted cgroup
after the initial filtering of processes according to the blacklist.
When setting its affinity fails, re-check whether that is the case,
and if yes, ignore the error.

Resolves: RHEL-72981