### PR TITLE
beakerlib: Use ncat explicitly instead of nc

### DIFF
--- a/tests/beakerlib/Expose-TuneD-API-to-the-Unix-Domain-Socket/runtest.sh
+++ b/tests/beakerlib/Expose-TuneD-API-to-the-Unix-Domain-Socket/runtest.sh
@@ -24,7 +24,7 @@ send() {
   local socket=/run/tuned/tuned.sock
 #  local send_only=--send-only
   
-  printf "$data" | nc $send_only -U /run/tuned/tuned.sock
+  printf "$data" | ncat $send_only -U /run/tuned/tuned.sock
 }
 
 rlJournalStart


### PR DESCRIPTION
This PR should fix recent test failures in Fedora Rawhide (for some reason, Rawhide has netcat installed by default).