### PR TITLE
hardware: do not traceback on invalid devices_udev_regex

### DIFF
--- a/tests/unit/hardware/test_device_matcher_udev.py
+++ b/tests/unit/hardware/test_device_matcher_udev.py
@@ -34,3 +34,19 @@ class DeviceMatcherUdevTestCase(unittest.TestCase):
 				"/sys/devices/virtual/tty/tty0")
 		self.assertTrue(self.matcher.match("tty.", device))
 		self.assertFalse(self.matcher.match("tty[1-9]", device))
+
+	def test_invalid_regex_does_not_traceback(self):
+		# An invalid devices_udev_regex must not raise re.error and break
+		# profile application; it should be reported and treated as no match.
+		class FakeProperties(dict):
+			pass
+		class FakeDevice:
+			def __init__(self):
+				self.sys_name = "fakedev"
+				self.properties = FakeProperties({"ID_MODEL": "foo"})
+			def items(self):
+				return self.properties.items()
+		device = FakeDevice()
+		self.assertFalse(self.matcher.match("[", device))
+		self.assertFalse(self.matcher.match("(a", device))
+		self.assertFalse(self.matcher.match("*", device))

--- a/tuned/hardware/device_matcher_udev.py
+++ b/tuned/hardware/device_matcher_udev.py
@@ -1,7 +1,10 @@
 from . import device_matcher
 import re
+import tuned.logs
 
 __all__ = ["DeviceMatcherUdev"]
+
+log = tuned.logs.get()
 
 class DeviceMatcherUdev(device_matcher.DeviceMatcher):
 	def match(self, regex, device):
@@ -24,4 +27,8 @@ class DeviceMatcherUdev(device_matcher.DeviceMatcher):
 		for key, val in sorted(list(items)):
 			properties += key + '=' + val + '\n'
 
-		return re.search(regex, properties, re.MULTILINE) is not None
+		try:
+			return re.search(regex, properties, re.MULTILINE) is not None
+		except re.error:
+			log.error("Invalid regular expression in devices_udev_regex: '%s'" % regex)
+			return False

--- a/tuned/utils/profile_recommender.py
+++ b/tuned/utils/profile_recommender.py
@@ -123,7 +123,7 @@ class ProfileRecommender:
 					r = re.compile(r",[^,]*$")
 					matching_profile = r.sub("", section)
 					break
-		except (IOError, OSError, Error) as e:
+		except (IOError, OSError, Error, re.error) as e:
 			log.error("error processing '%s', %s" % (fname, e))
 		return matching_profile
 


### PR DESCRIPTION
The `devices_udev_regex` profile option (also settable through the `instance_create` D-Bus method) is used verbatim as a regular expression in `DeviceMatcherUdev.match` (`tuned/hardware/device_matcher_udev.py`). An invalid regex raised an unhandled `re.error` that propagated through `assign_free_devices` / `instance_apply_tuning` and broke profile application (and the `instance_create` D-Bus method).

This catches `re.error`, logs it and treats the device as non-matching, mirroring the fix already applied for `lscpu_check` in e83a746 (PR #867).

It also extends `ProfileRecommender.process_config` to catch `re.error`, so an invalid regex in `recommend.conf` (reachable through the unauthenticated `recommend_profile` D-Bus method) no longer crashes profile recommendation.

**Reproducer** (invalid regex):
```
devices_udev_regex=[
```
Before: `re.error: unterminated character set` traceback breaks profile apply. After: error is logged, the device is treated as non-matching.

A unit test `test_invalid_regex_does_not_traceback` is added.

Related: #867 (lscpu_check: do not traceback on invalid regex).