### PR TITLE
tuned-ppd: Fix handling of profile change signals from TuneD

### DIFF
--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -243,7 +243,6 @@ class Controller(exports.interfaces.ExportableInterface):
         """
         if not result:
             return
-        self._profile_holds.clear()
         if tuned_profile != self._tuned_interface.active_profile():
             log.debug("Received a profile change signal from TuneD, but it is not relevant anymore.")
             return
@@ -254,6 +253,7 @@ class Controller(exports.interfaces.ExportableInterface):
             log.warning("TuneD profile changed to an unknown profile '%s'" % tuned_profile)
         if self._active_profile != ppd_profile:
             log.info("Profile changed to '%s'" % ppd_profile)
+            self._profile_holds.clear()
             self._active_profile = ppd_profile
             exports.property_changed("ActiveProfile", self._active_profile)
             if ppd_profile != UNKNOWN_PROFILE:

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -244,6 +244,9 @@ class Controller(exports.interfaces.ExportableInterface):
         if not result:
             return
         self._profile_holds.clear()
+        if tuned_profile != self._tuned_interface.active_profile():
+            log.debug("Received a profile change signal from TuneD, but it is not relevant anymore.")
+            return
         try:
             ppd_profile = self._config.tuned_to_ppd.get(tuned_profile, self._on_battery)
         except KeyError:


### PR DESCRIPTION
Two adjustments needed:
- If multiple profile changes happen too quickly, we must handle the signal only from the last one - i.e., the one that matches the current TuneD profile.
- We must not clear profile holds with each signal from TuneD - the signals come even if the profile change was initiated by tuned-ppd itself.