### PR TITLE
perf: dropped from irqbalance and improved detection in scheduler

### DIFF
--- a/tuned/plugins/plugin_irqbalance.py
+++ b/tuned/plugins/plugin_irqbalance.py
@@ -3,7 +3,6 @@ from .decorators import command_custom
 from tuned import consts
 import tuned.logs
 import errno
-import perf
 import re
 
 log = tuned.logs.get()
@@ -29,7 +28,7 @@ class IrqbalancePlugin(base.Plugin):
 
 	def __init__(self, *args, **kwargs):
 		super(IrqbalancePlugin, self).__init__(*args, **kwargs)
-		self._cpus = perf.cpu_map()
+		self._cpus = self._cmd.get_cpus()
 
 	def _instance_init(self, instance):
 		instance._has_dynamic_tuning = False

--- a/tuned/utils/commands.py
+++ b/tuned/utils/commands.py
@@ -555,3 +555,9 @@ class commands:
 
 	def getconf(self, variable):
 		return check_output(["getconf", variable]).decode().strip()
+
+	# Gets list of available CPUs
+	def get_cpus(self):
+		cpus = self.read_file(consts.SYSFS_CPUS_PRESENT_PATH)
+		# fallback to single core CPU if sysfs is unavailable
+		return self.cpulist_unpack(cpus) if cpus else [ 0 ]


### PR DESCRIPTION
Now the irqbalance plugin will work even if perf is unavailable. Also improved perf detection in the scheduler plugin. If the perf.cpu_map() fails for some reason, perf is disabled and the perf library will not segfault.