### PR TITLE
Fix thinkpad_function_keys feature

### DIFF
--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -11,7 +11,7 @@ PROFILES_SECTION = "profiles"
 BATTERY_SECTION = "battery"
 DEFAULT_PROFILE_OPTION = "default"
 BATTERY_DETECTION_OPTION = "battery_detection"
-THINKPAD_FUNCTION_KEYS_OPTION = "thinkpad_function_keys"
+SYSFS_ACPI_MONITOR_OPTION = "sysfs_acpi_monitor"
 
 
 class ProfileMap:
@@ -75,13 +75,13 @@ class PPDConfig:
         return self._tuned_to_ppd
 
     @property
-    def thinkpad_function_keys(self):
+    def sysfs_acpi_monitor(self):
         """
         Whether to react to changes of ACPI platform profile
         done via function keys (e.g., Fn-L) on newer Thinkpad
         machines. Experimental feature.
         """
-        return self._thinkpad_function_keys
+        return self._sysfs_acpi_monitor
 
     def load_from_file(self, config_file):
         """
@@ -141,4 +141,4 @@ class PPDConfig:
         self._ppd_to_tuned = ProfileMap(profile_dict_ac, profile_dict_dc)
         self._tuned_to_ppd = ProfileMap({v: k for k, v in profile_dict_ac.items()}, {v: k for k, v in profile_dict_dc.items()})
 
-        self._thinkpad_function_keys = cfg.getboolean(MAIN_SECTION, THINKPAD_FUNCTION_KEYS_OPTION, fallback=False)
+        self._sysfs_acpi_monitor = cfg.getboolean(MAIN_SECTION, SYSFS_ACPI_MONITOR_OPTION, fallback=False)

--- a/tuned/ppd/config.py
+++ b/tuned/ppd/config.py
@@ -141,4 +141,4 @@ class PPDConfig:
         self._ppd_to_tuned = ProfileMap(profile_dict_ac, profile_dict_dc)
         self._tuned_to_ppd = ProfileMap({v: k for k, v in profile_dict_ac.items()}, {v: k for k, v in profile_dict_dc.items()})
 
-        self._sysfs_acpi_monitor = cfg.getboolean(MAIN_SECTION, SYSFS_ACPI_MONITOR_OPTION, fallback=False)
+        self._sysfs_acpi_monitor = cfg.getboolean(MAIN_SECTION, SYSFS_ACPI_MONITOR_OPTION, fallback=True)

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -298,7 +298,7 @@ class Controller(exports.interfaces.ExportableInterface):
             self._inotify_watches |= self._watch_manager.add_watch(path=os.path.dirname(LAP_MODE_PATH),
                                                                    mask=pyinotify.IN_MODIFY,
                                                                    proc_fun=PerformanceDegradedEventHandler(LAP_MODE_PATH, self))
-        if self._platform_profile_supported and self._config.thinkpad_function_keys:
+        if self._platform_profile_supported and self._config.sysfs_acpi_monitor:
            self._inotify_watches |= self._watch_manager.add_watch(path=os.path.dirname(PLATFORM_PROFILE_PATH),
                                                                   mask=pyinotify.IN_OPEN | pyinotify.IN_MODIFY | pyinotify.IN_CLOSE_WRITE | pyinotify.IN_CLOSE_NOWRITE,
                                                                   proc_fun=PlatformProfileEventHandler(self))

--- a/tuned/ppd/ppd.conf
+++ b/tuned/ppd/ppd.conf
@@ -2,6 +2,7 @@
 # The default PPD profile
 default=balanced
 battery_detection=true
+sysfs_acpi_monitor=true
 
 [profiles]
 # PPD = TuneD


### PR DESCRIPTION
The thinkpad_function_keys feature is incorrectly named, so rename it to sysfs_acpi_monitor to be more correct.

It is also a useful feature - if profiles are updated on Fedora 41 outside of tuned, then they are not reflected in tuned or gnome-settings (or likely KDE, though I didn't test that). Enable the feature by default.

Tested on multiple devices. As a note - I expect this feature to be useful to any vendor supporting platform profiles, not just Thinkpads (though it does mean our function keys work correctly again which is nice)

Thanks
Mark