### PR TITLE
Allow dynamic instances of non-hotplug plugins

### DIFF
--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -68,6 +68,7 @@ class PluginBaseTestCase(unittest.TestCase):
 		instance = self._plugin.create_instance(\
 			'first_instance',0,'right_device*',None,'test','test',\
 			{'default_option1':'default_value2'})
+		instance.plugin.init_devices()
 
 		self.assertEqual(self._plugin._get_matching_devices(\
 			instance,['bad_device','right_device1','right_device2']),\
@@ -77,6 +78,7 @@ class PluginBaseTestCase(unittest.TestCase):
 		instance = self._plugin.create_instance(\
 			'second_instance',0,'right_device*','device[1-2]','test','test',\
 			{'default_option1':'default_value2'})
+		instance.plugin.init_devices()
 
 		device1 = DummyDevice('device1',{'name':'device1'})
 		device2 = DummyDevice('device2',{'name':'device2'})
@@ -176,6 +178,10 @@ class DummyPlugin(Plugin):
 
 	def _instance_cleanup(self, instance):
 		self.cleaned_instances.append(instance)
+
+	def _init_devices(self):
+		super(DummyPlugin,self)._init_devices()
+		self._devices_supported = True
 
 	def _get_device_objects(self, devices):
 		objects = []

--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -495,10 +495,6 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			log.error(rets)
 			return (False, rets)
 		plugin = plugins[plugin_name]
-		if not isinstance(plugin, hotplug.Plugin):
-			rets = "Plugin '%s' does not support hotplugging or dynamic instances." % plugin.name
-			log.error(rets)
-			return (False, rets)
 		devices = options.pop("devices", None)
 		devices_udev_regex = options.pop("devices_udev_regex", None)
 		script_pre = options.pop("script_pre", None)
@@ -553,10 +549,6 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 			log.error(rets)
 			return (False, rets)
 		plugin = instance.plugin
-		if not isinstance(plugin, hotplug.Plugin):
-			rets = "Plugin '%s' does not support hotplugging or dynamic instances." % plugin.name
-			log.error(rets)
-			return (False, rets)
 		devices = instance.processed_devices.copy()
 		try:
 			plugin._remove_devices_nocheck(instance, devices)

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -154,6 +154,9 @@ class Plugin(object):
 		return None
 
 	def _get_matching_devices(self, instance, devices):
+		if not self._devices_supported:
+			return set()
+
 		if instance.devices_udev_regex is None:
 			return set(self._device_matcher.match_list(instance.devices_expression, devices))
 		else:
@@ -163,6 +166,18 @@ class Plugin(object):
 				return set()
 			udev_devices = self._device_matcher_udev.match_list(instance.devices_udev_regex, udev_devices)
 			return set([x.sys_name for x in udev_devices])
+
+	def _add_device(self, device_name):
+		pass
+
+	def _add_devices_nocheck(self, instance, device_names):
+		pass
+
+	def _remove_device(self, device_name):
+		pass
+
+	def _remove_devices_nocheck(self, instance, device_names):
+		pass
 
 	def assign_free_devices(self, instance):
 		if not self._devices_supported:


### PR DESCRIPTION
Split off #628 for easier review and discussion.

This removes the checks for "is the plugin of type `hotplug.Plugin`" from `instance_create` and `instance_destroy`, while keeping the rest of the code in controller.py as-is. To do this, some of the device related methods need noop-implementations in `base.Plugin`.

Notes:

* `base.Plugin` seems to implement some device methods with actual logic (`assign_free_devices`, `release_devices`, `_run_for_each_device`, `_call_device_script`, `_*_device_commands`). Why are those not in `hotplug.Plugin`?
* In `create_instance`, we could add checking and warnings if the user creates a `base.Plugin` instance and sets the `devices=` or `devices_udev_regex=` options. At the moment these options would be ignored silently (which is also ok I guess).