### PR TITLE
functions: Silence errors if module kvm_intel does not exist

### DIFF
--- a/functions
+++ b/functions
@@ -477,7 +477,7 @@ setup_kvm_mod_low_latency()
 
 	modinfo -p kvm | grep -q kvmclock_periodic_sync && HAS_KPS=1
 	modinfo -p kvm | grep -q nx_huge_pages && HAS_NX_HP=1
-	modinfo -p kvm_intel | grep -q ple_gap && HAS_PLE_GAP=1
+	modinfo -p kvm_intel 2>/dev/null | grep -q ple_gap && HAS_PLE_GAP=1
 	grep -qs kvmclock_periodic_sync "$kvm_modprobe_file" && WANTS_KPS=1
 	grep -qs nx_huge_pages "$kvm_modprobe_file" && WANTS_NX_HP=1
 	grep -qs ple_gap "$kvm_modprobe_file" && WANTS_PLE_GAP=1


### PR DESCRIPTION
Without the redirect to /dev/null, an error message would be reported in TuneD logs on aarch64 machines, which do not have the kernel module.

Resolves: RHEL-79943