### PR TITLE
Fix NameError and retry decrement in udev event handler

### DIFF
--- a/tuned/hardware/inventory.py
+++ b/tuned/hardware/inventory.py
@@ -1,3 +1,5 @@
+import time
+
 import pyudev
 import tuned.logs
 from tuned import consts
@@ -65,7 +67,7 @@ class Inventory(object):
 		while not device.is_initialized and retry > 0:
 			log.debug("Device '%s' is uninitialized, waiting '%.2f' seconds for its initialization." % (device, consts.HOTPLUG_WAIT_FOR_DEV_INIT_DELAY))
 			time.sleep(consts.HOTPLUG_WAIT_FOR_DEV_INIT_DELAY)
-			retry =- 1
+			retry -= 1
 		if not device.is_initialized:
 			log.warn("Unsuccessfully waited for device '%s' initialization, continuing with uninitialized device, problems may occur." % device)
 


### PR DESCRIPTION
`Inventory._handle_udev_event()` waits for a hotplugged device to finish
initializing:

    retry = consts.HOTPLUG_WAIT_FOR_DEV_INIT_RETRIES
    while not device.is_initialized and retry > 0:
        log.debug(...)
        time.sleep(consts.HOTPLUG_WAIT_FOR_DEV_INIT_DELAY)
        retry =- 1

Two problems.

The module imports `pyudev`, `tuned.logs` and `consts`, but not `time`, so the
call to `time.sleep()` raises

    NameError: name 'time' is not defined

as soon as an uninitialized device appears. To reproduce, hotplug a device
whose udev initialization is not yet complete; the handler aborts before
dispatching the event to any subscribed plugin.

Second, `retry =- 1` is an assignment of `-1` rather than a decrement. Python
parses it as

    Assign([Name('retry')], UnaryOp(USub(), Constant(1)))

so the loop exits after a single iteration and
`HOTPLUG_WAIT_FOR_DEV_INIT_RETRIES` has no effect.

This imports `time` and uses the decrement operator. The second bug is only
reachable once the first is fixed, which is why both are in one patch.