### PR TITLE
vm: Deprecate dirty_ratio in favour of dirty_bytes with %

### DIFF
--- a/profiles/accelerator-performance/tuned.conf
+++ b/profiles/accelerator-performance/tuned.conf
@@ -25,11 +25,11 @@ readahead=>4096
 #
 # The generator of dirty data starts writeback at this percentage (system default
 # is 20%)
-dirty_ratio = 40
+dirty_bytes = 40%
 
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-dirty_background_ratio = 10
+dirty_background_bytes = 10%
 
 [sysctl]
 # PID allocation wrap value.  When the kernel's next PID value

--- a/profiles/latency-performance/tuned.conf
+++ b/profiles/latency-performance/tuned.conf
@@ -22,11 +22,11 @@ platform_profile=performance
 #
 # The generator of dirty data starts writeback at this percentage (system default
 # is 20%)
-dirty_ratio=10
+dirty_bytes=10%
 
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-dirty_background_ratio=3
+dirty_background_bytes=3%
 
 [sysctl]
 # The swappiness parameter controls the tendency of the kernel to move

--- a/profiles/mssql/tuned.conf
+++ b/profiles/mssql/tuned.conf
@@ -12,8 +12,8 @@ force_latency=5
 [vm]
 # For multi-instance SQL deployments use 'madvise' instead of 'always'
 transparent_hugepages=always
-dirty_background_ratio=3
-dirty_ratio=80
+dirty_background_bytes=3%
+dirty_bytes=80%
 
 [sysctl]
 vm.swappiness=1

--- a/profiles/oracle/tuned.conf
+++ b/profiles/oracle/tuned.conf
@@ -25,6 +25,6 @@ kernel.panic_on_oops = 1
 kernel.numa_balancing = 0
 
 [vm]
-dirty_background_ratio = 3
-dirty_ratio = 40
+dirty_background_bytes = 3%
+dirty_bytes = 40%
 transparent_hugepages=never

--- a/profiles/sap-hana/tuned.conf
+++ b/profiles/sap-hana/tuned.conf
@@ -13,8 +13,8 @@ min_perf_pct=100
 
 [vm]
 transparent_hugepages=madvise
-dirty_ratio = 40
-dirty_background_ratio = 10
+dirty_bytes = 40%
+dirty_background_bytes = 10%
 
 [sysctl]
 kernel.sem = 32000 1024000000 500 32000

--- a/profiles/spectrumscale-ece/tuned.conf
+++ b/profiles/spectrumscale-ece/tuned.conf
@@ -12,8 +12,8 @@ energy_perf_bias=performance
 min_perf_pct=100
 
 [vm]
-dirty_ratio = 40
-dirty_background_ratio = 10
+dirty_bytes = 40%
+dirty_background_bytes = 10%
 
 [sysctl]
 kernel.numa_balancing = 1

--- a/profiles/spindown-disk/tuned.conf
+++ b/profiles/spindown-disk/tuned.conf
@@ -27,7 +27,7 @@ spindown=6
 alpm=medium_power
 
 [vm]
-dirty_ratio=60
+dirty_bytes=60%
 
 [sysctl]
 vm.dirty_writeback_centisecs=6000

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -25,11 +25,11 @@ platform_profile=performance
 #
 # The generator of dirty data starts writeback at this percentage (system default
 # is 20%)
-dirty_ratio = 40
+dirty_bytes = 40%
 
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-dirty_background_ratio = 10
+dirty_background_bytes = 10%
 
 # Marvell ThunderX
 [vm.thunderx]

--- a/profiles/virtual-guest/tuned.conf
+++ b/profiles/virtual-guest/tuned.conf
@@ -14,7 +14,7 @@ include=throughput-performance
 #
 # The generator of dirty data starts writeback at this percentage (system default
 # is 20%)
-dirty_ratio = 30
+dirty_bytes = 30%
 
 [sysctl]
 # Filesystem I/O is usually much more efficient than swapping, so try to keep

--- a/profiles/virtual-host/tuned.conf
+++ b/profiles/virtual-host/tuned.conf
@@ -9,7 +9,7 @@ include=throughput-performance
 [vm]
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-dirty_background_ratio = 5
+dirty_background_bytes = 5%
 
 [cpu]
 # Setting C3 state sleep mode/power savings

--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post-vars/tuned.conf
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post-vars/tuned.conf
@@ -2,4 +2,4 @@
 summary=Post-loaded profile that uses variables from the regular active profile
 
 [vm]
-dirty_ratio=${foo}
+dirty_bytes=${foo}%

--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post/tuned.conf
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post/tuned.conf
@@ -2,4 +2,4 @@
 summary=Post-loaded profile
 
 [vm]
-dirty_ratio=8
+dirty_bytes=8%

--- a/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post2/tuned.conf
+++ b/tests/beakerlib/bz1798183-RFE-support-post-loaded-profile/post2/tuned.conf
@@ -2,4 +2,4 @@
 summary=Second version of the post-loaded profile
 
 [vm]
-dirty_ratio=7
+dirty_bytes=7%


### PR DESCRIPTION
Same for dirty_background_ratio and dirty_background_bytes.

Using both the ratio and the bytes is not compatible with the current profile inheritance implementation, because it is not possible for dirty_bytes in a child profile to override dirty_ratio in its parent profile.

Resolves: RHEL-101578