### PR TITLE
 cpu: fix TypeError when load_threshold is set in a profil

### DIFF
--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -430,7 +430,13 @@ class CPULatencyPlugin(hotplug.Plugin):
 			return
 
 		load = instance._load_monitor.get_load()["system"]
-		if load < instance.options["load_threshold"]:
+		try:
+			load_threshold = float(instance.options["load_threshold"])
+		except (ValueError, TypeError):
+			log.error("invalid load_threshold value '%s', skipping dynamic latency update"
+					% instance.options["load_threshold"])
+			return
+		if load < load_threshold:
 			self._set_latency(instance.options["latency_high"])
 		else:
 			self._set_latency(instance.options["latency_low"])


### PR DESCRIPTION
Setting `load_threshold` in a profile's cpu section crashed dynamic tuning.

Credit to Lucas Kanashiro (@lucaskanashiro) for the original fix carried in Debian/Ubuntu.

fixes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU latency tuning robustness by adding proper validation of load threshold configuration settings. The system now gracefully handles missing or invalid threshold values with appropriate error logging, preventing unexpected behavior during dynamic tuning cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/tuned/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->