### PR TITLE
spec: Require rpm-ostree on image mode (bootc) systems

### DIFF
--- a/tuned.spec
+++ b/tuned.spec
@@ -134,6 +134,12 @@ Recommends: subscription-manager
 Requires: python3-syspurpose
 %endif
 %endif
+# On image mode (bootc) systems, rpm-ostree is needed by the bootloader
+# plugin for kernel argument management when bootc's native
+# set-options-for-source is not yet available
+%if 0%{?fedora} || 0%{?rhel} >= 9
+Requires: (rpm-ostree if bootc)
+%endif
 
 %description
 The tuned package contains a daemon that tunes system settings dynamically.


### PR DESCRIPTION
On image mode systems, the bootloader plugin needs rpm-ostree for kernel
argument management when bootc's native set-options-for-source is not yet
available. Without it, tuned fails to apply profiles correctly.

Add a rich dependency `Requires: (rpm-ostree if bootc)` so that rpm-ostree
is a hard requirement when bootc is installed, and ignored on traditional
systems.

Resolves: RHEL-224327