### PR TITLE
vm.laptop_mode is deprecated in kernel 7.0

### DIFF
--- a/doc/TIPS.txt
+++ b/doc/TIPS.txt
@@ -19,8 +19,6 @@
 * Make sure writes to hd don't wake it up too quickly:
 ** Set flushing to once per 5 minutes
 ** echo "3000" > /proc/sys/vm/dirty_writeback_centisecs
-** Enable laptop mode
-** echo "5" > /proc/sys/vm/laptop_mode
 * Use relatime for your / partition
 ** mount -o remount,relatime / 
 * Enable USB autosuspend by adding the following to the kernel boot commandline:

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -37,7 +37,6 @@ panel_power_savings=3
 alpm=med_power_with_dipm
 
 [sysctl]
-vm.laptop_mode=5
 vm.dirty_writeback_centisecs=1500
 kernel.nmi_watchdog=0
 

--- a/profiles/spindown-disk/tuned.conf
+++ b/profiles/spindown-disk/tuned.conf
@@ -32,7 +32,6 @@ dirty_bytes=60%
 [sysctl]
 vm.dirty_writeback_centisecs=6000
 vm.dirty_expire_centisecs=9000
-vm.laptop_mode=5
 vm.swappiness=30
 
 [script]


### PR DESCRIPTION
vm.laptop_mode is deprecated in kernel 7.x ; let's remove it from the tuned profiles that previously leveraged it.

see original discussion in https://lore.kernel.org/all/20251216185201.GH905277@cmpxchg.org/T/#u
and the commit message from https://github.com/torvalds/linux/commit/64dd89ae01f2708a508e028c28b7906e4702a9a7


```
[clockfort@clockfort-nas ~]$ sudo dmesg | grep laptop_mode
[   18.978816] Thread-1 (_thre: vm.laptop_mode is deprecated. Ignoring setting.
```