### PR TITLE
fix: initialize `_devices_supported` in `Plugin.__init__`

### DIFF
--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -63,6 +63,39 @@ class PluginBaseTestCase(unittest.TestCase):
 		self._plugin.destroy_instance(instance)
 		self.assertIn(instance,self._plugin.cleaned_instances)
 
+	def test_destroy_instance_without_init_devices(self):
+		"""Destroying an instance must not require init_devices() first.
+
+		Regression guard for behaviour that has since been fixed. Before
+		_devices_supported was initialised in Plugin.__init__, it was created
+		only by _init_devices(), which runs only via init_devices(), while
+		release_devices() read it unconditionally -- so an instance destroyed
+		before init_devices() had run raised AttributeError. That happened in
+		practice when create() failed part way through: the instances already
+		made were torn down by plugins whose init_devices() had never been
+		reached, and every one of them raised again in cleanup.
+		"""
+		instance = self._plugin.create_instance(\
+			'first_instance',0,'test','test','test','test',\
+			{'default_option1':'default_value2'})
+
+		# deliberately no instance.plugin.init_devices() here
+		self._plugin.destroy_instance(instance)
+		self.assertIn(instance,self._plugin.cleaned_instances)
+
+	def test_assign_free_devices_without_init_devices(self):
+		"""Assigning devices must not require init_devices() first.
+
+		Regression guard for the same fixed behaviour: assign_free_devices()
+		read _devices_supported unguarded, exactly as release_devices() did.
+		"""
+		instance = self._plugin.create_instance(\
+			'first_instance',0,'test','test','test','test',\
+			{'default_option1':'default_value2'})
+
+		# deliberately no instance.plugin.init_devices() here
+		self._plugin.assign_free_devices(instance)
+
 	def test_get_matching_devices(self):
 		""" without udev regex """
 		instance = self._plugin.create_instance(\

--- a/tuned/plugins/base.py
+++ b/tuned/plugins/base.py
@@ -36,6 +36,7 @@ class Plugin(object):
 		self._variables = variables
 		self._has_dynamic_options = False
 		self._devices_inited = False
+		self._devices_supported = False
 
 		self._options_used_by_dynamic = self._get_config_options_used_by_dynamic()
 


### PR DESCRIPTION
## What

`_devices_supported` is created in `_init_devices()`, which runs only from `init_devices()` and only when `_devices_inited` is `False`. Three methods read it without checking whether that has happened:

| method | line |
| :--- | :--- |
| `assign_free_devices()` | `tuned/plugins/base.py:168` |
| `release_devices()` | `tuned/plugins/base.py:186` |
| `_run_for_each_device()` | `tuned/plugins/base.py:204` |

Any plugin reaching one of them before `init_devices()` has run raises:

```
AttributeError: '<Name>Plugin' object has no attribute '_devices_supported'.
Did you mean: '_devices_inited'?
```

In `units/manager.py:create()`, `init_devices()` and `assign_free_devices()` are called per instance in the same loop, so an exception part way through leaves the instances already created to be torn down by plugins whose `init_devices()` was never reached. Each of those raises again during cleanup, via `cleanup()` -> `destroy_instances()` -> `_destroy_instance()` -> `release_devices()`.

## Why it is worth fixing

The exceptions are caught and logged as `BUG: Unhandled exception in destroy_all: ...`, the daemon continues, and it then reports:

```
static tuning from profile '<profile>' applied
```

**The settings owned by the failed plugins are silently not applied while the daemon reports success.** Nothing downstream can tell the difference. On 2.27.0 this hit four plugins in a single run -- `sysfs`, `sysctl`, `scsi_host` and `cpu` -- and the only visible symptom was that `[sysfs]` entries in the profile never took effect; the daemon's own status said the  rofile had been applied.

## Reproducing

Rapid repeated profile switching is what triggered it in the field (a second profile-management daemon was switching profiles underneath TuneD). It is simpler to provoke directly: construct a plugin, create an instance, and destroy it without calling `init_devices()` -- which is what the two tests added here do.

`test_destroy_instance()` does not catch it because it calls `instance.plugin.init_devices()` explicitly before destroying, which primes the attribute. The new tests take the path that does not.

## The change

One line, beside `_devices_inited` in the constructor, so the invariant lives in one place:

```python
self._devices_inited = False
self._devices_supported = False
```

Guarding each of the three readers on `_devices_inited` instead would work equally well and is arguably more explicit about the invariant. That seemed the larger change for the same result -- happy to switch if you prefer it.

## Tests

Both new tests fail on unmodified master with the `AttributeError` above and pass with the change. Full suite: 136 tests before, 138 after, all passing.

Tested against master (2.28.0-rc.1); originally observed on 2.27.0 with Python 3.13.
