### PR TITLE
Fix error responses in the unix socket exporter

### DIFF
--- a/tuned/exports/unix_socket_exporter.py
+++ b/tuned/exports/unix_socket_exporter.py
@@ -220,15 +220,15 @@ class UnixSocketExporter(interfaces.ExporterInterface):
 						data = json.loads(data)
 					except Exception as e:
 						log.error("Failed to load json data '%s': %s" % (data, e))
-						self._send_data(conn, self._create_error_responce(-32700, "Parse error", str(e)))
+						self._send_data(conn, self._create_error_responce(-32700, "Parse error", data=str(e)))
 						continue
 					if type(data) not in (tuple, list, dict):
 						log.error("Wrong format of call")
-						self._send_data(conn, self._create_error_responce(-32700, "Parse error", str(e)))
+						self._send_data(conn, self._create_error_responce(-32700, "Parse error", data="Wrong format of call"))
 						continue
 					if type(data) in (tuple, list):
 						if len(data) == 0:
-							self._send_data(conn, self._create_error_responce(-32600, "Invalid Request", str(e)))
+							self._send_data(conn, self._create_error_responce(-32600, "Invalid Request", data="Empty batch"))
 							continue
 						res = []
 						for req in data:


### PR DESCRIPTION
`_create_error_responce()` is declared as

    def _create_error_responce(self, code, message, id=None, data=None)

so its third positional argument is the request id. Three call sites in the
receive loop pass the detail string there instead of as `data`:

    self._create_error_responce(-32700, "Parse error", str(e))

The result is an error response whose `id` field holds an exception string and
whose `data` field is `None`. Line 187 in the same file shows the intended
form, passing `id` and then `str(e)`.

Two of those three sites are also outside the `except` block that binds `e`.
Python 3 deletes the name bound by `except ... as e` when the block exits, so
`e` is undefined there and the handler raises

    NameError: name 'e' is not defined

To reproduce, send the socket valid JSON that is neither an object nor an
array, such as `42`, or send an empty batch, `[]`. Instead of a JSON-RPC error
response the client receives nothing.

This passes the detail as `data=` at all three sites, with a literal
description at the two where no exception is in scope. The error codes are
unchanged.