### PR TITLE
Dockerfile: New to build on a bootc image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Avoid rebuilding when this changes
+Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,22 @@
+name: Docker Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get a newer podman for heredoc support (from debian testing)
+        run: |
+          set -eux
+          echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
+          sudo apt update
+          sudo apt install -y crun/testing podman/testing skopeo/testing
+
+      - uses: actions/checkout@v4
+
+      - name: Build container
+        run: sudo podman build -t localhost/tuned .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG base=quay.io/centos-bootc/centos-bootc:stream10
+
+FROM $base as build
+COPY tuned.spec /tmp/tuned.spec
+# This installs our package dependencies, and we want to cache it independently of the rest.
+RUN <<EORUN
+set -xeuo pipefail
+dnf -y install rpm-build
+dnf -y builddep /tmp/tuned.spec
+EORUN
+# Now copy the rest of the source
+COPY . /build
+WORKDIR /build
+RUN <<EORUN
+set -xeuo pipefail
+mkdir -p /var/roothome
+make rpm
+mkdir -p /out
+mv ~/rpmbuild/RPMS/noarch/tuned-2*.rpm /out
+EORUN
+
+FROM $base
+RUN --mount=from=build,target=/build,type=bind <<EORUN
+set -xeuo pipefail
+dnf -y install /build/out/*.rpm
+dnf clean all
+rm -rf /var/{lib,cache,log}/*
+bootc container lint --fatal-warnings
+EORUN
+


### PR DESCRIPTION
This is a pretty straightforward wiring up of the `make rpm` flow and then installing it in a bootc container image.

Intended as a starting point both for local development but also wiring up further CI.