### PR TITLE
Re-raise daemon init exception in no-daemon mode

### DIFF
--- a/tuned/admin/admin.py
+++ b/tuned/admin/admin.py
@@ -303,7 +303,7 @@ class Admin(object):
 		print("Trying to (re)start tuned...")
 		(ret, msg) = self._cmd.execute(["service", "tuned", "restart"])
 		if ret != 0:
-			raise TunedException("TuneD (re)start failed, you need to (re)start TuneD by hand.")
+			raise TunedException("TuneD (re)start failed, check TuneD logs for details.")
 		print("TuneD (re)started.")
 
 	def _set_profile(self, profile_name, manual):

--- a/tuned/daemon/daemon.py
+++ b/tuned/daemon/daemon.py
@@ -51,6 +51,8 @@ class Daemon(object):
 			self._init_profile(profile_names)
 		except TunedException as e:
 			log.error("Cannot set initial profile. No tunings will be enabled: %s" % e)
+			if not self._daemon:
+				raise TunedException("Applying TuneD profile failed, check TuneD logs for details.")
 
 	def _init_threads(self):
 		self._thread = None


### PR DESCRIPTION
This way, the exception gets caught in tuned.py,
which prints an error message and exits with
non-zero error code, providing feedback to
tuned-adm. Previously, tuned-adm would have no
way of knowing that TuneD failed.

Resolves: RHEL-71304