### PR TITLE
utils.commands: Fix CPU online detection when not present

### DIFF
--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -280,7 +280,7 @@ class commands:
 	def is_cpu_online(self, cpu):
 		scpu = str(cpu)
 		# CPU0 is always online
-		return cpu == "0" or self.read_file("/sys/devices/system/cpu/cpu%s/online" % scpu, no_error = True).strip() == "1"
+		return cpu == "0" or self.read_file("/sys/devices/system/cpu/cpu%s/online" % scpu, err_ret = "1", no_error = True).strip() == "1"
 
 	# Converts hexadecimal CPU mask to CPU list
 	def hex2cpulist(self, mask):


### PR DESCRIPTION
Not all platforms can offline CPUs. On those that can't, there is no "online" attribute. Default to online in that case.