### PR TITLE
profiles: Correct CPU governor settings

### DIFF
--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -10,7 +10,7 @@ cpufreq_conservative=+r
 
 [cpu]
 priority=10
-governor=conservative|powersave
+governor=schedutil|ondemand|powersave
 energy_perf_bias=normal
 energy_performance_preference=balance_performance
 boost=1

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -6,7 +6,7 @@
 summary=Optimize for low power consumption
 
 [cpu]
-governor=ondemand|powersave
+governor=schedutil|conservative|powersave
 energy_perf_bias=powersave|power
 energy_performance_preference=power
 boost=0


### PR DESCRIPTION
First, always prefer schedutil for balanced/powersave. On platforms where this governor is available, this enables Energy-Aware-Scheduling which offers the best power efficiency and performance combination. There is absolutely no reason to use another governor by default in the "balanced" profile on these systems, in particular.

Second, swap around "conservative" and "ondemand". "conservative" is supposed to be lower power and higher latency. The commit that made this change [1] tested on a single server platform (10 years ago), but came to the wrong conclusion. Dividing the throughput by power numbers of that commit, "conservative" did in fact provide better performance/watt, which is the intent of lower-power modes. The fact that it also happened to provide better overall performance than "ondemand" is probably an artifact of suboptimal power-management behavior or a flawed test. In fact, "performance" gave even better perf/W in that  test, which is just absurd and shows that platform was not at all representative of the effect changing CPU frequency governors is supposed to have on a well-behaved platform.

[1] https://github.com/redhat-performance/tuned/commit/b2897d9c1cfea9880bd64660bf519bdf04117f9c


Bugs:

* https://bugzilla.redhat.com/show_bug.cgi?id=2339067
* https://issues.redhat.com/browse/RHEL-74422
* https://github.com/AsahiLinux/linux/issues/365