### PR TITLE
tuned-main.conf: added startup_udev_settle_wait option

### DIFF
--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -77,7 +77,7 @@ log_file_max_size = 1MB
 # connections_backlog = 1024
 
 # TuneD daemon rollback strategy. Supported values: auto|not_on_exit
-# - auto: rollbacks are always performed on a profile switch or 
+# - auto: rollbacks are always performed on a profile switch or
 #   graceful TuneD process exit
 # - not_on_exit: rollbacks are always performed on a profile
 #   switch, but not on any kind of TuneD process exit
@@ -87,3 +87,13 @@ log_file_max_size = 1MB
 # In case of conflicts in profile names, the later directory
 # takes precedence
 # profile_dirs = /usr/lib/tuned/profiles,/etc/tuned/profiles
+
+# Timeout in seconds to wait until udev settles. Value 0 disables the wait.
+# With non-zero wait TuneD startup is delayed until there are no pending
+# udev events or the specified timeout occurs.
+# The delay can help in situations where there are a lot of udev events
+# during TuneD startup and TuneD is too slow to handle them.
+# In environments where systemd is utilised for starting TuneD
+# it is better to keep this feature disabled and rely on systemd
+# functionality (systemd-udev-settle).
+startup_udev_settle_wait = 0

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -146,6 +146,7 @@ CFG_UNIX_SOCKET_CONNECTIONS_BACKLOG = "connections_backlog"
 CFG_CPU_EPP_FLAG = "hwp_epp"
 CFG_ROLLBACK = "rollback"
 CFG_PROFILE_DIRS = "profile_dirs"
+CFG_STARTUP_UDEV_SETTLE_WAIT = "startup_udev_settle_wait"
 
 # no_daemon mode
 CFG_DEF_DAEMON = True
@@ -197,6 +198,8 @@ CFG_FUNC_UNIX_SOCKET_CONNECTIONS_BACKLOG = "getint"
 CFG_DEF_ROLLBACK = "auto"
 # default profile directories
 CFG_DEF_PROFILE_DIRS = [SYSTEM_PROFILES_DIR, USER_PROFILES_DIR]
+# default startup udev settle wait
+CFG_DEF_STARTUP_UDEV_SETTLE_WAIT = 0
 
 PATH_CPU_DMA_LATENCY = "/dev/cpu_dma_latency"
 

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -106,17 +106,17 @@ PPD_API_COMPATIBILITY = "0.23"
 PPD_DBUS_BUS = "org.freedesktop.UPower.PowerProfiles"
 PPD_DBUS_BUS_LEGACY = "net.hadess.PowerProfiles"
 PPD_DBUS_NAMES = [
-    {
-        "bus": PPD_DBUS_BUS,
-        "namespace": PPD_DBUS_BUS,
-        "interface": PPD_DBUS_BUS,
-        "object": "/org/freedesktop/UPower/PowerProfiles"
+	{
+		"bus": PPD_DBUS_BUS,
+		"namespace": PPD_DBUS_BUS,
+		"interface": PPD_DBUS_BUS,
+		"object": "/org/freedesktop/UPower/PowerProfiles"
 	},
-    {
-        "bus": PPD_DBUS_BUS_LEGACY,
-        "namespace": PPD_DBUS_BUS_LEGACY,
-        "interface": PPD_DBUS_BUS_LEGACY,
-        "object": "/net/hadess/PowerProfiles"
+	{
+		"bus": PPD_DBUS_BUS_LEGACY,
+		"namespace": PPD_DBUS_BUS_LEGACY,
+		"interface": PPD_DBUS_BUS_LEGACY,
+		"object": "/net/hadess/PowerProfiles"
 	}
 ]
 

--- a/tuned/utils/global_config.py
+++ b/tuned/utils/global_config.py
@@ -75,7 +75,10 @@ class GlobalConfig():
 			if isinstance(i, int):
 				return i
 			else:
-				return int(i, 0)
+				try:
+					return int(i, 0)
+				except ValueError:
+					log.error("Error parsing integer '%s', using '%d'." %(str(i), default))
 		return default
 
 	def get_list(self, key, default = []):


### PR DESCRIPTION
Timeout in seconds to maximally wait until udev settles. If set to value bigger than 0, it will either wait until udev settles or the timeout occurs. Disable with 0.

Resolves: RHEL-88238
