### PR TITLE
plugin_net: validate nf_conntrack_hashsize before converting to int

### DIFF
--- a/tuned/plugins/plugin_net.py
+++ b/tuned/plugins/plugin_net.py
@@ -503,7 +503,12 @@ class NetTuningPlugin(hotplug.Plugin):
 		if value is None:
 			return None
 
-		hashsize = int(value)
+		try:
+			hashsize = int(value)
+		except ValueError:
+			log.warning("nf_conntrack_hashsize value '%s' is not integer" % value)
+			return None
+
 		if hashsize >= 0:
 			if not sim:
 				self._cmd.write_to_file(self._nf_conntrack_hashsize_path(), hashsize, \

--- a/tuned/plugins/plugin_uncore.py
+++ b/tuned/plugins/plugin_uncore.py
@@ -127,7 +127,7 @@ class UncorePlugin(hotplug.Plugin):
 				return None
 
 			if freq_khz < initial_min_freq_khz:
-				log.info("%s: min_freq_khz %d value below initial_max_freq_khz - capped to %d" % (device, freq_khz, initial_min_freq_khz))
+				log.info("%s: min_freq_khz %d value below initial_min_freq_khz - capped to %d" % (device, freq_khz, initial_min_freq_khz))
 				freq_khz = initial_min_freq_khz
 
 		else:

--- a/tuned/plugins/plugin_video.py
+++ b/tuned/plugins/plugin_video.py
@@ -23,7 +23,7 @@ class VideoPlugin(base.Plugin):
 	* `dynpm`
 	* `dpm-battery`
 	* `dpm-balanced`
-	* `dpm-perfomance`
+	* `dpm-performance`
 
 	For additional detail, see
 	link:https://www.x.org/wiki/RadeonFeature/#kmspowermanagementoptions[KMS Power Management Options].


### PR DESCRIPTION
validate nf_conntrack_hashsize before converting to int

before the fix:
```
[root@localhost myprof]# cat tuned.conf
[main]
[vm]
transparent_hugepage=madvise

[net]
nf_conntrack_hashsize=abc

[sysctl]
vm.dirty_ratio = 20
[root@localhost myprof]# tuned-adm profile myprof
[root@localhost myprof]# tuned-adm verify
Verification failed, current system settings differ from the preset profile.
You can mostly fix this by restarting the TuneD daemon, e.g.:
  systemctl restart tuned
or
  service tuned restart
Sometimes (if some plugins like bootloader are used) a reboot may be required.
See TuneD log file ('/var/log/tuned/tuned.log') for details.
[root@localhost myprof]#
[root@localhost myprof]# tail -10f /var/log/tuned/tuned.log
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/tuned/plugins/base.py", line 606, in _verify_non_device_command
    new_value = command["set"](new_value, instance, True, False)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/tuned/plugins/plugin_net.py", line 503, in _set_nf_conntrack_hashsize
    hashsize = int(value)
               ^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'abc'
```

after this fix:
```
[root@localhost noarch]# tuned-adm profile myprof
[root@localhost noarch]# tuned-adm verify
Verification succeeded, current system settings match the preset profile.
See TuneD log file ('/var/log/tuned/tuned.log') for details.
[root@localhost noarch]# tail -f /var/log/tuned/tuned.log
2026-06-09 21:00:45,351 INFO     tuned.plugins.plugin_vm: Setting option 'dirty_ratio' to '20'
2026-06-09 21:00:45,352 INFO     tuned.profiles.loader: loading profile: myprof
2026-06-09 21:00:45,352 INFO     tuned.daemon.daemon: starting tuning
2026-06-09 21:00:45,356 INFO     tuned.plugins.base: instance net: assigning devices ens37, ens33
2026-06-09 21:00:45,358 WARNING  tuned.plugins.plugin_net: nf_conntrack_hashsize value 'abc' is not integer
2026-06-09 21:00:45,358 INFO     tuned.plugins.plugin_sysctl: reapplying system sysctl
2026-06-09 21:00:45,359 INFO     tuned.daemon.daemon: static tuning from profile 'myprof' applied
2026-06-09 21:00:52,027 INFO     tuned.daemon.daemon: verifying profile(s): myprof
2026-06-09 21:00:52,027 WARNING  tuned.plugins.plugin_net: nf_conntrack_hashsize value 'abc' is not integer
2026-06-09 21:00:52,027 INFO     tuned.plugins.base: verify: passed: 'vm.dirty_ratio' = '20'
```