### PR TITLE
profiles: use `med_power_with_dipm` for SATA ALPM

### DIFF
--- a/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/con_inheritance-between-tuned-profiles.adoc
@@ -22,14 +22,14 @@ If the [replaceable]_parent_ profile is updated, such as after a *TuneD* upgrade
 
 .A power-saving profile based on balanced
 ====
-The following is an example of a custom profile that extends the `balanced` profile and sets Aggressive Link Power Management (ALPM) for all devices to the maximum powersaving.
+The following is an example of a custom profile that extends the `balanced` profile and disables the capability of the CPU to boost above nominal frequencies for brief periods.
 
 ----
 [main]
 include=balanced
 
-[scsi_host]
-alpm=min_power
+[cpu]
+boost=0
 ----
 ====
 

--- a/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
+++ b/doc/manual/modules/performance/proc_creating-new-tuned-profiles.adoc
@@ -43,7 +43,7 @@ timeout=10
 radeon_powersave=dpm-balanced, auto
 
 [scsi_host]
-alpm=medium_power
+alpm=med_power_with_dipm
 ----
 
 . To activate the profile, use:

--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -30,4 +30,4 @@ panel_power_savings=0
 # devices=sda
 
 [scsi_host]
-alpm=medium_power
+alpm=med_power_with_dipm

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -34,7 +34,7 @@ panel_power_savings=3
 # devices=eth0
 
 [scsi_host]
-alpm=min_power
+alpm=med_power_with_dipm
 
 [sysctl]
 vm.laptop_mode=5

--- a/profiles/server-powersave/tuned.conf
+++ b/profiles/server-powersave/tuned.conf
@@ -11,4 +11,4 @@ energy_performance_preference=balance_power
 [disk]
 
 [scsi_host]
-alpm=min_power
+alpm=med_power_with_dipm

--- a/profiles/spindown-disk/tuned.conf
+++ b/profiles/spindown-disk/tuned.conf
@@ -24,7 +24,7 @@ apm=128
 spindown=6
 
 [scsi_host]
-alpm=medium_power
+alpm=med_power_with_dipm
 
 [vm]
 dirty_ratio=60

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -14,8 +14,8 @@ class SCSIHostPlugin(hotplug.Plugin):
 	Tunes options for SCSI hosts.
 
 	The plug-in sets Aggressive Link Power Management (ALPM) to the value specified
-	by the [option]`alpm` option. The option takes one of three values:
-	`min_power`, `medium_power` and `max_performance`.
+	by the [option]`alpm` option. The option takes one of four values:
+	`min_power`, `med_power_with_dipm`, `medium_power` and `max_performance`.
 
 	NOTE: ALPM is only available on SATA controllers that use the Advanced
 	Host Controller Interface (AHCI).
@@ -24,7 +24,7 @@ class SCSIHostPlugin(hotplug.Plugin):
 	====
 	----
 	[scsi_host]
-	alpm=min_power
+	alpm=med_power_with_dipm
 	----
 	====
 	"""


### PR DESCRIPTION
Using `min_power` can lead to data loss, and `med_power_with_dipm`
delivers similar power savings without the chance of data loss. [1]

`med_power_with_dipm` is the default setting[2] in upstream Linux for
SATA Link Power Management, and should provide significant power
savings on laptops using SATA drives over `medium_power`.

[1] https://hansdegoede.livejournal.com/18412.html
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/ata/Kconfig?id=5433f0e7427ae4f5b128d89ec16ccaafc9fef5ee

**Note:** Testing on a SATA system would be appreciated to confirm this patch is setting `med_power_with_dipm` as expected, since unfortunately I'm not sure when I'll be able to get back to my desktop at home