### PR TITLE
feat(sysctl): add reapply_sysctl_exclude option

### DIFF
--- a/man/tuned-main.conf.5
+++ b/man/tuned-main.conf.5
@@ -71,6 +71,21 @@ will not override user-provided system sysctl settings. If set to \fBFalse\fR or
 it's set to \fBTrue\fR.
 
 .TP
+.BI reapply_sysctl_exclude= LIST
+A comma or semicolon separated list of sysctl parameter patterns to exclude
+from reapplication when \fBreapply_sysctl\fR is enabled. This is useful for
+protecting runtime sysctl changes made by Kubernetes CNI plugins or other
+services that set sysctls dynamically. Supports shell-style wildcards
+(\fB*\fR, \fB?\fR, \fB[seq]\fR). By default the list is empty.
+.PP
+.RS
+.B Example:
+.nf
+  reapply_sysctl_exclude = net.ipv4.ip_forward, net.ipv6.conf.*.forwarding
+.fi
+.RE
+
+.TP
 .BI default_instance_priority= INT
 Default instance (unit) priority. By default it's \fB0\fR. Each unit has a
 priority which is by default preset to the \fIINT\fR. It can be overridden
@@ -86,6 +101,7 @@ processed as the first.
   update_interval = 10
   recommend_command = 0
   reapply_sysctl = 1
+  reapply_sysctl_exclude = net.ipv4.ip_forward, net.bridge.bridge-nf-call-iptables
   default_instance_priority = 0
 .fi
 

--- a/tuned-main.conf
+++ b/tuned-main.conf
@@ -28,6 +28,14 @@ recommend_command = 1
 # override user-provided system sysctls.
 reapply_sysctl = 1
 
+# Sysctl parameters matching these patterns will be excluded from
+# reapplication even when reapply_sysctl is enabled. Useful for
+# protecting runtime sysctl changes made by Kubernetes CNI plugins
+# or other services that set sysctls dynamically.
+# Supports shell-style wildcards (*, ?, [seq]). Separated by , or ;
+# Example: net.ipv4.ip_forward, net.ipv6.conf.*.forwarding
+# reapply_sysctl_exclude =
+
 # Default priority assigned to instances
 default_instance_priority = 0
 

--- a/tuned/consts.py
+++ b/tuned/consts.py
@@ -130,6 +130,7 @@ CFG_SLEEP_INTERVAL = "sleep_interval"
 CFG_UPDATE_INTERVAL = "update_interval"
 CFG_RECOMMEND_COMMAND = "recommend_command"
 CFG_REAPPLY_SYSCTL = "reapply_sysctl"
+CFG_REAPPLY_SYSCTL_EXCLUDE = "reapply_sysctl_exclude"
 CFG_DEFAULT_INSTANCE_PRIORITY = "default_instance_priority"
 CFG_UDEV_BUFFER_SIZE = "udev_buffer_size"
 CFG_LOG_FILE_COUNT = "log_file_count"
@@ -166,6 +167,8 @@ CFG_FUNC_RECOMMEND_COMMAND = "getboolean"
 # reapply system sysctl
 CFG_DEF_REAPPLY_SYSCTL = True
 CFG_FUNC_REAPPLY_SYSCTL = "getboolean"
+# sysctl parameters to exclude from reapplication
+CFG_DEF_REAPPLY_SYSCTL_EXCLUDE = []
 # default instance priority
 CFG_DEF_DEFAULT_INSTANCE_PRIORITY = 0
 CFG_FUNC_DEFAULT_INSTANCE_PRIORITY = "getint"


### PR DESCRIPTION
## Summary

When `reapply_sysctl=1` (default), TuneD re-applies all system sysctl settings from `/run/sysctl.d/`, `/etc/sysctl.d/`, and `/etc/sysctl.conf` after profile switches. This breaks Kubernetes overlay networking because CNI plugins set `net.ipv4.ip_forward=1` at runtime, which gets overwritten by static `/etc/sysctl.d/` files.

This PR adds a `reapply_sysctl_exclude` configuration option to protect specific sysctls from reapplication while maintaining backward compatibility.

## Changes

- **tuned/consts.py**: Add `CFG_REAPPLY_SYSCTL_EXCLUDE` constant and default (empty list)
- **tuned/plugins/plugin_sysctl.py**: Add `_is_sysctl_excluded()` method using fnmatch for wildcard pattern matching, integrate into `_apply_sysctl_config_line()`
- **tuned-main.conf**: Add commented configuration option with documentation
- **man/tuned-main.conf.5**: Add man page entry with examples

## Features

- Comma or semicolon-separated list of sysctl patterns
- Shell-style wildcards support (`*`, `?`, `[seq]`) via Python's `fnmatch`
- Empty default preserves backward compatibility
- Debug logging when sysctls are skipped

## Example Configuration

```ini
# For Kubernetes nodes:
reapply_sysctl_exclude = net.ipv4.ip_forward, net.ipv6.conf.*.forwarding, net.bridge.bridge-nf-call-iptables
```

## Test Plan

- [ ] Verify pattern matching works with wildcards (e.g., `net.ipv6.conf.*.forwarding`)
- [ ] Verify exact matches work (e.g., `net.ipv4.ip_forward`)
- [ ] Verify sysctls NOT in the exclude list are still applied
- [ ] Verify empty config (default) maintains current behavior
- [ ] Verify debug logging when sysctls are skipped

## Related Issue

Fixes #816