### PR TITLE
doc: enable documentation generation on RHEL with asciidoc

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -2,7 +2,7 @@
 
 index.html: master.adoc assemblies/*.adoc meta/*.adoc modules/performance/*.adoc ../../tuned/plugins/plugin_*.py
 	python3 ../../compile_plugin_docs.py modules/performance/ref_available-tuned-plug-ins_intro.adoc modules/performance/ref_available-tuned-plug-ins.adoc
-	asciidoctor -o index.html master.adoc || asciidoc -o index.html master.adoc
+	asciidoctor -o index.html master.adoc || asciidoc -d book -o index.html master.adoc
 
 install: index.html
 	install -Dpm 0644 index.html $(DESTDIR)$(DOCDIR)/manual/index.html

--- a/doc/manual/modules/performance/con_built-in-functions-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_built-in-functions-in-tuned-profiles.adoc
@@ -12,7 +12,7 @@ You can:
 
 To call a function, use the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 ${f:[replaceable]__function_name__:[replaceable]__argument_1__:[replaceable]__argument_2__}
 ----

--- a/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
@@ -7,7 +7,7 @@
 
 The `[main]` section of *TuneD* profiles recognizes the [option]`include` option:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 [main]
 include=[replaceable]_parent_

--- a/doc/manual/modules/performance/con_tuned-plug-ins.adoc
+++ b/doc/manual/modules/performance/con_tuned-plug-ins.adoc
@@ -20,7 +20,7 @@ Each tuning plug-in tunes an individual subsystem and takes several parameters t
 
 Sections describing plug-in instances are formatted in the following way:
 
-[subs=quotes]
+[subs="quotes"]
 ----
 [_NAME_]
 type=_TYPE_
@@ -69,7 +69,7 @@ If the plug-in supports more options, they can be also specified in the plug-in 
 
 If you do not need custom names for the plug-in instance and there is only one definition of the instance in your configuration file, *TuneD* supports the following short syntax:
 
-[subs=quotes]
+[subs="quotes"]
 ----
 [_TYPE_]
 devices=_DEVICES_

--- a/doc/manual/modules/performance/con_variables-and-built-in-functions-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_variables-and-built-in-functions-in-tuned-profiles.adoc
@@ -13,7 +13,7 @@ Using *TuneD* variables reduces the amount of necessary typing in *TuneD* profil
 
 There are no predefined variables in *TuneD* profiles. You can define your own variables by creating the `[variables]` section in a profile and using the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 [variables]
 
@@ -22,7 +22,7 @@ There are no predefined variables in *TuneD* profiles. You can define your own v
 
 To expand the value of a variable in a profile, use the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 ${[replaceable]__variable_name__}
 ----
@@ -41,7 +41,7 @@ cmdline=isolcpus=${isolated_cores}
 
 The variables can be specified in a separate file. For example, you can add the following lines to [filename]`tuned.conf`:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 [variables]
 include=/etc/tuned/[replaceable]_my-variables.conf_
@@ -60,7 +60,7 @@ If you add the [option]`isolated_cores=1,2` option to the [filename]`/etc/tuned/
 
 To call a function, use the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 ${f:[replaceable]__function_name__:[replaceable]__argument_1__:[replaceable]__argument_2__}
 ----

--- a/doc/manual/modules/performance/con_variables-in-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_variables-in-tuned-profiles.adoc
@@ -9,7 +9,7 @@ Using *TuneD* variables reduces the amount of necessary typing in *TuneD* profil
 
 There are no predefined variables in *TuneD* profiles. You can define your own variables by creating the `[variables]` section in a profile and using the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 [variables]
 
@@ -18,7 +18,7 @@ There are no predefined variables in *TuneD* profiles. You can define your own v
 
 To expand the value of a variable in a profile, use the following syntax:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 ${[replaceable]__variable_name__}
 ----
@@ -37,7 +37,7 @@ cmdline=isolcpus=${isolated_cores}
 
 The variables can be specified in a separate file. For example, you can add the following lines to [filename]`tuned.conf`:
 
-[subs=+quotes]
+[subs="quotes"]
 ----
 [variables]
 include=/etc/tuned/[replaceable]_my-variables.conf_

--- a/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 . In the [filename]`/etc/tuned/profiles/` directory, create a new directory named the same as the profile that you want to create:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # mkdir /etc/tuned/profiles/[replaceable]_my-profile_
 ----
@@ -48,14 +48,14 @@ alpm=medium_power
 
 . To activate the profile, use:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile [replaceable]_my-profile_
 ----
 
 . Verify that the *TuneD* profile is active and the system settings are applied:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ tuned-adm active
 

--- a/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
+++ b/doc/manual/modules/performance/proc_installing-and-enabling-tuned.adoc
@@ -33,7 +33,7 @@ This procedure installs and enables the *TuneD* application, installs *TuneD* pr
 
 . Verify that a *TuneD* profile is active and applied:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ tuned-adm active
 

--- a/doc/manual/modules/performance/proc_listing-available-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_listing-available-tuned-profiles.adoc
@@ -16,7 +16,7 @@ This procedure lists all *TuneD* profiles that are currently available on your s
 
 * To list all available *TuneD* profiles on your system, use:
 +
-[subs="+quotes",options="+nowrap",role=white-space-pre]
+[subs="quotes"]
 ----
 $ *tuned-adm list*
 
@@ -35,7 +35,7 @@ Current active profile: [replaceable]_balanced_
 
 * To display only the currently active profile, use:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ *tuned-adm active*
 

--- a/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_modifying-existing-tuned-profiles.adoc
@@ -19,14 +19,14 @@ endif::[]
 
 . In the [filename]`/etc/tuned/profiles/` directory, create a new directory named the same as the profile that you want to create:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # mkdir /etc/tuned/profiles/[replaceable]_modified-profile_
 ----
 
 . In the new directory, create a file named [filename]`tuned.conf`, and set the `[main]` section as follows:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 [main]
 include=[replaceable]_parent-profile_
@@ -53,14 +53,14 @@ vm.swappiness=5
 
 . To activate the profile, use:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile [replaceable]_modified-profile_
 ----
 
 . Verify that the *TuneD* profile is active and the system settings are applied:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ tuned-adm active
 

--- a/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
+++ b/doc/manual/modules/performance/proc_setting-a-tuned-profile.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 . Optionally, you can let *TuneD* recommend the most suitable profile for your system:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm recommend
 
@@ -28,14 +28,14 @@ endif::[]
 
 . Activate a profile:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile [replaceable]_selected-profile_
 ----
 +
 Alternatively, you can activate a combination of multiple profiles:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile [replaceable]_profile1_ [replaceable]_profile2_
 ----
@@ -51,7 +51,7 @@ The following example optimizes the system to run in a virtual machine with the 
 
 . View the current active *TuneD* profile on your system:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm active
 

--- a/doc/manual/modules/performance/proc_setting-the-disk-scheduler-using-tuned.adoc
+++ b/doc/manual/modules/performance/proc_setting-the-disk-scheduler-using-tuned.adoc
@@ -21,9 +21,6 @@ endif::[]
 ifdef::pantheonenv[]
 :installing-tuned-link: pass:macros[xref:modules/performance/proc_installing-and-enabling-tuned.adoc[Installing and enabling Tuned]]
 endif::[]
-ifdef::upstream[]
-:installing-tuned-link: pass:macros[xref:installing-and-enabling-tuned_getting-started-with-tuned[]]
-endif::[]
 
 // Use a link elsewhere.
 ifndef::performance-title[]
@@ -43,9 +40,6 @@ endif::[]
 ifdef::pantheonenv[]
 :tuned-profiles-link: pass:macros[xref:modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc[Tuned profiles distributed with RHEL]]
 endif::[]
-ifdef::upstream[]
-:tuned-profiles-link: pass:macros[xref:tuned-profiles-distributed-with-rhel_getting-started-with-tuned[]]
-endif::[]
 
 // Use a link elsewhere.
 ifndef::performance-title[]
@@ -62,14 +56,14 @@ $ tuned-adm active
 
 . Create a new directory to hold your *TuneD* profile:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # mkdir /etc/tuned/profiles/[replaceable]__my-profile__
 ----
 
 . Find the system unique identifier of the selected block device:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ udevadm info --query=property --name=/dev/_device_ | grep -E '(WWN|SERIAL)'
 
@@ -87,7 +81,7 @@ The command in the this example will return all values identified as a World Wid
 
 .. Optional: Include an existing profile:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 [main]
 include=_existing-profile_
@@ -95,7 +89,7 @@ include=_existing-profile_
 
 .. Set the selected disk scheduler for the device that matches the WWN identifier:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 [disk]
 devices_udev_regex=_IDNAME_=_device system unique id_
@@ -109,14 +103,14 @@ Here:
 +
 To match multiple devices in the `devices_udev_regex` option, enclose the identifiers in parentheses and separate them with vertical bars:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 devices_udev_regex=(ID_WWN=_0x5002538d00000000_)|(ID_WWN=_0x1234567800000000_)
 ----
 
 . Enable your profile:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile [replaceable]__my-profile__
 ----
@@ -125,7 +119,7 @@ devices_udev_regex=(ID_WWN=_0x5002538d00000000_)|(ID_WWN=_0x1234567800000000_)
 
 . Verify that the TuneD profile is active and applied:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 $ tuned-adm active
 
@@ -150,9 +144,6 @@ endif::[]
 endif::[]
 ifdef::pantheonenv[]
 :customizing-tuned-link: pass:macros[xref:assemblies/assembly_customizing-tuned-profiles.adoc[Customizing Tuned Profiles]]
-endif::[]
-ifdef::upstream[]
-:customizing-tuned-link: pass:macros[xref:customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance[Customizing Tuned profiles]]
 endif::[]
 // Use a link elsewhere.
 ifndef::performance-title[]

--- a/doc/manual/modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc
+++ b/doc/manual/modules/performance/ref_tuned-profiles-distributed-with-rhel.adoc
@@ -90,7 +90,7 @@ printk value. This should make the serial console more responsive.
 This profile is intended to be used as an overlay on other
 profiles. For example:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile throughput-performance optimize-serial-console
 ----
@@ -104,7 +104,7 @@ A profile optimized for PostgreSQL databases loads based on `throughput-performa
 `intel-sst`::
 A profile optimized for systems with user-defined Intel Speed Select Technology configurations. This profile is intended to be used as an overlay on other profiles. For example:
 +
-[subs=+quotes]
+[subs="quotes"]
 ----
 # tuned-adm profile cpu-partitioning intel-sst
 ----

--- a/tuned.spec
+++ b/tuned.spec
@@ -292,11 +292,7 @@ to TuneD from power-profiles-daemon (PPD).
 %autosetup -p1 -n %{name}-%{version}%{?prerel2}
 
 %build
-# Docs cannot be generated on RHEL now due to missing asciidoctor dependency
-# asciidoc doesn't seem to be compatible
-%if ! 0%{?rhel}
 make html %{make_python_arg}
-%endif
 
 %install
 make install DESTDIR=%{buildroot} DOCDIR=%{docdir} %{make_python_arg} \

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -36,14 +36,14 @@ class BootloaderPlugin(base.Plugin):
 
 	The kernel options can be specified by the following syntax:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	cmdline__suffix__=__arg1__ __arg2__ ... __argN__
 	----
 
 	Or with an alternative, but equivalent syntax:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	cmdline__suffix__=+__arg1__ __arg2__ ... __argN__
 	----
@@ -60,7 +60,7 @@ class BootloaderPlugin(base.Plugin):
 
 	It is also possible to remove kernel options by the following syntax:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	cmdline__suffix__=-__arg1__ __arg2__ ... __argN__
 	----

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -36,7 +36,7 @@ class NetTuningPlugin(hotplug.Plugin):
 	The [option]`coalesce` option allows changing coalescing settings
 	for the specified network devices. The syntax is:
 	+
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	coalesce=__param1__ __value1__ __param2__ __value2__ ... __paramN__ __valueN__
 	----

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -215,7 +215,7 @@ class SchedulerPlugin(base.Plugin):
 	To adjust scheduling policy, priority and affinity for a group of
 	processes/threads, use the following syntax.
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	group.__groupname__=__rule_prio__:__sched__:__prio__:__affinity__:__regex__
 	----
@@ -227,7 +227,7 @@ class SchedulerPlugin(base.Plugin):
 	defined. However, this is Python interpreter dependant. To disable
 	an inherited rule for `__groupname__` use:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	group.__groupname__=
 	----
@@ -245,7 +245,7 @@ class SchedulerPlugin(base.Plugin):
 
 	`__regex__` is Python regular expression. It is matched against the output of:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	ps -eo cmd
 	----

--- a/tuned/plugins/plugin_service.py
+++ b/tuned/plugins/plugin_service.py
@@ -174,7 +174,7 @@ class ServicePlugin(base.Plugin):
 
 	The syntax is as follows:
 
-	[subs="+quotes,+macros"]
+	[subs="quotes"]
 	----
 	[service]
 	service.__service_name__=__commands__[,file:__file__]


### PR DESCRIPTION
With this patch the documentation will be also generated on RHEL with now obsoleted asciidoc tool. The styling is a bit lame, but it's usable.
