### PR TITLE
gh-actions: fix doc build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo apt install -y make asciidoctor
       - name: Build the manual
-        run: make -C doc/manual
+        run: make html
       - name: Prepare the website contents
         run: |
           git fetch origin gh-pages:gh-pages


### PR DESCRIPTION
The main Makefile needs to be called to correctly export all variables like the PYTHON.