### PR TITLE
Fix races occuring when two threads expand variables at the same time

### DIFF
--- a/compile_plugin_docs.py
+++ b/compile_plugin_docs.py
@@ -2,13 +2,13 @@
 import argparse
 import os
 import inspect
-from tuned.utils.plugin_loader import PluginLoader
+from tuned.utils.class_loader import ClassLoader
 from tuned.plugins.base import Plugin
 
 
-class DocLoader(PluginLoader):
+class PluginDocLoader(ClassLoader):
 	def __init__(self):
-		super(DocLoader, self).__init__()
+		super(PluginDocLoader, self).__init__()
 
 	def _set_loader_parameters(self):
 		self._namespace = "tuned.plugins"
@@ -23,7 +23,7 @@ args = parser.parse_args()
 with open(args.intro, "r") as intro_file:
 	intro = intro_file.read()
 
-all_plugins = sorted(DocLoader().load_all_plugins(), key=lambda x: x.__module__)
+all_plugins = sorted(PluginDocLoader().load_all_classes(), key=lambda x: x.__module__)
 
 with open(args.out, "w") as out_file:
 	out_file.write(intro)

--- a/tuned/daemon/daemon.py
+++ b/tuned/daemon/daemon.py
@@ -291,12 +291,12 @@ class Daemon(object):
 
 	def get_all_plugins(self):
 		"""Return all accessible plugin classes"""
-		return self._unit_manager.plugins_repository.load_all_plugins()
+		return self._unit_manager.plugins_repository.load_all_classes()
 
 	def get_plugin_documentation(self, plugin_name):
 		"""Return plugin class docstring"""
 		try:
-			plugin_class = self._unit_manager.plugins_repository.load_plugin(
+			plugin_class = self._unit_manager.plugins_repository.load_class(
 				plugin_name
 			)
 		except ImportError:
@@ -313,7 +313,7 @@ class Daemon(object):
 		dictionary -- {parameter_name: hint}
 		"""
 		try:
-			plugin_class = self._unit_manager.plugins_repository.load_plugin(
+			plugin_class = self._unit_manager.plugins_repository.load_class(
 				plugin_name
 			)
 		except ImportError:

--- a/tuned/monitors/repository.py
+++ b/tuned/monitors/repository.py
@@ -1,12 +1,12 @@
 import tuned.logs
 import tuned.monitors
-from tuned.utils.plugin_loader import PluginLoader
+from tuned.utils.class_loader import ClassLoader
 
 log = tuned.logs.get()
 
 __all__ = ["Repository"]
 
-class Repository(PluginLoader):
+class Repository(ClassLoader):
 
 	def __init__(self):
 		super(Repository, self).__init__()
@@ -23,7 +23,7 @@ class Repository(PluginLoader):
 
 	def create(self, plugin_name, devices):
 		log.debug("creating monitor %s" % plugin_name)
-		monitor_cls = self.load_plugin(plugin_name)
+		monitor_cls = self.load_class(plugin_name)
 		monitor_instance = monitor_cls(devices)
 		self._monitors.add(monitor_instance)
 		return monitor_instance

--- a/tuned/plugins/repository.py
+++ b/tuned/plugins/repository.py
@@ -1,4 +1,4 @@
-from tuned.utils.plugin_loader import PluginLoader
+from tuned.utils.class_loader import ClassLoader
 import tuned.plugins.base
 import tuned.logs
 
@@ -6,7 +6,7 @@ log = tuned.logs.get()
 
 __all__ = ["Repository"]
 
-class Repository(PluginLoader):
+class Repository(ClassLoader):
 
 	def __init__(self, monitor_repository, storage_factory, hardware_inventory, device_matcher, device_matcher_udev, plugin_instance_factory, global_cfg, variables):
 		super(Repository, self).__init__()
@@ -31,7 +31,7 @@ class Repository(PluginLoader):
 
 	def create(self, plugin_name):
 		log.debug("creating plugin %s" % plugin_name)
-		plugin_cls = self.load_plugin(plugin_name)
+		plugin_cls = self.load_class(plugin_name)
 		plugin_instance = plugin_cls(self._monitor_repository, self._storage_factory, self._hardware_inventory, self._device_matcher,\
 			self._device_matcher_udev, self._plugin_instance_factory, self._global_cfg, self._variables)
 		self._plugins.add(plugin_instance)

--- a/tuned/profiles/functions/parser.py
+++ b/tuned/profiles/functions/parser.py
@@ -1,23 +1,18 @@
-import os
 import re
-import glob
-from . import repository
 import tuned.logs
-import tuned.consts as consts
 from tuned.utils.commands import commands
 
 log = tuned.logs.get()
 
 cmd = commands()
 
-class Functions():
+class Parser():
 	"""
-	Built-in functions
+	Parser used for expanding strings containing functions.
 	"""
 
-	def __init__(self):
-		self._repository = repository.Repository()
-		self._parse_init()
+	def __init__(self, repository):
+		self._repository = repository
 
 	def _parse_init(self, s = ""):
 		self._cnt = 0

--- a/tuned/profiles/functions/repository.py
+++ b/tuned/profiles/functions/repository.py
@@ -1,12 +1,11 @@
-from tuned.utils.plugin_loader import PluginLoader
-from . import base
+from tuned.utils.class_loader import ClassLoader
+from tuned.profiles.functions.base import Function
 import tuned.logs
 import tuned.consts as consts
-from tuned.utils.commands import commands
 
 log = tuned.logs.get()
 
-class Repository(PluginLoader):
+class Repository(ClassLoader):
 
 	def __init__(self):
 		super(Repository, self).__init__()
@@ -19,11 +18,11 @@ class Repository(PluginLoader):
 	def _set_loader_parameters(self):
 		self._namespace = "tuned.profiles.functions"
 		self._prefix = consts.FUNCTION_PREFIX
-		self._interface = tuned.profiles.functions.base.Function
+		self._interface = Function
 
 	def create(self, function_name):
 		log.debug("creating function %s" % function_name)
-		function_cls = self.load_plugin(function_name)
+		function_cls = self.load_class(function_name)
 		function_instance = function_cls()
 		self._functions[function_name] = function_instance
 		return function_instance

--- a/tuned/profiles/functions/repository.py
+++ b/tuned/profiles/functions/repository.py
@@ -1,4 +1,5 @@
 from tuned.utils.class_loader import ClassLoader
+from tuned.profiles.functions.parser import Parser
 from tuned.profiles.functions.base import Function
 import tuned.logs
 import tuned.consts as consts
@@ -6,6 +7,10 @@ import tuned.consts as consts
 log = tuned.logs.get()
 
 class Repository(ClassLoader):
+	"""
+	Repository of functions used within TuneD profiles.
+	The functions are loaded lazily (when first used).
+	"""
 
 	def __init__(self):
 		super(Repository, self).__init__()
@@ -27,7 +32,7 @@ class Repository(ClassLoader):
 		self._functions[function_name] = function_instance
 		return function_instance
 
-	# loads function from plugin file and return it
+	# load a function from its file and return it
 	# if it is already loaded, just return it, it is not loaded again
 	def load_func(self, function_name):
 		if not function_name in self._functions:
@@ -40,3 +45,6 @@ class Repository(ClassLoader):
 		for k, v in list(self._functions.items()):
 			if v == function:
 				del self._functions[k]
+
+	def expand(self, s):
+		return Parser(self).expand(s)

--- a/tuned/profiles/variables.py
+++ b/tuned/profiles/variables.py
@@ -1,8 +1,8 @@
 import os
 import re
 import tuned.logs
-from .functions import functions as functions
 import tuned.consts as consts
+from tuned.profiles import functions
 from tuned.utils.commands import commands
 from tuned.utils.config_parser import ConfigParser, Error
 
@@ -17,7 +17,7 @@ class Variables():
 		self._cmd = commands()
 		self._lookup_re = {}
 		self._lookup_env = {}
-		self._functions = functions.Functions()
+		self._functions = functions.Repository()
 
 	def _add_env_prefix(self, s, prefix):
 		if s.find(prefix) == 0:


### PR DESCRIPTION
While fixing this, I got confused by the naming of the `PluginLoader` class. In the first commit, I propose to rename it to `ClassLoader`, and fix one of its methods so that it truly behaves like an abstract class.

For the race fix itself, see the second commit.

Resolves: RHEL-75773
