### PR TITLE
bootloader: export Grub variables to make them available in submenus

### DIFF
--- a/00_tuned
+++ b/00_tuned
@@ -26,4 +26,6 @@ tuned_bootcmdline_file=$tunedcfgdir/bootcmdline
 . $tuned_bootcmdline_file
 
 echo "set tuned_params=\"$TUNED_BOOT_CMDLINE\""
+echo "export tuned_params"
 echo "set tuned_initrd=\"$TUNED_BOOT_INITRD_ADD\""
+echo "export tuned_initrd"


### PR DESCRIPTION
Without exporting the grub variables, they are only available in the main grub menu[0]. When descending in a submenu (like in default Debian for example), tuned_* variable are expanded to the empty string and, so, tuned kernel cmdline tuning is effectively disabled.

With the export, variables are available in submenus and tuned tuning is applied as expected.

[0]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1094201#10