### PR TITLE
Fix misspellings in user-visible messages

### DIFF
--- a/tuned/daemon/controller.py
+++ b/tuned/daemon/controller.py
@@ -67,7 +67,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
 				monitor.set_receive_buffer_size(udev_buffer_size)
 			except EnvironmentError:
 				log.warning("cannot set udev monitor receive buffer size, we are probably running inside " +
-					 "container or with limited capabilites, TuneD functionality may be limited")
+					 "container or with limited capabilities, TuneD functionality may be limited")
 			p = True
 			t = time.time()
 			try:

--- a/tuned/hardware/inventory.py
+++ b/tuned/hardware/inventory.py
@@ -29,7 +29,7 @@ class Inventory(object):
 				self._udev_monitor.set_receive_buffer_size(buffer_size)
 			except EnvironmentError:
 				log.warning("cannot set udev monitor receive buffer size, we are probably running inside " +
-					 "container or with limited capabilites, TuneD functionality may be limited")
+					 "container or with limited capabilities, TuneD functionality may be limited")
 
 		if monitor_observer_factory is None:
 			monitor_observer_factory = _MonitorObserverFactory()

--- a/tuned/plugins/plugin_cpu.py
+++ b/tuned/plugins/plugin_cpu.py
@@ -331,7 +331,7 @@ class CPULatencyPlugin(hotplug.Plugin):
 			log.debug("'%s' is not online, skipping" % device)
 			return False
 		if not self._cpu_has_scaling_governor(device):
-			log.debug("there is no scaling governor fo '%s', skipping" % device)
+			log.debug("there is no scaling governor for '%s', skipping" % device)
 			return False
 		return True
 

--- a/tuned/plugins/plugin_scheduler.py
+++ b/tuned/plugins/plugin_scheduler.py
@@ -1088,7 +1088,7 @@ class SchedulerPlugin(base.Plugin):
 			return False
 
 	def _cgroup_verify_affinity(self):
-		log.debug("Veryfying cgroups affinities")
+		log.debug("Verifying cgroups affinities")
 		ret = True
 		if self._affinity is not None and self._cgroup is not None and not self._cgroup in self._cgroups:
 			ret = ret and self._cgroup_verify_affinity_one(self._cgroup, self._affinity)

--- a/tuned/plugins/plugin_systemd.py
+++ b/tuned/plugins/plugin_systemd.py
@@ -111,7 +111,7 @@ class SystemdPlugin(base.Plugin):
 		if rollback == consts.ROLLBACK_FULL:
 			log.info("removing '%s' systemd tuning previously added by TuneD" % consts.SYSTEMD_CPUAFFINITY_VAR)
 			self._remove_systemd_tuning()
-			log.console("you may need to manualy run 'dracut -f' to update the systemd configuration in initrd image")
+			log.console("you may need to manually run 'dracut -f' to update the systemd configuration in initrd image")
 
 	# convert cpulist from systemd syntax to TuneD syntax and unpack it
 	def _cpulist_convert_unpack(self, cpulist):

--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -459,7 +459,7 @@ class Controller(exports.interfaces.ExportableInterface):
         if not self._profile_holds.has(cookie):
             raise dbus.exceptions.DBusException("No active hold for cookie '%s'" % cookie)
         if not self._profile_holds.check_caller(cookie, caller):
-            raise dbus.exceptions.DBusException("Cannot release a profile hold inititated by another process.")
+            raise dbus.exceptions.DBusException("Cannot release a profile hold initiated by another process.")
         self._profile_holds.remove(cookie)
 
     @exports.signal("u")


### PR DESCRIPTION
Six messages that reach users contain typos:

    ppd/controller.py       "hold inititated by another process"
    plugins/plugin_systemd  "you may need to manualy run 'dracut -f'"
    daemon/controller.py    "with limited capabilites"
    hardware/inventory.py   "with limited capabilites"
    plugins/plugin_sched.   "Veryfying cgroups affinities"
    plugins/plugin_cpu.py   "no scaling governor fo '%s'"

Two of these are more than cosmetic. The first is the message body of a
`DBusException`, so it is surfaced by any client of tuned-ppd, and the second
is emitted with `log.console()`, which writes to the terminal of whoever ran
`tuned-adm`.

The "limited capabilites" warning is duplicated verbatim in
`daemon/controller.py` and `hardware/inventory.py`, so both copies are
corrected together.

Only message text is changed; no logic is touched.

This touches `tuned/hardware/inventory.py`, which #869 also modifies, but on
different lines — the two merge cleanly in either order.