### PR TITLE
Add zsh completion for `tuned` and `tuned-adm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ TUNED_USER_PROFILES_DIR = $(TUNED_CFG_DIR)/profiles
 TUNED_RECOMMEND_DIR = $(TUNED_SYSTEM_DIR)/recommend.d
 TUNED_USER_RECOMMEND_DIR = $(TUNED_CFG_DIR)/recommend.d
 BASH_COMPLETIONS = $(DATADIR)/bash-completion/completions
+ZSH_COMPLETIONS = $(DATADIR)/zsh/site-functions
 PPD_BUS_NAMES = org.freedesktop.UPower.PowerProfiles net.hadess.PowerProfiles
 
 copy_executable = install -Dm 0755 $(1) $(2)
@@ -73,10 +74,10 @@ release-cp: release-dir
 	cp -a AUTHORS COPYING INSTALL README.md $(VERSIONED_NAME)
 
 	cp -a tuned.py tuned.spec tuned.service tuned.tmpfiles Makefile tuned-adm.py \
-		tuned-adm.bash dbus.conf recommend.conf tuned-main.conf 00_tuned.grub \
-		00-tuned.conf.systemd 92-tuned.install bootcmdline modules.conf \
-		com.redhat.tuned.policy tuned-gui.py tuned-gui.glade tuned-ppd.py \
-		tuned-gui.desktop functions $(VERSIONED_NAME)
+		tuned-adm.bash tuned.zsh tuned-adm.zsh dbus.conf recommend.conf \
+		tuned-main.conf 00_tuned.grub 00-tuned.conf.systemd 92-tuned.install \
+		bootcmdline modules.conf com.redhat.tuned.policy tuned-gui.py \
+		tuned-gui.glade tuned-ppd.py tuned-gui.desktop functions $(VERSIONED_NAME)
 	cp -a doc experiments libexec man profiles systemtap tuned contrib icons \
 		tests $(VERSIONED_NAME)
 
@@ -207,6 +208,10 @@ install: install-dirs
 
 	# bash completion
 	install -Dpm 0644 tuned-adm.bash $(DESTDIR)$(BASH_COMPLETIONS)/tuned-adm
+
+	# zsh completion
+	install -Dpm 0644 tuned.zsh $(DESTDIR)$(ZSH_COMPLETIONS)/_tuned
+	install -Dpm 0644 tuned-adm.zsh $(DESTDIR)$(ZSH_COMPLETIONS)/_tuned-adm
 
 	# runtime directory
 	install -Dpm 0644 tuned.tmpfiles $(DESTDIR)$(TMPFILESDIR)/tuned.conf

--- a/tuned-adm.zsh
+++ b/tuned-adm.zsh
@@ -1,0 +1,64 @@
+#compdef tuned-adm
+
+_tuned-adm()
+{
+    # local variables needed by _arguments
+    local context state state_descr line
+    typeset -A opt_args
+
+    local -a subcmds=('list:list available profiles or plugins'
+                      'active:show active profile'
+                      'off:switch off all tunings'
+                      'profile:switch to a given profile'
+                      'profile_info:show information about given/current profile'
+                      'recommend:recommend profile'
+                      'verify:verify profile'
+                      'auto_profile:enable automatic profile selection mode'
+                      'profile_mode:show current profile selection mode'
+                      'instance_acquire_devices:assign other instances'\'' devices to the given instance'
+                      'get_instances:list active instances of a given plugin'
+                      'instance_get_devices:list devices assigned to a given instance')
+    local -a profiles=("${(f)$(find /usr/lib/tuned/profiles /etc/tuned/profiles -mindepth 1 -maxdepth 1 -type d -printf '%f\n')}")
+    local -a loglevels=('debug' 'info' 'warn' 'error' 'console' 'none')
+
+    # The first two arrays below are named differently so that they cannot be
+    # completed by using 'global' or 'none' as a subcommand
+    local -a global_args=('(- :)'{-h,--help}'[show help message and exit]')
+    local -a none_args=('(-t --timeout)'{-t+,--timeout=}'[use timeout for sync operation (default 600s)]:timeout:()'
+                        '(-l --loglevel)'{-l+,--loglevel=}'[level of log messages to capture]:log level:->loglevel'
+                        '(-a --async)'{-a,--async}'[with dbus, don'\''t wait for completion and return immediately]'
+                        '(-d --debug)'{-d,--debug}'[show debug messages]'
+                        '(- :)'{-v,--version}'[show program'\''s version number and exit]'
+                        '1:subcommand:->subcmd'
+                        '*:args:->args')
+    local -a args_list=('(-v --verbose)'{-v,--verbose}'[show plugin configuration parameters]'
+                        '2:listmode:(plugins profiles)')
+    local -a args_profile=('*:profile:->profile')
+    local -a args_profile_info=('*:profile:->profile')
+    local -a args_verify=('(-i --ignore-missing)'{-i,--ignore-missing}'[do not treat missing/unsupported tunings as errors]')
+    local -a args_instance_acquire_devices=('2:devices'
+                                            '3:instance')
+    local -a args_get_instances=('2:plugin name')
+    local -a args_instance_get_devices=('2:instance')
+
+    _arguments -C -A '-*' -s -S "${none_args[@]}" "${global_args[@]}" && return 0
+
+    case "$state" in
+        (subcmd)
+            _describe 'subcommand' subcmds
+            return 0
+            ;;
+        (args)
+            local name="args_${line[1]}"
+            [[ "${#${(P)name}[@]}" -eq 0 ]] && return 1
+            _arguments -s -S "${global_args[@]}" "${${(P)name}[@]}" && return 0
+            ;;
+    esac
+
+    case "$state" in
+        (profile) _values 'profile' "${profiles[@]}" ;;
+        (loglevel) _values 'loglevel' "${loglevels[@]}" ;;
+    esac
+
+    return 0
+}

--- a/tuned.spec
+++ b/tuned.spec
@@ -465,6 +465,8 @@ fi
 %exclude %{docdir}/README.NFV
 %doc %{docdir}
 %{_datadir}/bash-completion/completions/tuned-adm
+%{_datadir}/zsh/site-functions/_tuned
+%{_datadir}/zsh/site-functions/_tuned-adm
 %if %{with python3}
 %exclude %{python3_sitelib}/tuned/gtk
 %{python3_sitelib}/tuned

--- a/tuned.zsh
+++ b/tuned.zsh
@@ -1,0 +1,31 @@
+#compdef tuned
+
+_tuned()
+{
+    # local variables needed by _arguments
+    local context state state_descr line
+    typeset -A opt_args
+
+    local -a profiles=("${(f)$(find /usr/lib/tuned/profiles /etc/tuned/profiles -mindepth 1 -maxdepth 1 -type d -printf '%f\n')}")
+
+    local -a global_args=('(-d --daemon)'{-d,--daemon}'[run in background]'
+                          '(-D --debug)'{-D,--debug}'[show/log debugging messages]'
+                          '(-l --log)'{-l,--log}'[use log file]::path:_files'
+                          '(-P --pid)'{-P,--pid}'[use PID file]::path:_files'
+                          '(-p --profile)'{-p+,--profile=}'[tuning profile to be activated]:profile:->profile'
+                          '(- :)'{-h,--help}'[show help message and exit]'
+                          '(- :)'{-v,--version}'[show program'\''s version number and exit]'
+                          '--no-dbus[do not attach to Dbus]'
+                          '--no-socket[do not attach to socket]')
+
+    # The lack of a delimiter for path options is intentional -- if a filepath
+    # is adjacent to an equals sign, then tilde expansion will not occur
+
+    _arguments -s -S "${global_args[@]}" && return 0
+
+    case "$state" in
+        (profile) _values 'profile' "${profiles[@]}" ;;
+    esac
+
+    return 0
+}


### PR DESCRIPTION
Each subcommand and its corresponding options can be completed. This includes tuning profiles, but does not include devices, instances, or plugins.

It took a while to figure out that `-A '-*'` is needed for the first invocation of `_arguments` to prevent collisions between the different levels of arguments.