### PR TITLE
profiles: Set boost=1 in *-performance profiles

### DIFF
--- a/profiles/accelerator-performance/tuned.conf
+++ b/profiles/accelerator-performance/tuned.conf
@@ -9,6 +9,7 @@ summary=Throughput performance based tuning with disabled higher latency STOP st
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+boost=1
 force_latency=99
 
 [acpi]

--- a/profiles/latency-performance/tuned.conf
+++ b/profiles/latency-performance/tuned.conf
@@ -10,6 +10,7 @@ force_latency=cstate.id_no_zero:1|3
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+boost=1
 
 [acpi]
 platform_profile=performance

--- a/profiles/sap-hana/tuned.conf
+++ b/profiles/sap-hana/tuned.conf
@@ -10,6 +10,7 @@ force_latency=cstate.id_no_zero:3|70
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+boost=1
 
 [vm]
 transparent_hugepages=madvise

--- a/profiles/spectrumscale-ece/tuned.conf
+++ b/profiles/spectrumscale-ece/tuned.conf
@@ -10,6 +10,7 @@ include=throughput-performance
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+boost=1
 
 [vm]
 dirty_bytes = 40%

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -13,6 +13,7 @@ governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
 energy_performance_preference=performance
+boost=1
 
 [acpi]
 platform_profile=performance


### PR DESCRIPTION
Commit 068928e ("Add support for controlling amd-pstate core performance boost") started setting the newly-introduced `boost` parameter in the balanced and powersave profiles, but forgot to do the same in the performance profiles. The net result was that transitioning directly from the powersave profile to a performance profile would leave boosting disabled.

Fix this by setting boost=1 explictly in all performance-oriented profiles (i.e., those with a min_perf_pct of 100).