### PR TITLE
openshift: include network-throughput profile

### DIFF
--- a/profiles/network-throughput/tuned.conf
+++ b/profiles/network-throughput/tuned.conf
@@ -7,6 +7,10 @@ summary=Optimize for streaming network throughput, generally only necessary on o
 include=throughput-performance
 
 [sysctl]
+# Sets tcp_notsent_lowat to a value intended to balance throughput and latency while limiting total socket memory usage.
+net.ipv4.tcp_notsent_lowat=131072
+# Disables slow start after a connection has been idle, allowing immediate maximum throughput upon resuming data transfer.
+net.ipv4.tcp_slow_start_after_idle=0
 # Increase kernel buffer size maximums.  Currently this seems only necessary at 40Gb speeds.
 #
 # The buffer tuning values below do not account for any potential hugepage allocation.

--- a/profiles/openshift/tuned.conf
+++ b/profiles/openshift/tuned.conf
@@ -4,7 +4,7 @@
 
 [main]
 summary=Optimize systems running OpenShift (parent profile)
-include=${f:virt_check:virtual-guest:throughput-performance}
+include=${f:virt_check:virtual-guest:network-throughput}
 
 [selinux]
 avc_cache_threshold=8192
@@ -17,10 +17,6 @@ kernel.pid_max=>4194304
 fs.aio-max-nr=>1048576
 net.netfilter.nf_conntrack_max=1048576
 net.ipv4.conf.all.arp_announce=2
-net.ipv4.tcp_notsent_lowat=131072
-net.ipv4.tcp_slow_start_after_idle=0
-net.ipv4.tcp_rmem="4096 131072 16777216"
-net.ipv4.tcp_wmem="4096 16384 16777216"
 net.ipv4.neigh.default.gc_thresh1=8192
 net.ipv4.neigh.default.gc_thresh2=32768
 net.ipv4.neigh.default.gc_thresh3=65536


### PR DESCRIPTION
Update network-throughput profile and drop now duplicate tuning from the openshift profile. Follows up the #809 and cleans the things a bit.