### PR TITLE
plugin_net: added support for hotplug and rename

### DIFF
--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -139,7 +139,7 @@ class PluginBaseTestCase(unittest.TestCase):
 		command = [com for com in self._commands_plugin._commands.values()\
 			if com['name'] == 'size'][0]
 
-		self.assertEqual(self._commands_plugin._get_current_value(command),'S')
+		self.assertEqual(self._commands_plugin._get_current_value(instance, command),'S')
 
 	def test_norm_value(self):
 		self.assertEqual(self._plugin._norm_value('"000000021"'),'21')
@@ -211,25 +211,25 @@ class CommandsPlugin(Plugin):
 		return {'size':'S','device_setting':'101'}
 
 	@decorators.command_set('size')
-	def _set_size(self, new_size, sim, remove):
+	def _set_size(self, new_size, instance, sim, remove):
 		self._size = new_size
 		return new_size
 
 	@decorators.command_get('size')
-	def _get_size(self):
+	def _get_size(self, instance):
 		return self._size
 
-	@decorators.command_set('device_setting',per_device = True)
-	def _set_device_setting(self,value,device,sim,remove):
+	@decorators.command_set('device_setting', per_device = True)
+	def _set_device_setting(self, value, device, instance, sim, remove):
 		device.setting = value
 		return device.setting
 
 	@decorators.command_get('device_setting')
-	def _get_device_setting(self,device,ignore_missing = False):
+	def _get_device_setting(self, device, instance, ignore_missing = False):
 		return device.setting
 
 	@decorators.command_custom('custom_name')
-	def the_most_custom_command(self):
+	def the_most_custom_command(self, instance):
 		return True
 
 class BadCommandsPlugin(Plugin):

--- a/tuned/hardware/inventory.py
+++ b/tuned/hardware/inventory.py
@@ -41,10 +41,17 @@ class Inventory(object):
 	def get_device(self, subsystem, sys_name):
 		"""Get a pyudev.Device object for the sys_name (e.g. 'sda')."""
 		try:
-			return pyudev.Devices.from_name(self._udev_context, subsystem, sys_name)
+			try:
+				d = pyudev.Devices.from_name(self._udev_context, subsystem, sys_name)
+			except pyudev.DeviceNotFoundByNameError:
+				d = None
 		# workaround for pyudev < 0.18
 		except AttributeError:
-			return pyudev.Device.from_name(self._udev_context, subsystem, sys_name)
+			try:
+				d = pyudev.Device.from_name(self._udev_context, subsystem, sys_name)
+			except pyudev.DeviceNotFoundByNameError:
+				d = None
+		return d
 
 	def get_devices(self, subsystem):
 		"""Get list of devices on a given subsystem."""

--- a/tuned/monitors/monitor_net.py
+++ b/tuned/monitors/monitor_net.py
@@ -30,10 +30,20 @@ class NetMonitor(tuned.monitors.Monitor):
 		return (int) (0.6 * 1024 * 1024 * speed / 8)
 
 	@classmethod
+	def _set_dev_map(cls, map_fce):
+		cls.map_fce = map_fce
+
+	@classmethod
+	def _dev_map(cls, dev):
+		try:
+			return cls.map_fce(dev)
+		except AttributeError:
+			return dev
+	@classmethod
 	def _updateStat(cls, dev):
 		files = ["rx_bytes", "rx_packets", "tx_bytes", "tx_packets"]
 		for i,f in enumerate(files):
-			cls._load[dev][i] = cmd.read_file("/sys/class/net/" + dev + "/statistics/" + f, err_ret = "0").strip()
+			cls._load[dev][i] = cmd.read_file("/sys/class/net/" + cls._dev_map(dev) + "/statistics/" + f, err_ret = "0").strip()
 
 	@classmethod
 	def update(cls):

--- a/tuned/plugins/hotplug.py
+++ b/tuned/plugins/hotplug.py
@@ -27,11 +27,14 @@ class Plugin(base.Plugin):
 
 	def _hardware_events_callback(self, event, device):
 		if event == "add":
-			log.info("device '%s' added" % device.sys_name)
+			log.info("device '%s', add event" % device.sys_name)
 			self._add_device(device.sys_name)
 		elif event == "remove":
-			log.info("device '%s' removed" % device.sys_name)
+			log.info("device '%s', remove event" % device.sys_name)
 			self._remove_device(device.sys_name)
+		elif event == "move":
+			log.info("device: '%s', rename event, reported new name" % device.sys_name)
+			self._move_device(device.sys_name)
 
 	def _add_device_process(self, instance, device_name):
 		log.info("instance %s: adding new device %s" % (instance.name, device_name))
@@ -77,6 +80,19 @@ class Plugin(base.Plugin):
 			self._assigned_devices.remove(device_name)
 			return True
 		return False
+
+	def _move_device(self, device_name):
+		"""Rename device in the instance, this probably applies only
+		to network interfaces. The udev device environment is
+		mostly unchanged (except the name) and the old device name
+		isn't announced, thus the rename functionality is plugin
+		dependant and has to be implemented in the child plugin class.
+
+		Parameters:
+		device_name -- new name of the device
+
+		"""
+		pass
 
 	def _remove_device(self, device_name):
 		"""Remove device from the instance

--- a/tuned/plugins/plugin_acpi.py
+++ b/tuned/plugins/plugin_acpi.py
@@ -52,7 +52,7 @@ class ACPIPlugin(base.Plugin):
 		return os.path.join(ACPI_DIR, "platform_profile")
 
 	@command_set("platform_profile")
-	def _set_platform_profile(self, profiles, sim, remove):
+	def _set_platform_profile(self, profiles, instance, sim, remove):
 		if not os.path.isfile(self._platform_profile_path()):
 			log.debug("ACPI platform_profile is not supported on this system")
 			return None
@@ -70,7 +70,7 @@ class ACPIPlugin(base.Plugin):
 		return None
 
 	@command_get("platform_profile")
-	def _get_platform_profile(self, ignore_missing=False):
+	def _get_platform_profile(self, instance, ignore_missing=False):
 		if not os.path.isfile(self._platform_profile_path()):
 			log.debug("ACPI platform_profile is not supported on this system")
 			return None

--- a/tuned/plugins/plugin_audio.py
+++ b/tuned/plugins/plugin_audio.py
@@ -72,7 +72,7 @@ class AudioPlugin(hotplug.Plugin):
 		return "/sys/module/%s/parameters/power_save_controller" % device
 
 	@command_set("timeout", per_device = True)
-	def _set_timeout(self, value, device, sim, remove):
+	def _set_timeout(self, value, device, instance, sim, remove):
 		try:
 			timeout = int(value)
 		except ValueError:
@@ -88,7 +88,7 @@ class AudioPlugin(hotplug.Plugin):
 			return None
 
 	@command_get("timeout")
-	def _get_timeout(self, device, ignore_missing=False):
+	def _get_timeout(self, device, instance, ignore_missing=False):
 		sys_file = self._timeout_path(device)
 		value = cmd.read_file(sys_file, no_error=ignore_missing)
 		if len(value) > 0:
@@ -96,7 +96,7 @@ class AudioPlugin(hotplug.Plugin):
 		return None
 
 	@command_set("reset_controller", per_device = True)
-	def _set_reset_controller(self, value, device, sim, remove):
+	def _set_reset_controller(self, value, device, instance, sim, remove):
 		v = cmd.get_bool(value)
 		sys_file = self._reset_controller_path(device)
 		if os.path.exists(sys_file):
@@ -107,7 +107,7 @@ class AudioPlugin(hotplug.Plugin):
 		return None
 
 	@command_get("reset_controller")
-	def _get_reset_controller(self, device, ignore_missing=False):
+	def _get_reset_controller(self, device, instance, ignore_missing=False):
 		sys_file = self._reset_controller_path(device)
 		if os.path.exists(sys_file):
 			value = cmd.read_file(sys_file)

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -526,7 +526,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return self._cmd.read_file("/sys/devices/system/cpu/%s/cpufreq/scaling_available_governors" % device).strip().split()
 
 	@command_set("governor", per_device=True)
-	def _set_governor(self, governors, device, sim, remove):
+	def _set_governor(self, governors, device, instance, sim, remove):
 		if not self._check_cpu_can_change_governor(device):
 			return None
 		governors = str(governors)
@@ -555,7 +555,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return governor
 
 	@command_get("governor")
-	def _get_governor(self, device, ignore_missing=False):
+	def _get_governor(self, device, instance, ignore_missing=False):
 		governor = None
 		if not self._check_cpu_can_change_governor(device):
 			return None
@@ -572,7 +572,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return "/sys/devices/system/cpu/cpufreq/%s/sampling_down_factor" % governor
 
 	@command_set("sampling_down_factor", per_device = True, priority = 10)
-	def _set_sampling_down_factor(self, sampling_down_factor, device, sim, remove):
+	def _set_sampling_down_factor(self, sampling_down_factor, device, instance, sim, remove):
 		val = None
 
 		# hack to clear governors map when the profile starts unloading
@@ -599,7 +599,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return val
 
 	@command_get("sampling_down_factor")
-	def _get_sampling_down_factor(self, device, ignore_missing=False):
+	def _get_sampling_down_factor(self, device, instance, ignore_missing=False):
 		governor = self._get_governor(device, ignore_missing=ignore_missing)
 		if governor is None:
 			return None
@@ -627,7 +627,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return "/sys/devices/system/cpu/cpu%s/power/energy_perf_bias" % cpu_id
 
 	@command_set("energy_perf_bias", per_device=True)
-	def _set_energy_perf_bias(self, energy_perf_bias, device, sim, remove):
+	def _set_energy_perf_bias(self, energy_perf_bias, device, instance, sim, remove):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -706,7 +706,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 				}.get(self._try_parse_num(s), s)
 
 	@command_get("energy_perf_bias")
-	def _get_energy_perf_bias(self, device, ignore_missing=False):
+	def _get_energy_perf_bias(self, device, instance, ignore_missing=False):
 		energy_perf_bias = None
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
@@ -741,7 +741,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return self._has_pm_qos_resume_latency_us
 
 	@command_set("pm_qos_resume_latency_us", per_device=True)
-	def _set_pm_qos_resume_latency_us(self, pm_qos_resume_latency_us, device, sim, remove):
+	def _set_pm_qos_resume_latency_us(self, pm_qos_resume_latency_us, device, instance, sim, remove):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -757,7 +757,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return latency
 
 	@command_get("pm_qos_resume_latency_us")
-	def _get_pm_qos_resume_latency_us(self, device, ignore_missing=False):
+	def _get_pm_qos_resume_latency_us(self, device, instance, ignore_missing=False):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -766,7 +766,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return self._cmd.read_file(self._pm_qos_resume_latency_us_path(device), no_error=ignore_missing).strip()
 
 	@command_set("boost", per_device=True)
-	def _set_boost(self, boost, device, sim, remove):
+	def _set_boost(self, boost, device, instance, sim, remove):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -785,7 +785,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return None
 
 	@command_get("boost")
-	def _get_boost(self, device, ignore_missing=False):
+	def _get_boost(self, device, instance, ignore_missing=False):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -797,7 +797,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return None
 
 	@command_set("energy_performance_preference", per_device=True)
-	def _set_energy_performance_preference(self, energy_performance_preference, device, sim, remove):
+	def _set_energy_performance_preference(self, energy_performance_preference, device, instance, sim, remove):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None
@@ -823,7 +823,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 		return None
 
 	@command_get("energy_performance_preference")
-	def _get_energy_performance_preference(self, device, ignore_missing=False):
+	def _get_energy_performance_preference(self, device, instance, ignore_missing=False):
 		if not self._is_cpu_online(device):
 			log.debug("%s is not online, skipping" % device)
 			return None

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -335,7 +335,7 @@ class DiskPlugin(hotplug.Plugin):
 		return self._sysfs_path(device, "queue/scheduler")
 
 	@command_set("elevator", per_device=True)
-	def _set_elevator(self, value, device, sim, remove):
+	def _set_elevator(self, value, device, instance, sim, remove):
 		sys_file = self._elevator_file(device)
 		if not sim:
 			self._cmd.write_to_file(sys_file, value, \
@@ -343,14 +343,14 @@ class DiskPlugin(hotplug.Plugin):
 		return value
 
 	@command_get("elevator")
-	def _get_elevator(self, device, ignore_missing=False):
+	def _get_elevator(self, device, instance, ignore_missing=False):
 		sys_file = self._elevator_file(device)
 		# example of scheduler file content:
 		# noop deadline [cfq]
 		return self._cmd.get_active_option(self._cmd.read_file(sys_file, no_error=ignore_missing))
 
 	@command_set("apm", per_device=True)
-	def _set_apm(self, value, device, sim, remove):
+	def _set_apm(self, value, device, instance, sim, remove):
 		if not self._is_hdparm_apm_supported(device):
 			if not sim:
 				log.info("apm option is not supported for device '%s'" % device)
@@ -366,7 +366,7 @@ class DiskPlugin(hotplug.Plugin):
 			return None
 
 	@command_get("apm")
-	def _get_apm(self, device, ignore_missing=False):
+	def _get_apm(self, device, instance, ignore_missing=False):
 		if not self._is_hdparm_apm_supported(device):
 			if not ignore_missing:
 				log.info("apm option is not supported for device '%s'" % device)
@@ -390,7 +390,7 @@ class DiskPlugin(hotplug.Plugin):
 		return value
 
 	@command_set("spindown", per_device=True)
-	def _set_spindown(self, value, device, sim, remove):
+	def _set_spindown(self, value, device, instance, sim, remove):
 		if not self._is_hdparm_apm_supported(device):
 			if not sim:
 				log.info("spindown option is not supported for device '%s'" % device)
@@ -406,7 +406,7 @@ class DiskPlugin(hotplug.Plugin):
 			return None
 
 	@command_get("spindown")
-	def _get_spindown(self, device, ignore_missing=False):
+	def _get_spindown(self, device, instance, ignore_missing=False):
 		if not self._is_hdparm_apm_supported(device):
 			if not ignore_missing:
 				log.info("spindown option is not supported for device '%s'" % device)
@@ -429,7 +429,7 @@ class DiskPlugin(hotplug.Plugin):
 		return v
 
 	@command_set("readahead", per_device=True)
-	def _set_readahead(self, value, device, sim, remove):
+	def _set_readahead(self, value, device, instance, sim, remove):
 		sys_file = self._readahead_file(device)
 		val = self._parse_ra(value)
 		if val is None:
@@ -441,7 +441,7 @@ class DiskPlugin(hotplug.Plugin):
 		return val
 
 	@command_get("readahead")
-	def _get_readahead(self, device, ignore_missing=False):
+	def _get_readahead(self, device, instance, ignore_missing=False):
 		sys_file = self._readahead_file(device)
 		value = self._cmd.read_file(sys_file, no_error=ignore_missing).strip()
 		if len(value) == 0:
@@ -449,7 +449,7 @@ class DiskPlugin(hotplug.Plugin):
 		return int(value)
 
 	@command_custom("readahead_multiply", per_device=True)
-	def _multiply_readahead(self, enabling, multiplier, device, verify, ignore_missing):
+	def _multiply_readahead(self, enabling, multiplier, device, verify, ignore_missing, instance):
 		if verify:
 			return None
 		storage_key = self._storage_key(
@@ -473,7 +473,7 @@ class DiskPlugin(hotplug.Plugin):
 		return self._sysfs_path(device, "queue/iosched/quantum")
 
 	@command_set("scheduler_quantum", per_device=True)
-	def _set_scheduler_quantum(self, value, device, sim, remove):
+	def _set_scheduler_quantum(self, value, device, instance, sim, remove):
 		sys_file = self._scheduler_quantum_file(device)
 		if not sim:
 			self._cmd.write_to_file(sys_file, "%d" % int(value), \
@@ -481,7 +481,7 @@ class DiskPlugin(hotplug.Plugin):
 		return value
 
 	@command_get("scheduler_quantum")
-	def _get_scheduler_quantum(self, device, ignore_missing=False):
+	def _get_scheduler_quantum(self, device, instance, ignore_missing=False):
 		sys_file = self._scheduler_quantum_file(device)
 		value = self._cmd.read_file(sys_file, no_error=ignore_missing).strip()
 		if len(value) == 0:

--- a/tuned/plugins/plugin_irq.py
+++ b/tuned/plugins/plugin_irq.py
@@ -248,7 +248,7 @@ class IrqPlugin(hotplug.Plugin):
 	# command definitions: entry to device-specific tuning
 	#
 	@command_custom("mode", per_device=False, priority=-10)
-	def _mode(self, enabling, value, verify, ignore_missing):
+	def _mode(self, enabling, value, verify, ignore_missing, instance):
 		if (enabling or verify) and value is not None:
 			# Store the operating mode of the current instance in the plugin
 			# object, from where it is read by the "affinity" command.
@@ -256,7 +256,7 @@ class IrqPlugin(hotplug.Plugin):
 			self._mode_val = value
 
 	@command_custom("affinity", per_device=True)
-	def _affinity(self, enabling, value, device, verify, ignore_missing):
+	def _affinity(self, enabling, value, device, verify, ignore_missing, instance):
 		irq = "DEFAULT" if device == "DEFAULT" else device[len("irq"):]
 		if irq not in self._irqs:
 			log.error("Unknown device: %s" % device)

--- a/tuned/plugins/plugin_irqbalance.py
+++ b/tuned/plugins/plugin_irqbalance.py
@@ -101,7 +101,7 @@ class IrqbalancePlugin(base.Plugin):
 			self._restart_irqbalance()
 
 	@command_custom("banned_cpus", per_device=False)
-	def _banned_cpus(self, enabling, value, verify, ignore_missing):
+	def _banned_cpus(self, enabling, value, verify, ignore_missing, instance):
 		banned_cpulist_string = None
 		if value is not None:
 			banned = set(self._cmd.cpulist_unpack(value))

--- a/tuned/plugins/plugin_mounts.py
+++ b/tuned/plugins/plugin_mounts.py
@@ -129,7 +129,7 @@ class MountsPlugin(base.Plugin):
 		cmd.execute(remount_command)
 
 	@command_custom("disable_barriers", per_device=True)
-	def _disable_barriers(self, start, value, mountpoint, verify, ignore_missing):
+	def _disable_barriers(self, start, value, mountpoint, verify, ignore_missing, instance):
 		storage_key = self._storage_key(
 				command_name = "disable_barriers",
 				device_name = mountpoint)

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -1110,7 +1110,7 @@ class SchedulerPlugin(base.Plugin):
 								self._remove_pid(instance, int(event.tid))
 
 	@command_custom("cgroup_ps_blacklist", per_device = False)
-	def _cgroup_ps_blacklist(self, enabling, value, verify, ignore_missing):
+	def _cgroup_ps_blacklist(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1118,7 +1118,7 @@ class SchedulerPlugin(base.Plugin):
 			self._cgroup_ps_blacklist_re = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("ps_whitelist", per_device = False)
-	def _ps_whitelist(self, enabling, value, verify, ignore_missing):
+	def _ps_whitelist(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1126,7 +1126,7 @@ class SchedulerPlugin(base.Plugin):
 			self._ps_whitelist = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("ps_blacklist", per_device = False)
-	def _ps_blacklist(self, enabling, value, verify, ignore_missing):
+	def _ps_blacklist(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1134,7 +1134,7 @@ class SchedulerPlugin(base.Plugin):
 			self._ps_blacklist = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("irq_process", per_device = False)
-	def _irq_process(self, enabling, value, verify, ignore_missing):
+	def _irq_process(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1142,7 +1142,7 @@ class SchedulerPlugin(base.Plugin):
 			self._irq_process = self._cmd.get_bool(value) == "1"
 
 	@command_custom("default_irq_smp_affinity", per_device = False)
-	def _default_irq_smp_affinity(self, enabling, value, verify, ignore_missing):
+	def _default_irq_smp_affinity(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1153,7 +1153,7 @@ class SchedulerPlugin(base.Plugin):
 				self._default_irq_smp_affinity_value = self._cmd.cpulist_unpack(value)
 
 	@command_custom("perf_process_fork", per_device = False)
-	def _perf_process_fork(self, enabling, value, verify, ignore_missing):
+	def _perf_process_fork(self, enabling, value, verify, ignore_missing, instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1365,7 +1365,7 @@ class SchedulerPlugin(base.Plugin):
 		return res
 
 	@command_custom("isolated_cores", per_device = False, priority = 10)
-	def _isolated_cores(self, enabling, value, verify, ignore_missing):
+	def _isolated_cores(self, enabling, value, verify, ignore_missing, instance):
 		affinity = None
 		self._affinity = None
 		if value is not None:
@@ -1399,6 +1399,7 @@ class SchedulerPlugin(base.Plugin):
 			# _instance_unapply_static()
 			if self._irq_process:
 				self._restore_all_irq_affinity()
+		return True
 
 	def _get_sched_knob_path(self, prefix, namespace, knob):
 		key = "%s_%s_%s" % (prefix, namespace, knob)
@@ -1436,81 +1437,81 @@ class SchedulerPlugin(base.Plugin):
 		return value
 
 	@command_get("sched_min_granularity_ns")
-	def _get_sched_min_granularity_ns(self):
+	def _get_sched_min_granularity_ns(self, instance):
 		return self._get_sched_knob("", "sched", "min_granularity_ns")
 
 	@command_set("sched_min_granularity_ns")
-	def _set_sched_min_granularity_ns(self, value, sim, remove):
+	def _set_sched_min_granularity_ns(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "min_granularity_ns", value, sim, remove)
 
 	@command_get("sched_latency_ns")
-	def _get_sched_latency_ns(self):
+	def _get_sched_latency_ns(self, instance):
 		return self._get_sched_knob("", "sched", "latency_ns")
 
 	@command_set("sched_latency_ns")
-	def _set_sched_latency_ns(self, value, sim, remove):
+	def _set_sched_latency_ns(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "latency_ns", value, sim, remove)
 
 	@command_get("sched_wakeup_granularity_ns")
-	def _get_sched_wakeup_granularity_ns(self):
+	def _get_sched_wakeup_granularity_ns(self, instance):
 		return self._get_sched_knob("", "sched", "wakeup_granularity_ns")
 
 	@command_set("sched_wakeup_granularity_ns")
-	def _set_sched_wakeup_granularity_ns(self, value, sim, remove):
+	def _set_sched_wakeup_granularity_ns(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "wakeup_granularity_ns", value, sim, remove)
 
 	@command_get("sched_tunable_scaling")
-	def _get_sched_tunable_scaling(self):
+	def _get_sched_tunable_scaling(self, instance):
 		return self._get_sched_knob("", "sched", "tunable_scaling")
 
 	@command_set("sched_tunable_scaling")
-	def _set_sched_tunable_scaling(self, value, sim, remove):
+	def _set_sched_tunable_scaling(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "tunable_scaling", value, sim, remove)
 
 	@command_get("sched_migration_cost_ns")
-	def _get_sched_migration_cost_ns(self):
+	def _get_sched_migration_cost_ns(self, instance):
 		return self._get_sched_knob("", "sched", "migration_cost_ns")
 
 	@command_set("sched_migration_cost_ns")
-	def _set_sched_migration_cost_ns(self, value, sim, remove):
+	def _set_sched_migration_cost_ns(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "migration_cost_ns", value, sim, remove)
 
 	@command_get("sched_nr_migrate")
-	def _get_sched_nr_migrate(self):
+	def _get_sched_nr_migrate(self, instance):
 		return self._get_sched_knob("", "sched", "nr_migrate")
 
 	@command_set("sched_nr_migrate")
-	def _set_sched_nr_migrate(self, value, sim, remove):
+	def _set_sched_nr_migrate(self, value, instance, sim, remove):
 		return self._set_sched_knob("", "sched", "nr_migrate", value, sim, remove)
 
 	@command_get("numa_balancing_scan_delay_ms")
-	def _get_numa_balancing_scan_delay_ms(self):
+	def _get_numa_balancing_scan_delay_ms(self, instance):
 		return self._get_sched_knob("sched", "numa_balancing", "scan_delay_ms")
 
 	@command_set("numa_balancing_scan_delay_ms")
-	def _set_numa_balancing_scan_delay_ms(self, value, sim, remove):
+	def _set_numa_balancing_scan_delay_ms(self, value, instance, sim, remove):
 		return self._set_sched_knob("sched", "numa_balancing", "scan_delay_ms", value, sim, remove)
 
 	@command_get("numa_balancing_scan_period_min_ms")
-	def _get_numa_balancing_scan_period_min_ms(self):
+	def _get_numa_balancing_scan_period_min_ms(self, instance):
 		return self._get_sched_knob("sched", "numa_balancing", "scan_period_min_ms")
 
 	@command_set("numa_balancing_scan_period_min_ms")
-	def _set_numa_balancing_scan_period_min_ms(self, value, sim, remove):
+	def _set_numa_balancing_scan_period_min_ms(self, value, instance, sim, remove):
 		return self._set_sched_knob("sched", "numa_balancing", "scan_period_min_ms", value, sim, remove)
 
 	@command_get("numa_balancing_scan_period_max_ms")
-	def _get_numa_balancing_scan_period_max_ms(self):
+	def _get_numa_balancing_scan_period_max_ms(self, instance):
 		return self._get_sched_knob("sched", "numa_balancing", "scan_period_max_ms")
 
 	@command_set("numa_balancing_scan_period_max_ms")
-	def _set_numa_balancing_scan_period_max_ms(self, value, sim, remove):
+	def _set_numa_balancing_scan_period_max_ms(self, value, instance, sim, remove):
 		return self._set_sched_knob("sched", "numa_balancing", "scan_period_max_ms", value, sim, remove)
 
 	@command_get("numa_balancing_scan_size_mb")
-	def _get_numa_balancing_scan_size_mb(self):
+	def _get_numa_balancing_scan_size_mb(self, instance):
 		return self._get_sched_knob("sched", "numa_balancing", "scan_size_mb")
 
 	@command_set("numa_balancing_scan_size_mb")
-	def _set_numa_balancing_scan_size_mb(self, value, sim, remove):
+	def _set_numa_balancing_scan_size_mb(self, value, instance, sim, remove):
 		return self._set_sched_knob("sched", "numa_balancing", "scan_size_mb", value, sim, remove)

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -84,7 +84,7 @@ class SCSIHostPlugin(hotplug.Plugin):
 		return os.path.join("/sys/class/scsi_host/", str(device), "link_power_management_policy")
 
 	@command_set("alpm", per_device = True)
-	def _set_alpm(self, policy, device, sim, remove):
+	def _set_alpm(self, policy, device, instance, sim, remove):
 		if policy is None:
 			return None
 		policy_file = self._get_alpm_policy_file(device)
@@ -98,7 +98,7 @@ class SCSIHostPlugin(hotplug.Plugin):
 		return policy
 
 	@command_get("alpm")
-	def _get_alpm(self, device, ignore_missing=False):
+	def _get_alpm(self, device, instance, ignore_missing=False):
 		policy_file = self._get_alpm_policy_file(device)
 		policy = self._cmd.read_file(policy_file, no_error = True).strip()
 		return policy if policy != "" else None

--- a/tuned/plugins/plugin_selinux.py
+++ b/tuned/plugins/plugin_selinux.py
@@ -62,7 +62,7 @@ class SelinuxPlugin(base.Plugin):
 		pass
 
 	@command_set("avc_cache_threshold")
-	def _set_avc_cache_threshold(self, value, sim, remove):
+	def _set_avc_cache_threshold(self, value, instance, sim, remove):
 		if value is None:
 			return None
 		threshold = int(value)
@@ -75,7 +75,7 @@ class SelinuxPlugin(base.Plugin):
 			return None
 
 	@command_get("avc_cache_threshold")
-	def _get_avc_cache_threshold(self):
+	def _get_avc_cache_threshold(self, instance):
 		value = self._cmd.read_file(self._cache_threshold_path)
 		if len(value) > 0:
 			return int(value)

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -122,7 +122,7 @@ class SystemdPlugin(base.Plugin):
 		return " ".join(str(v) for v in self._cmd.cpulist_unpack(re.sub(r"\s+", r",", re.sub(r",\s+", r",", cpulist))))
 
 	@command_custom("cpu_affinity", per_device = False)
-	def _cmdline(self, enabling, value, verify, ignore_missing):
+	def _cmdline(self, enabling, value, verify, ignore_missing, instance):
 		conf_affinity = None
 		conf_affinity_unpacked = None
 		v = self._cmd.unescape(self._variables.expand(self._cmd.unquote(value)))
@@ -141,3 +141,6 @@ class SystemdPlugin(base.Plugin):
 
 			log.info("setting '%s' to '%s' in the '%s'" % (consts.SYSTEMD_CPUAFFINITY_VAR, v_unpacked, consts.SYSTEMD_SYSTEM_CONF_FILE))
 			self._write_systemd_system_conf(self._add_keyval(conf, consts.SYSTEMD_CPUAFFINITY_VAR, v_unpacked))
+			return True
+		return None
+

--- a/tuned/plugins/plugin_uncore.py
+++ b/tuned/plugins/plugin_uncore.py
@@ -166,7 +166,7 @@ class UncorePlugin(hotplug.Plugin):
 		return self._validate_khz_value(device, min_or_max, khz)
 
 	@command_set("max_freq_khz", per_device = True)
-	def _set_max_freq_khz(self, value, device, sim, remove):
+	def _set_max_freq_khz(self, value, device, instance, sim, remove):
 		max_freq_khz = self._validate_value(device, IS_MAX, value)
 		if max_freq_khz is None:
 			return None
@@ -178,7 +178,7 @@ class UncorePlugin(hotplug.Plugin):
 		return self._set(device, "max_freq_khz", max_freq_khz)
 
 	@command_get("max_freq_khz")
-	def _get_max_freq_khz(self, device, ignore_missing=False):
+	def _get_max_freq_khz(self, device, instance, ignore_missing=False):
 		if ignore_missing and not os.path.isdir(SYSFS_DIR):
 			return None
 
@@ -192,7 +192,7 @@ class UncorePlugin(hotplug.Plugin):
 		return max_freq_khz
 
 	@command_set("min_freq_khz", per_device = True)
-	def _set_min_freq_khz(self, value, device, sim, remove):
+	def _set_min_freq_khz(self, value, device, instance, sim, remove):
 		min_freq_khz = self._validate_value(device, IS_MIN, value)
 		if min_freq_khz is None:
 			return None
@@ -204,7 +204,7 @@ class UncorePlugin(hotplug.Plugin):
 		return self._set(device, "min_freq_khz", min_freq_khz)
 
 	@command_get("min_freq_khz")
-	def _get_min_freq_khz(self, device, ignore_missing=False):
+	def _get_min_freq_khz(self, device, instance, ignore_missing=False):
 		if ignore_missing and not os.path.isdir(SYSFS_DIR):
 			return None
 

--- a/tuned/plugins/plugin_usb.py
+++ b/tuned/plugins/plugin_usb.py
@@ -56,7 +56,7 @@ class USBPlugin(base.Plugin):
 		return "/sys/bus/usb/devices/%s/power/autosuspend" % device
 
 	@command_set("autosuspend", per_device=True)
-	def _set_autosuspend(self, value, device, sim, remove):
+	def _set_autosuspend(self, value, device, instance, sim, remove):
 		enable = self._option_bool(value)
 		if enable is None:
 			return None
@@ -69,6 +69,6 @@ class USBPlugin(base.Plugin):
 		return val
 
 	@command_get("autosuspend")
-	def _get_autosuspend(self, device, ignore_missing=False):
+	def _get_autosuspend(self, device, instance, ignore_missing=False):
 		sys_file = self._autosuspend_sysfile(device)
 		return self._cmd.read_file(sys_file, no_error=ignore_missing).strip()

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -107,7 +107,7 @@ class VideoPlugin(base.Plugin):
 		return None
 
 	@command_set("radeon_powersave", per_device=True)
-	def _set_radeon_powersave(self, value, device, sim, remove):
+	def _set_radeon_powersave(self, value, device, instance, sim, remove):
 		sys_files = self._files(device)
 		va = str(re.sub(r"(\s*:\s*)|(\s+)|(\s*;\s*)|(\s*,\s*)", " ", value)).split()
 		if not os.path.exists(sys_files["method"]):
@@ -143,7 +143,7 @@ class VideoPlugin(base.Plugin):
 		return None
 
 	@command_get("radeon_powersave")
-	def _get_radeon_powersave(self, device, ignore_missing = False):
+	def _get_radeon_powersave(self, device, instance, ignore_missing = False):
 		sys_files = self._files(device)
 		if not os.path.exists(sys_files["method"]):
 			log.debug("radeon_powersave is not supported on '%s'" % device)
@@ -159,7 +159,7 @@ class VideoPlugin(base.Plugin):
 			return None
 
 	@command_set("panel_power_savings", per_device=True)
-	def _set_panel_power_savings(self, value, device, sim, remove):
+	def _set_panel_power_savings(self, value, device, instance, sim, remove):
 		"""Set the panel_power_savings value"""
 		try:
 			value = int(value, 10)
@@ -173,7 +173,7 @@ class VideoPlugin(base.Plugin):
 		return None
 
 	@command_get("panel_power_savings")
-	def _get_panel_power_savings(self, device, ignore_missing=False):
+	def _get_panel_power_savings(self, device, instance, ignore_missing=False):
 		"""Get the current panel_power_savings value"""
 		if not os.path.exists(self._files(device)["panel_power_savings"]):
 			log.debug("panel_power_savings is not supported on '%s'" % device)

--- a/tuned/plugins/plugin_vm.py
+++ b/tuned/plugins/plugin_vm.py
@@ -77,7 +77,7 @@ class VMPlugin(base.Plugin):
 		return path
 
 	@command_set("transparent_hugepages")
-	def _set_transparent_hugepages(self, value, sim, remove):
+	def _set_transparent_hugepages(self, value, instance, sim, remove):
 		if value not in ["always", "never", "madvise"]:
 			if not sim:
 				log.warning("Incorrect 'transparent_hugepages' value '%s'." % str(value))
@@ -102,11 +102,11 @@ class VMPlugin(base.Plugin):
 
         # just an alias to transparent_hugepages
 	@command_set("transparent_hugepage")
-	def _set_transparent_hugepage(self, value, sim, remove):
+	def _set_transparent_hugepage(self, value, instance, sim, remove):
 		self._set_transparent_hugepages(value, sim, remove)
 
 	@command_get("transparent_hugepages")
-	def _get_transparent_hugepages(self):
+	def _get_transparent_hugepages(self, instance):
 		sys_file = os.path.join(self._thp_path(), "enabled")
 		if os.path.exists(sys_file):
 			return cmd.get_active_option(cmd.read_file(sys_file))
@@ -115,11 +115,11 @@ class VMPlugin(base.Plugin):
 
         # just an alias to transparent_hugepages
 	@command_get("transparent_hugepage")
-	def _get_transparent_hugepage(self):
+	def _get_transparent_hugepage(self, instance):
 		return self._get_transparent_hugepages()
 
 	@command_set("transparent_hugepage.defrag")
-	def _set_transparent_hugepage_defrag(self, value, sim, remove):
+	def _set_transparent_hugepage_defrag(self, value, instance, sim, remove):
 		sys_file = os.path.join(self._thp_path(), "defrag")
 		if os.path.exists(sys_file):
 			if not sim:
@@ -132,7 +132,7 @@ class VMPlugin(base.Plugin):
 			return None
 
 	@command_get("transparent_hugepage.defrag")
-	def _get_transparent_hugepage_defrag(self):
+	def _get_transparent_hugepage_defrag(self, instance):
 		sys_file = os.path.join(self._thp_path(), "defrag")
 		if os.path.exists(sys_file):
 			return cmd.get_active_option(cmd.read_file(sys_file))
@@ -159,19 +159,19 @@ class VMPlugin(base.Plugin):
 		return True
 
 	@command_custom("dirty_bytes")
-	def _dirty_bytes(self, enabling, value, verify, ignore_missing):
+	def _dirty_bytes(self, enabling, value, verify, ignore_missing, instance):
 		return self._dirty_option("dirty_bytes", "dirty_ratio", self._check_twice_pagesize, enabling, value, verify)
 
 	@command_custom("dirty_ratio")
-	def _dirty_ratio(self, enabling, value, verify, ignore_missing):
+	def _dirty_ratio(self, enabling, value, verify, ignore_missing, instance):
 		return self._dirty_option("dirty_ratio", "dirty_bytes", self._check_ratio, enabling, value, verify)
 
 	@command_custom("dirty_background_bytes")
-	def _dirty_background_bytes(self, enabling, value, verify, ignore_missing):
+	def _dirty_background_bytes(self, enabling, value, verify, ignore_missing, instance):
 		return self._dirty_option("dirty_background_bytes", "dirty_background_ratio", self._check_positive, enabling, value, verify)
 
 	@command_custom("dirty_background_ratio")
-	def _dirty_background_ratio(self, enabling, value, verify, ignore_missing):
+	def _dirty_background_ratio(self, enabling, value, verify, ignore_missing, instance):
 		return self._dirty_option("dirty_background_ratio", "dirty_background_bytes", self._check_ratio, enabling, value, verify)
 
 	def _dirty_option(self, option, counterpart, check_fun, enabling, value, verify):


### PR DESCRIPTION
This will not completely resolve RHEL-60906, because there will be always race condition if the rename event happens before the instance is fully initialized, but it should significantly improve the situation.

Drawback is that it can report in the logs device names that shouldn't be matched by the plugin_net instance, i.e. it matches devices according to their original names but accesses them with their new names. This can be confusing. Also in the runtime API (e.g. for removal of the device from the instance), the original device names have to be used. For insertion of the device to the instance, new names have to be used. This can be even more confusing.

Unfortunately, there probably isn't better alternative now, because for correct operation we would have to handle rename by removal and addition events. This would require rollback and retune steps which would lead to very negative performance consequences. Also we would have to cope with partially tuned devices if the rename event happens during profile application. It's doable, but it would require big architectural changes.

The PR also extends internal API, now the plugin instances receive 'instance' as a method parameter.

Resolves: RHEL-60906