### PR TITLE
variables: Add an option to prepend child variables before parent ones

### DIFF
--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -21,6 +21,7 @@ USER_PROFILES_DIR = "/etc/tuned/profiles"
 SYSTEM_PROFILES_DIR = "/usr/lib/tuned/profiles"
 PERSISTENT_STORAGE_DIR = "/var/lib/tuned"
 PLUGIN_MAIN_UNIT_NAME = "main"
+PLUGIN_VARIABLES_UNIT_NAME = "variables"
 # Magic section header because ConfigParser does not support "headerless" config
 MAGIC_HEADER_NAME = "this_is_some_magic_section_header_because_of_compatibility"
 RECOMMEND_DIRECTORIES = ["/usr/lib/tuned/recommend.d", "/etc/tuned/recommend.d"]

--- a/tuned/profiles/loader.py
+++ b/tuned/profiles/loader.py
@@ -51,15 +51,9 @@ class Loader(object):
 		processed_files = []
 		self._load_profile(profile_names, profiles, processed_files)
 
-		if len(profiles) > 1:
-			final_profile = self._profile_merger.merge(profiles)
-		else:
-			final_profile = profiles[0]
-
+		final_profile = self._profile_merger.merge(profiles)
 		final_profile.name = " ".join(profile_names)
-		if "variables" in final_profile.units:
-			self._variables.add_from_cfg(final_profile.units["variables"].options)
-			del(final_profile.units["variables"])
+		self._variables.add_from_cfg(final_profile.variables)
 		# FIXME hack, do all variable expansions in one place
 		self._expand_vars_in_devices(final_profile)
 		self._expand_vars_in_regexes(final_profile)

--- a/tuned/profiles/profile.py
+++ b/tuned/profiles/profile.py
@@ -7,10 +7,11 @@ class Profile(object):
 	Representation of a tuning profile.
 	"""
 
-	__slots__ = ["_name", "_options", "_units"]
+	__slots__ = ["_name", "_options", "_variables", "_units"]
 
-	def __init__(self, name, config):
+	def __init__(self, name=None, config={}):
 		self._name = name
+		self._variables = collections.OrderedDict()
 		self._init_options(config)
 		self._init_units(config)
 
@@ -39,6 +40,10 @@ class Profile(object):
 	@name.setter
 	def name(self, value):
 		self._name = value
+
+	@property
+	def variables(self):
+		return self._variables
 
 	@property
 	def units(self):

--- a/tuned/profiles/unit.py
+++ b/tuned/profiles/unit.py
@@ -6,7 +6,7 @@ class Unit(object):
 	Unit description.
 	"""
 
-	__slots__ = [ "_name", "_priority", "_type", "_enabled", "_replace", "_drop", "_devices", "_devices_udev_regex", \
+	__slots__ = [ "_name", "_priority", "_type", "_enabled", "_replace", "_prepend", "_drop", "_devices", "_devices_udev_regex", \
 		"_cpuinfo_regex", "_uname_regex", "_script_pre", "_script_post", "_options" ]
 
 	def __init__(self, name, config):
@@ -15,6 +15,7 @@ class Unit(object):
 		self._type = config.pop("type", self._name)
 		self._enabled = config.pop("enabled", True) in [True, "True", "true", 1, "1"]
 		self._replace = config.pop("replace", False) in [True, "True", "true", 1, "1"]
+		self._prepend = config.pop("prepend", False) in [True, "True", "true", 1, "1"]
 		self._drop = config.pop("drop", None)
 		if self._drop is not None:
 			self._drop = re.split(r"\b\s*[,;]\s*", str(self._drop))
@@ -57,6 +58,10 @@ class Unit(object):
 	@property
 	def replace(self):
 		return self._replace
+
+	@property
+	def prepend(self):
+		return self._prepend
 
 	@property
 	def drop(self):


### PR DESCRIPTION
When a child profile overwrites an option defined by its parent,
the option stays in its place in the option dictionary. Until now, this
prevented the child profile from using any _new_ variables in the option
definition, because those would get added to the end of the option
dictionary. As a workaround (see, e.g., redhat-performance#239), such variables would have
to be pre-defined (empty) in the parent profile. However, there is no
suitable workaround if we do not want to touch the parent profile.

This commit adds a new `prepend` option available in variable units.
With this option set to true, new variables are prepended before
parent variables instead of being added to the end. The location of
overwritten variables is not changed, i.e., they remain in their place.

As part of this change, we now allow multiple instances of variable
units. If multiple instances are defined, they must have unique names.
Instances that are not named "variables" must contain the option
`type=variables`. This is useful in scenarios when some variables
need to be prepended and some appended.

The following is a simple example of what this allows.

Parent profile:
```
[variables]
var_x="defined by parent"
var_y="also defined by parent"
```
Child profile:
```
[main]
include=parent

[variables_prepend]
type=variables
prepend=True
var_z="defined by child"
var_x=${var_z}

[variables_append]
type=variables
var_y_copy=${var_y}
```
When the child profile is loaded, all four variables will be defined with the values:
```
var_x="defined by child"
var_y="also defined by parent"
var_z="defined by child"
var_y_copy="also defined by parent"
```
Resolves redhat-performance#751.