### PR TITLE
cpu-partitioning: autodetect dracut hook directory

### DIFF
--- a/profiles/cpu-partitioning/script.sh
+++ b/profiles/cpu-partitioning/script.sh
@@ -3,10 +3,19 @@
 . /usr/lib/tuned/functions
 
 start() {
+    DRACUT_VER=`dracut --version | sed 's/^.* \([0-9]\+\).*/\1/'`
+    echo "$DRACUT_VER" | grep -q '^[[:digit:]]\+$' || DRACUT_VER="0"
+    # https://issues.redhat.com/browse/RHEL-119889
+    if [ "$DRACUT_VER" -gt "102" ]
+    then
+      DRACUT_HOOK_DIR="/var/lib/dracut/hooks/pre-udev"
+    else
+      DRACUT_HOOK_DIR="/usr/lib/dracut/hooks/pre-udev"
+    fi
     mkdir -p "${TUNED_tmpdir}/etc/systemd"
-    mkdir -p "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev"
+    mkdir -p "${TUNED_tmpdir}${DRACUT_HOOK_DIR}"
     cp /etc/systemd/system.conf "${TUNED_tmpdir}/etc/systemd/"
-    cp 00-tuned-pre-udev.sh "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev/"
+    cp 00-tuned-pre-udev.sh "${TUNED_tmpdir}${DRACUT_HOOK_DIR}"
     setup_kvm_mod_low_latency
     disable_ksm
     return "$?"

--- a/profiles/cpu-partitioning/tuned.conf
+++ b/profiles/cpu-partitioning/tuned.conf
@@ -23,6 +23,7 @@ tmpdir=${f:strip:${f:exec:mktemp:-d}}
 isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
 isolated_cpumask=${f:cpulist2hex:${isolated_cores_expanded}}
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+not_isolated_cores=${f:cpulist_pack:${not_isolated_cores_expanded}}
 isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
 not_isolated_cores_online_expanded=${f:cpulist_online:${not_isolated_cores_expanded}}
 not_isolated_cpumask=${f:cpulist2hex:${not_isolated_cores_expanded}}
@@ -62,4 +63,4 @@ priority=10
 initrd_remove_dir=True
 initrd_dst_img=tuned-initrd.img
 initrd_add_dir=${tmpdir}
-cmdline_cpu_part=+nohz=on${cmd_isolcpus} nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup
+cmdline_cpu_part=+nohz=on${cmd_isolcpus} nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores} intel_pstate=disable nosoftlockup


### PR DESCRIPTION
Wrong hook directory can make the machine unbootable: https://issues.redhat.com/browse/RHEL-119889