### PR TITLE
GUI: Fix the profile deleter script

### DIFF
--- a/tuned/gtk/gui_profile_deleter.py
+++ b/tuned/gtk/gui_profile_deleter.py
@@ -2,6 +2,12 @@ import os
 import sys
 import shutil
 
+import tuned.consts
+
 if __name__ == '__main__':
 
-	shutil.rmtree('/etc/tuned/%s' % (os.path.basename(os.path.abspath(sys.argv[1]))))
+    shutil.rmtree(
+        os.path.join(
+            tuned.consts.USER_PROFILES_DIR,
+            os.path.basename(os.path.abspath(sys.argv[1]))
+    ))


### PR DESCRIPTION
This PR fixes profile deletion in the GUI (using `tuned.gtk.gui_profile_deleter`), which was broken by the refactoring performed in #138.

Instead of hardcoding a path, use `tuned.consts.USER_PROFILES_DIR` as the location where we should expect to find profile directories that we've been asked to delete. (The alternative would be to load, and call, `_locate_profile_dir()` on the profile name, like the code did before the refactor. But, if it's deletable we know it'll be in the `USER_PROFILES_DIR`, so that's probably overkill.)