### PR TITLE
ppd: map ACPI quiet platform profile to PPD power saver

### DIFF
--- a/tuned/ppd/controller.py
+++ b/tuned/ppd/controller.py
@@ -25,6 +25,7 @@ UPOWER_DBUS_INTERFACE = "org.freedesktop.UPower"
 PLATFORM_PROFILE_PATH = "/sys/firmware/acpi/platform_profile"
 PLATFORM_PROFILE_MAPPING = {
     "low-power": PPD_POWER_SAVER,
+    "quiet": PPD_POWER_SAVER,
     "balanced": PPD_BALANCED,
     "performance": PPD_PERFORMANCE
 }


### PR DESCRIPTION
## Description

The `powersave` profile already accepts the acpi platform profile `quiet` (`platform_profile=low-power|quiet`), but the hardcoded `PLATFORM_PROFILE_MAPPING` in `tuned/ppd/controller.py` does not know about it. Laptops exposing a `quiet` acpi platform profile (e.g. asus tuf gaming f15) therefore fall back to the `unknown` profile when the user selects quiet mode, ignoring the configured power saver profile.

## Change

Add the missing mapping so that selecting the `quiet` platform profile switches tuned-ppd to the power saver profile, matching the existing `low-power` behavior:

```python
PLATFORM_PROFILE_MAPPING = {
    "low-power": PPD_POWER_SAVER,
    "quiet": PPD_POWER_SAVER,
    "balanced": PPD_BALANCED,
    "performance": PPD_PERFORMANCE
}
```

## Why

This is a user-visible behavior improvement for laptops exposing a `quiet` acpi profile (asus, some lenovo). Users currently have to patch `controller.py` manually after every update to get this working (see the workaround referenced in #853).

## Notes

- `quiet` does not appear in kde's control center. kde only exposes the three standard ppd profiles (power-saver, balanced, performance).
- the `quiet` profile comes from the kernel via the acpi platform profile interface (`/sys/firmware/acpi/platform_profile_choices` on asus tuf laptops). the fn+f5 hardware key cycles `quiet` -> `balanced` -> `performance` at the kernel level, which is the kernel initiated path `PLATFORM_PROFILE_MAPPING` exists for (same mechanism as the thinkpad fn+l handling).
- the ppd to tuned mapping in `ppd.conf` needs no change. `power-saver=powersave` already exists. the only missing piece is the acpi to ppd hop. with `quiet` unmapped, `check_platform_profile()` returns early and keeps the previous profile, so fn+f5 skips power-saver entirely.

Fixes #853
