### PR TITLE
Seamless transfer of devices between plugin instances

### DIFF
--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -463,13 +463,13 @@ class Plugin(object):
 			if new_value is not None:
 				self._execute_non_device_command(instance, command, new_value)
 
-	def _execute_all_device_commands(self, instance, devices):
+	def _execute_all_device_commands(self, instance, devices, transfer_from_instance=None):
 		for command in [command for command in list(self._commands.values()) if command["per_device"]]:
 			new_value = self._variables.expand(instance.options.get(command["name"], None))
 			if new_value is None:
 				continue
 			for device in devices:
-				self._execute_device_command(instance, command, device, new_value)
+				self._execute_device_command(instance, command, device, new_value, transfer_from_instance)
 
 	def _verify_all_non_device_commands(self, instance, ignore_missing):
 		ret = True
@@ -521,24 +521,30 @@ class Plugin(object):
 		else:
 			return command["get"](instance)
 
-	def _check_and_save_value(self, instance, command, device = None, new_value = None):
-		current_value = self._get_current_value(instance, command, device)
+	def _check_and_save_value(self, instance, command, device = None, new_value = None, transfer_from_instance=None):
+		if transfer_from_instance is not None and transfer_from_instance.options.get(command["name"], None) is not None:
+			# we're transfering: base new value calculation on the stored original
+			# and take over ownership of the stored value from the source instance
+			current_value = self._storage_get(transfer_from_instance, command, device)
+			self._storage_unset(transfer_from_instance, command, device)
+		else:
+			current_value = self._get_current_value(instance, command, device)
 		new_value = self._process_assignment_modifiers(new_value, current_value)
 		if new_value is not None and current_value is not None:
 			self._storage_set(instance, command, current_value, device)
 		return new_value
 
-	def _execute_device_command(self, instance, command, device, new_value):
+	def _execute_device_command(self, instance, command, device, new_value, transfer_from_instance=None):
 		if command["custom"] is not None:
-			command["custom"](True, new_value, device, False, False, instance)
+			command["custom"](True, new_value, device, False, False, instance, transfer_from_instance)
 		else:
-			new_value = self._check_and_save_value(instance, command, device, new_value)
+			new_value = self._check_and_save_value(instance, command, device, new_value, transfer_from_instance)
 			if new_value is not None:
 				command["set"](new_value, device, instance, sim = False, remove = False)
 
 	def _execute_non_device_command(self, instance, command, new_value):
 		if command["custom"] is not None:
-			command["custom"](True, new_value, False, False, instance)
+			command["custom"](True, new_value, False, False, instance, None)
 		else:
 			new_value = self._check_and_save_value(instance, command, None, new_value)
 			if new_value is not None:
@@ -599,7 +605,7 @@ class Plugin(object):
 
 	def _verify_device_command(self, instance, command, device, new_value, ignore_missing):
 		if command["custom"] is not None:
-			return command["custom"](True, new_value, device, True, ignore_missing, instance)
+			return command["custom"](True, new_value, device, True, ignore_missing, instance, None)
 		current_value = self._get_current_value(instance, command, device, ignore_missing=ignore_missing)
 		new_value = self._process_assignment_modifiers(new_value, current_value)
 		if new_value is None:
@@ -609,7 +615,7 @@ class Plugin(object):
 
 	def _verify_non_device_command(self, instance, command, new_value, ignore_missing):
 		if command["custom"] is not None:
-			return command["custom"](True, new_value, True, ignore_missing, instance)
+			return command["custom"](True, new_value, True, ignore_missing, instance, None)
 		current_value = self._get_current_value(instance, command)
 		new_value = self._process_assignment_modifiers(new_value, current_value)
 		if new_value is None:
@@ -622,24 +628,29 @@ class Plugin(object):
 			if (instance.options.get(command["name"], None) is not None) or (command["name"] in self._options_used_by_dynamic):
 				self._cleanup_non_device_command(instance, command)
 
-	def _cleanup_all_device_commands(self, instance, devices, remove = False):
+	def _cleanup_all_device_commands(self, instance, devices, remove = False, transfer_to_instance=None):
 		for command in reversed([command for command in list(self._commands.values()) if command["per_device"]]):
+			if transfer_to_instance is not None and transfer_to_instance.options.get(command["name"], None) is not None:
+				transfer_this_command = transfer_to_instance
+			else:
+				transfer_this_command = None
 			if (instance.options.get(command["name"], None) is not None) or (command["name"] in self._options_used_by_dynamic):
 				for device in devices:
-					self._cleanup_device_command(instance, command, device, remove)
+					self._cleanup_device_command(instance, command, device, remove, transfer_this_command)
 
-	def _cleanup_device_command(self, instance, command, device, remove = False):
+	def _cleanup_device_command(self, instance, command, device, remove = False, transfer_to_instance=None):
 		if command["custom"] is not None:
-			command["custom"](False, None, device, False, False, instance)
+			command["custom"](False, None, device, False, False, instance, transfer_to_instance)
 		else:
 			old_value = self._storage_get(instance, command, device)
-			if old_value is not None:
+			if old_value is not None and transfer_to_instance is None:
 				command["set"](old_value, device, instance, sim = False, remove = remove)
-			self._storage_unset(instance, command, device)
+			if transfer_to_instance is None:
+				self._storage_unset(instance, command, device)
 
 	def _cleanup_non_device_command(self, instance, command):
 		if command["custom"] is not None:
-			command["custom"](False, None, False, False, instance)
+			command["custom"](False, None, False, False, instance, None)
 		else:
 			old_value = self._storage_get(instance, command)
 			if old_value is not None:

--- a/tuned/plugins/plugin_bootloader.py
+++ b/tuned/plugins/plugin_bootloader.py
@@ -541,7 +541,7 @@ class BootloaderPlugin(base.Plugin):
 		return True
 
 	@command_custom("grub2_cfg_file")
-	def _grub2_cfg_file(self, enabling, value, verify, ignore_missing, instance):
+	def _grub2_cfg_file(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# nothing to verify
 		if verify:
 			return None
@@ -549,7 +549,7 @@ class BootloaderPlugin(base.Plugin):
 			self._grub2_cfg_file_names = [str(value)]
 
 	@command_custom("initrd_dst_img")
-	def _initrd_dst_img(self, enabling, value, verify, ignore_missing, instance):
+	def _initrd_dst_img(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# nothing to verify
 		if verify:
 			return None
@@ -564,7 +564,7 @@ class BootloaderPlugin(base.Plugin):
 		return None
 
 	@command_custom("initrd_remove_dir")
-	def _initrd_remove_dir(self, enabling, value, verify, ignore_missing, instance):
+	def _initrd_remove_dir(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# nothing to verify
 		if verify:
 			return None
@@ -574,7 +574,7 @@ class BootloaderPlugin(base.Plugin):
 		return None
 
 	@command_custom("initrd_add_img", per_device = False, priority = 10)
-	def _initrd_add_img(self, enabling, value, verify, ignore_missing, instance):
+	def _initrd_add_img(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# nothing to verify
 		if verify:
 			return None
@@ -589,7 +589,7 @@ class BootloaderPlugin(base.Plugin):
 		return None
 
 	@command_custom("initrd_add_dir", per_device = False, priority = 10)
-	def _initrd_add_dir(self, enabling, value, verify, ignore_missing, instance):
+	def _initrd_add_dir(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# nothing to verify
 		if verify:
 			return None
@@ -640,7 +640,7 @@ class BootloaderPlugin(base.Plugin):
 		return None
 
 	@command_custom("cmdline", per_device = False, priority = 10)
-	def _cmdline(self, enabling, value, verify, ignore_missing, instance):
+	def _cmdline(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		v = self._variables.expand(self._cmd.unquote(value))
 		if verify:
 			if self._rpm_ostree:
@@ -674,7 +674,7 @@ class BootloaderPlugin(base.Plugin):
 		return None
 
 	@command_custom("skip_grub_config", per_device = False, priority = 10)
-	def _skip_grub_config(self, enabling, value, verify, ignore_missing, instance):
+	def _skip_grub_config(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		if verify:
 			return None
 		if enabling and value is not None:

--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -147,15 +147,15 @@ class DiskPlugin(hotplug.Plugin):
 		if self._device_is_supported(device) or event == "remove":
 			super(DiskPlugin, self)._hardware_events_callback(event, device)
 
-	def _added_device_apply_tuning(self, instance, device_name):
+	def _added_device_apply_tuning(self, instance, device_name, transfer_from_instance):
 		if instance._load_monitor is not None:
 			instance._load_monitor.add_device(device_name)
-		super(DiskPlugin, self)._added_device_apply_tuning(instance, device_name)
+		super(DiskPlugin, self)._added_device_apply_tuning(instance, device_name, transfer_from_instance)
 
-	def _removed_device_unapply_tuning(self, instance, device_name):
+	def _removed_device_unapply_tuning(self, instance, device_name, transfer_to_instance):
 		if instance._load_monitor is not None:
 			instance._load_monitor.remove_device(device_name)
-		super(DiskPlugin, self)._removed_device_unapply_tuning(instance, device_name)
+		super(DiskPlugin, self)._removed_device_unapply_tuning(instance, device_name, transfer_to_instance)
 
 	@classmethod
 	def _get_config_options(cls):
@@ -450,7 +450,7 @@ class DiskPlugin(hotplug.Plugin):
 		return int(value)
 
 	@command_custom("readahead_multiply", per_device=True)
-	def _multiply_readahead(self, enabling, multiplier, device, verify, ignore_missing, instance):
+	def _multiply_readahead(self, enabling, multiplier, device, verify, ignore_missing, instance, transfer_instance):
 		if verify:
 			return None
 		storage_key = self._storage_key(

--- a/tuned/plugins/plugin_irq.py
+++ b/tuned/plugins/plugin_irq.py
@@ -248,7 +248,7 @@ class IrqPlugin(hotplug.Plugin):
 	# command definitions: entry to device-specific tuning
 	#
 	@command_custom("mode", per_device=False, priority=-10)
-	def _mode(self, enabling, value, verify, ignore_missing, instance):
+	def _mode(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		if (enabling or verify) and value is not None:
 			# Store the operating mode of the current instance in the plugin
 			# object, from where it is read by the "affinity" command.
@@ -256,7 +256,7 @@ class IrqPlugin(hotplug.Plugin):
 			self._mode_val = value
 
 	@command_custom("affinity", per_device=True)
-	def _affinity(self, enabling, value, device, verify, ignore_missing, instance):
+	def _affinity(self, enabling, value, device, verify, ignore_missing, instance, transfer_instance):
 		irq = "DEFAULT" if device == "DEFAULT" else device[len("irq"):]
 		if irq not in self._irqs:
 			log.error("Unknown device: %s" % device)

--- a/tuned/plugins/plugin_irq.py
+++ b/tuned/plugins/plugin_irq.py
@@ -182,18 +182,25 @@ class IrqPlugin(hotplug.Plugin):
 	#
 	# "high-level" methods: apply tuning while saving original affinities
 	#
-	def _apply_irq_affinity(self, irqinfo, affinity, mode):
+	def _apply_irq_affinity(self, irqinfo, affinity, mode, transfer):
 		"""Apply IRQ affinity tuning
 
 		Args:
 			irqinfo (IrqInfo): IRQ that should be tuned
 			affinity (set): desired affinity
 		"""
-		original = self._get_irq_affinity(irqinfo.irq)
+		if transfer:
+			original = irqinfo.original_affinity
+			if original is None:
+				# the source instance never changed this IRQ, so the current
+				# affinity is the original
+				original = self._get_irq_affinity(irqinfo.irq)
+		else:
+			original = self._get_irq_affinity(irqinfo.irq)
 		if mode == "intersect":
 			# intersection of affinity and original, if that is empty fall back to configured affinity
 			affinity = affinity & original or affinity
-		if irqinfo.unchangeable or affinity == original:
+		if irqinfo.unchangeable or (not transfer and affinity == original):
 			return
 		res = self._set_irq_affinity(irqinfo.irq, affinity, False)
 		if res == 0:
@@ -202,13 +209,13 @@ class IrqPlugin(hotplug.Plugin):
 		elif res == -2:
 			irqinfo.unchangeable = True
 
-	def _restore_irq_affinity(self, irqinfo):
+	def _restore_irq_affinity(self, irqinfo, transfer):
 		"""Restore IRQ affinity
 
 		Args:
 			irqinfo (IrqInfo): IRQ that should be restored
 		"""
-		if irqinfo.unchangeable or irqinfo.original_affinity is None:
+		if transfer or irqinfo.unchangeable or irqinfo.original_affinity is None:
 			return
 		self._set_irq_affinity(irqinfo.irq, irqinfo.original_affinity, True)
 		irqinfo.original_affinity = None
@@ -257,6 +264,7 @@ class IrqPlugin(hotplug.Plugin):
 
 	@command_custom("affinity", per_device=True)
 	def _affinity(self, enabling, value, device, verify, ignore_missing, instance, transfer_instance):
+		transfer = transfer_instance is not None
 		irq = "DEFAULT" if device == "DEFAULT" else device[len("irq"):]
 		if irq not in self._irqs:
 			log.error("Unknown device: %s" % device)
@@ -267,6 +275,6 @@ class IrqPlugin(hotplug.Plugin):
 			return self._verify_irq_affinity(irqinfo, affinity, self._mode_val)
 		if enabling:
 			affinity = set(self._cmd.cpulist_unpack(value))
-			return self._apply_irq_affinity(irqinfo, affinity, self._mode_val)
+			return self._apply_irq_affinity(irqinfo, affinity, self._mode_val, transfer)
 		else:
-			return self._restore_irq_affinity(irqinfo)
+			return self._restore_irq_affinity(irqinfo, transfer)

--- a/tuned/plugins/plugin_irqbalance.py
+++ b/tuned/plugins/plugin_irqbalance.py
@@ -100,7 +100,7 @@ class IrqbalancePlugin(base.Plugin):
 			self._restart_irqbalance()
 
 	@command_custom("banned_cpus", per_device=False)
-	def _banned_cpus(self, enabling, value, verify, ignore_missing, instance):
+	def _banned_cpus(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		banned_cpulist_string = None
 		if value is not None:
 			banned = set(self._cmd.cpulist_unpack(value))

--- a/tuned/plugins/plugin_mounts.py
+++ b/tuned/plugins/plugin_mounts.py
@@ -129,7 +129,7 @@ class MountsPlugin(base.Plugin):
 		cmd.execute(remount_command)
 
 	@command_custom("disable_barriers", per_device=True)
-	def _disable_barriers(self, start, value, mountpoint, verify, ignore_missing, instance):
+	def _disable_barriers(self, start, value, mountpoint, verify, ignore_missing, instance, transfer_instance):
 		storage_key = self._storage_key(
 				command_name = "disable_barriers",
 				device_name = mountpoint)

--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -203,15 +203,15 @@ class NetTuningPlugin(hotplug.Plugin):
 		if self._device_is_supported(device):
 			super(NetTuningPlugin, self)._hardware_events_callback(event, device)
 
-	def _added_device_apply_tuning(self, instance, device_name):
+	def _added_device_apply_tuning(self, instance, device_name, transfer_from_instance):
 		if instance._load_monitor is not None:
 			instance._load_monitor.add_device(device_name)
-		super(NetTuningPlugin, self)._added_device_apply_tuning(instance, device_name)
+		super(NetTuningPlugin, self)._added_device_apply_tuning(instance, device_name, transfer_from_instance)
 
-	def _removed_device_unapply_tuning(self, instance, device_name):
+	def _removed_device_unapply_tuning(self, instance, device_name, transfer_to_instance):
 		if instance._load_monitor is not None:
 			instance._load_monitor.remove_device(device_name)
-		super(NetTuningPlugin, self)._removed_device_unapply_tuning(instance, device_name)
+		super(NetTuningPlugin, self)._removed_device_unapply_tuning(instance, device_name, transfer_to_instance)
 
 	# pyudev >= 0.21
 	def _get_device_property_1(self, pyudev_dev, prop):
@@ -776,21 +776,21 @@ class NetTuningPlugin(hotplug.Plugin):
 		return None
 
 	@command_custom("features", per_device = True)
-	def _features(self, start, value, device, verify, ignore_missing, instance):
+	def _features(self, start, value, device, verify, ignore_missing, instance, transfer_instance):
 		return self._custom_parameters("features", start, value, device, verify, instance)
 
 	@command_custom("coalesce", per_device = True)
-	def _coalesce(self, start, value, device, verify, ignore_missing, instance):
+	def _coalesce(self, start, value, device, verify, ignore_missing, instance, transfer_instance):
 		return self._custom_parameters("coalesce", start, value, device, verify, instance)
 
 	@command_custom("pause", per_device = True)
-	def _pause(self, start, value, device, verify, ignore_missing, instance):
+	def _pause(self, start, value, device, verify, ignore_missing, instance, transfer_instance):
 		return self._custom_parameters("pause", start, value, device, verify, instance)
 
 	@command_custom("ring", per_device = True)
-	def _ring(self, start, value, device, verify, ignore_missing, instance):
+	def _ring(self, start, value, device, verify, ignore_missing, instance, transfer_instance):
 		return self._custom_parameters("ring", start, value, device, verify, instance)
 
 	@command_custom("channels", per_device = True)
-	def _channels(self, start, value, device, verify, ignore_missing, instance):
+	def _channels(self, start, value, device, verify, ignore_missing, instance, transfer_instance):
 		return self._custom_parameters("channels", start, value, device, verify, instance)

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -1161,7 +1161,7 @@ class SchedulerPlugin(base.Plugin):
 								self._remove_pid(instance, int(event.tid))
 
 	@command_custom("cgroup_ps_blacklist", per_device = False)
-	def _cgroup_ps_blacklist(self, enabling, value, verify, ignore_missing, instance):
+	def _cgroup_ps_blacklist(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1169,7 +1169,7 @@ class SchedulerPlugin(base.Plugin):
 			self._cgroup_ps_blacklist_re = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("ps_whitelist", per_device = False)
-	def _ps_whitelist(self, enabling, value, verify, ignore_missing, instance):
+	def _ps_whitelist(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1177,7 +1177,7 @@ class SchedulerPlugin(base.Plugin):
 			self._ps_whitelist = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("ps_blacklist", per_device = False)
-	def _ps_blacklist(self, enabling, value, verify, ignore_missing, instance):
+	def _ps_blacklist(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1185,7 +1185,7 @@ class SchedulerPlugin(base.Plugin):
 			self._ps_blacklist = "|".join(["(%s)" % v for v in re.split(r"(?<!\\);", str(value))])
 
 	@command_custom("kthread_process", per_device = False)
-	def _kthread_process(self, enabling, value, verify, ignore_missing, instance):
+	def _kthread_process(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1193,7 +1193,7 @@ class SchedulerPlugin(base.Plugin):
 			self._kthread_process = self._cmd.get_bool(value) == "1"
 
 	@command_custom("irq_process", per_device = False)
-	def _irq_process(self, enabling, value, verify, ignore_missing, instance):
+	def _irq_process(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1201,7 +1201,7 @@ class SchedulerPlugin(base.Plugin):
 			self._irq_process = self._cmd.get_bool(value) == "1"
 
 	@command_custom("default_irq_smp_affinity", per_device = False)
-	def _default_irq_smp_affinity(self, enabling, value, verify, ignore_missing, instance):
+	def _default_irq_smp_affinity(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1212,7 +1212,7 @@ class SchedulerPlugin(base.Plugin):
 				self._default_irq_smp_affinity_value = self._cmd.cpulist_unpack(value)
 
 	@command_custom("perf_process_fork", per_device = False)
-	def _perf_process_fork(self, enabling, value, verify, ignore_missing, instance):
+	def _perf_process_fork(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		# currently unsupported
 		if verify:
 			return None
@@ -1429,7 +1429,7 @@ class SchedulerPlugin(base.Plugin):
 		return res
 
 	@command_custom("isolated_cores", per_device = False, priority = 10)
-	def _isolated_cores(self, enabling, value, verify, ignore_missing, instance):
+	def _isolated_cores(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		affinity = None
 		self._affinity = None
 		if value is not None:

--- a/tuned/plugins/plugin_scsi_host.py
+++ b/tuned/plugins/plugin_scsi_host.py
@@ -61,11 +61,11 @@ class SCSIHostPlugin(hotplug.Plugin):
 		if self._device_is_supported(device):
 			super(SCSIHostPlugin, self)._hardware_events_callback(event, device)
 
-	def _added_device_apply_tuning(self, instance, device_name):
-		super(SCSIHostPlugin, self)._added_device_apply_tuning(instance, device_name)
+	def _added_device_apply_tuning(self, instance, device_name, transfer_from_instance):
+		super(SCSIHostPlugin, self)._added_device_apply_tuning(instance, device_name, transfer_from_instance)
 
-	def _removed_device_unapply_tuning(self, instance, device_name):
-		super(SCSIHostPlugin, self)._removed_device_unapply_tuning(instance, device_name)
+	def _removed_device_unapply_tuning(self, instance, device_name, transfer_to_instance):
+		super(SCSIHostPlugin, self)._removed_device_unapply_tuning(instance, device_name, transfer_to_instance)
 
 	@classmethod
 	def _get_config_options(cls):

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -120,7 +120,7 @@ class SystemdPlugin(base.Plugin):
 		return " ".join(str(v) for v in self._cmd.cpulist_unpack(re.sub(r"\s+", r",", re.sub(r",\s+", r",", cpulist))))
 
 	@command_custom("cpu_affinity", per_device = False)
-	def _cmdline(self, enabling, value, verify, ignore_missing, instance):
+	def _cmdline(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		conf_affinity = None
 		conf_affinity_unpacked = None
 		v = self._cmd.unescape(self._variables.expand(self._cmd.unquote(value)))

--- a/tuned/plugins/plugin_vm.py
+++ b/tuned/plugins/plugin_vm.py
@@ -175,24 +175,24 @@ class VMPlugin(base.Plugin):
 		return True
 
 	@command_custom("dirty_bytes")
-	def _dirty_bytes(self, enabling, value, verify, ignore_missing, instance):
+	def _dirty_bytes(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		if value is not None and value.strip().endswith("%"):
 			return self._dirty_option("dirty_ratio", "dirty_bytes", self._check_ratio, enabling, value.strip().rstrip("%"), verify)
 		return self._dirty_option("dirty_bytes", "dirty_ratio", self._check_twice_pagesize, enabling, value, verify)
 
 	@command_custom("dirty_ratio")
-	def _dirty_ratio(self, enabling, value, verify, ignore_missing, instance):
+	def _dirty_ratio(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		log.warning("The 'dirty_ratio' option is deprecated and does not support inheritance, use 'dirty_bytes' with '%' instead.")
 		return self._dirty_option("dirty_ratio", "dirty_bytes", self._check_ratio, enabling, value, verify)
 
 	@command_custom("dirty_background_bytes")
-	def _dirty_background_bytes(self, enabling, value, verify, ignore_missing, instance):
+	def _dirty_background_bytes(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		if value is not None and value.strip().endswith("%"):
 			return self._dirty_option("dirty_background_ratio", "dirty_background_bytes", self._check_ratio, enabling, value.strip().rstrip("%"), verify)
 		return self._dirty_option("dirty_background_bytes", "dirty_background_ratio", self._check_positive, enabling, value, verify)
 
 	@command_custom("dirty_background_ratio")
-	def _dirty_background_ratio(self, enabling, value, verify, ignore_missing, instance):
+	def _dirty_background_ratio(self, enabling, value, verify, ignore_missing, instance, transfer_instance):
 		log.warning("The 'dirty_background_ratio' option is deprecated and does not support inheritance, use 'dirty_background_bytes' with '%' instead.")
 		return self._dirty_option("dirty_background_ratio", "dirty_background_bytes", self._check_ratio, enabling, value, verify)
 


### PR DESCRIPTION
The problem (briefly discussed in https://github.com/redhat-performance/tuned/pull/580#issuecomment-1898287455):

* when moving a device from one plugin instance to another (via `instance_aquire_devices`, or during dynamic `instance_create`/`instance_destroy`), tuning of the device is unapplied (settings reverted back to original) before the new tuning is applied.

This proposal makes the following changes:

* For device specific tuning via `@command`s (`_(execute|cleanup)_all_device_commands`), there is a new argument providing (optionally) the instance from/to which the device is being moved.
* For `@command_(get|set)` we can handle all logic in the base plugin class.
  * When un-tuning in the "from" instance, only unapply those settings that are not set in the "to" instance.
  * For the settings that are set in both "from" and "to" instance, apply the new settings without unapplying the old ones, but transfer the proper original value of the setting so that it can be correctly restored.
* For `@command_custom` we pass the `transfer_instance` to the command
  * Command implementation can provide a seamless transfer, or just ignore the new argument, and the current "unapply-then-apply" behavior will remain unchanged.
* In `controller`, replace the current calls to `_remove_devices_nocheck`/`_add_devices_nocheck` with calls to the new `_transfer_device`.
* Adapt the `irq` plugin, which uses `@command_custom`, to support seamless device transfer (separate commit).
