### PR TITLE
network-latency: increase AVC cache to 8192

### DIFF
--- a/profiles/network-latency/tuned.conf
+++ b/profiles/network-latency/tuned.conf
@@ -23,3 +23,6 @@ kernel.timer_migration = 0
 cmdline_network_latency=skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1 rcutree.nohz_full_patience_delay=1000
 
 [rtentsk]
+
+[selinux]
+avc_cache_threshold=8192


### PR DESCRIPTION
Default setting for RHEL-9/10 kernels are 512 which can cause latency spikes for networking workloads.

Fixes #863