### PR TITLE
plugin_net: handle cqe-mode-rx ethtool option

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -312,6 +312,7 @@ class NetTuningPlugin(hotplug.Plugin):
 		return {
 			"adaptive-rx": None,
 			"adaptive-tx": None,
+			"cqe-mode-rx": None,
 			"rx-usecs": None,
 			"rx-frames": None,
 			"rx-usecs-irq": None,
@@ -437,6 +438,7 @@ class NetTuningPlugin(hotplug.Plugin):
 		value = self._cmd.multiple_re_replace({
 			"Adaptive RX:": "adaptive-rx:",
 			"\\s+TX:": "\nadaptive-tx:",
+			"CQE mode RX:": "cqe-mode-rx:",
 			"rx-frame-low:": "rx-frames-low:",
 			"rx-frame-high:": "rx-frames-high:",
 			"tx-frame-low:": "tx-frames-low:",


### PR DESCRIPTION
Parsing ethtool output has been broken for several years, since `ethtool -c` started producing a line resembling `CQE mode RX: n/a  TX: n/a`. This prevents setting any [net] coalesce= options, which log `tuned.plugins.plugin_net: unknown coalesce parameter(s): {'CQE mode RX'}`.

Substituting `cqe-mode-rx:` for `CQE mode RX:` resolves the issue, although there is a conflict with the `adaptive-tx` workaround which prevents us from supporting `cqe-mode-tx` directly. Do not attempt to address that issue as part of this change.

Fixes #726.