### PR TITLE
network_latency: Set non-zero rcutree.nohz_full_patience_delay

### DIFF
--- a/profiles/network-latency/tuned.conf
+++ b/profiles/network-latency/tuned.conf
@@ -20,6 +20,6 @@ vm.stat_interval = 10
 kernel.timer_migration = 0
 
 [bootloader]
-cmdline_network_latency=skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1
+cmdline_network_latency=skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1 rcutree.nohz_full_patience_delay=1000
 
 [rtentsk]


### PR DESCRIPTION
`rcutree.nohz_full_patience_delay` is a new kernel parameter added in 6.11. For more details, see https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=68d124b0999919015e6d23008eafea106ec6bb40.