### PR TITLE
plugins: Support MMC devices

### DIFF
--- a/tuned/plugins/plugin_disk.py
+++ b/tuned/plugins/plugin_disk.py
@@ -134,7 +134,8 @@ class DiskPlugin(hotplug.Plugin):
 		return  device.device_type == "disk" and \
 			device.attributes.get("removable", None) == b"0" and \
 			(device.parent is None or \
-					device.parent.subsystem in ["scsi", "virtio", "xen", "nvme"])
+					device.parent.subsystem in ["scsi", "virtio", "xen", "nvme",
+												"mmc"])
 
 	def _hardware_events_init(self):
 		self._hardware_inventory.subscribe(self, "block", self._hardware_events_callback)


### PR DESCRIPTION
Add support for MMC (MultiMediaCard) devices in tuned's disk plugin.

fixes: #776