### PR TITLE
Fix completions to obey customized profile directories

### DIFF
--- a/tuned-adm.bash
+++ b/tuned-adm.bash
@@ -1,5 +1,36 @@
 # bash completion for tuned-adm
 
+_tuned-adm_get-profiles()
+{
+    local config_file='/etc/tuned/tuned-main.conf'
+    local curV="$(tuned --version)"  # Convert to lowercase to be safe (below)
+    local minV='tuned 2.23.0'
+    local versions="$minV"$'\n'"${curV,,?}"
+    local profile_dirs  # Default value
+
+    # (GNU version of `sort` is needed for this)
+    if [[ "$versions" != "$(sort --version-sort <<<"$versions")" ]]; then
+        profile_dirs='/usr/lib/tuned,/etc/tuned'
+    else
+        profile_dirs='/usr/lib/tuned/profiles,/etc/tuned/profiles'
+
+        # Find `profile_dirs` definition (only supported >=v2.23.0)
+        if [[ -f "$config_file" ]] && [[ -r "$config_file" ]]; then
+            parsed_dirs="$(grep -E '^profile_dirs\s*=\s*.*$' "$config_file")"
+
+            [[ -n "$parsed_dirs" ]] &&
+                profile_dirs="$(sed -En 's/profile_dirs\s*=\s*(.*)$/\1/p' <<<"${parsed_dirs##*$'\n'}")"
+        fi
+    fi
+
+    # Print list of profiles
+    local IFS=',;'
+    [[ -n "$profile_dirs" ]] &&
+        find $profile_dirs -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null
+    return 0
+}
+
+
 _tuned_adm()
 {
 	local commands="active list off profile recommend verify --version -v --help -h auto_profile profile_mode profile_info"
@@ -7,9 +38,9 @@ _tuned_adm()
 	_init_completion || return
 
 	if [[ "$cword" -eq 1 ]]; then
-		COMPREPLY=( $(compgen -W "$commands" -- "$cur" ) )
+		COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
 	elif [[ "$cword" -eq 2 && ("$prev" == "profile" || "$prev" == "profile_info") ]]; then
-		COMPREPLY=( $(compgen -W "$(command find /usr/lib/tuned/profiles /etc/tuned/profiles -mindepth 1 -maxdepth 1 -type d -printf "%f\n")" -- "$cur" ) )
+        COMPREPLY=( $(compgen -W "$(_tuned-adm_get-profiles)" -- "$cur") )
 	else
 		COMPREPLY=()
 	fi

--- a/tuned-adm.zsh
+++ b/tuned-adm.zsh
@@ -1,5 +1,35 @@
 #compdef tuned-adm
 
+_tuned-adm_get-profiles()
+{
+    local config_file='/etc/tuned/tuned-main.conf'
+    local curV="${(L)$(tuned --version)}"  # Convert to lowercase to be safe
+    local minV='tuned 2.23.0'
+    local versions="$minV"$'\n'"$curV"
+    local profile_dirs  # Default value
+
+    # (GNU version of `sort` is needed for this)
+    if [[ "$versions" != "$(sort --version-sort <<<"$versions")" ]]; then
+        profile_dirs='/usr/lib/tuned,/etc/tuned'
+    else
+        profile_dirs='/usr/lib/tuned/profiles,/etc/tuned/profiles'
+
+        # Find `profile_dirs` definition (only supported >=v2.23.0)
+        if [[ -f "$config_file" ]] && [[ -r "$config_file" ]]; then
+            parsed_dirs="$(grep -E '^profile_dirs\s*=\s*.*$' "$config_file")"
+
+            [[ -n "$parsed_dirs" ]] &&
+                profile_dirs="$(sed -En 's/profile_dirs\s*=\s*(.*)$/\1/p' <<<"${parsed_dirs##*$'\n'}")"
+        fi
+    fi
+
+    # Print list of profiles
+    local IFS=',;'
+    find "${=profile_dirs}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null
+    return 0
+}
+
+
 _tuned-adm()
 {
     # local variables needed by _arguments
@@ -18,7 +48,6 @@ _tuned-adm()
                       'instance_acquire_devices:assign other instances'\'' devices to the given instance'
                       'get_instances:list active instances of a given plugin'
                       'instance_get_devices:list devices assigned to a given instance')
-    local -a profiles=("${(f)$(find /usr/lib/tuned/profiles /etc/tuned/profiles -mindepth 1 -maxdepth 1 -type d -printf '%f\n')}")
     local -a loglevels=('debug' 'info' 'warn' 'error' 'console' 'none')
 
     # The first two arrays below are named differently so that they cannot be
@@ -56,7 +85,7 @@ _tuned-adm()
     esac
 
     case "$state" in
-        (profile) _values 'profile' "${profiles[@]}" ;;
+        (profile) _values 'profile' "${(f)$(_tuned-adm_get-profiles)}" ;;
         (loglevel) _values 'loglevel' "${loglevels[@]}" ;;
     esac
 

--- a/tuned.zsh
+++ b/tuned.zsh
@@ -1,12 +1,40 @@
 #compdef tuned
 
+_tuned_get-profiles()
+{
+    local config_file='/etc/tuned/tuned-main.conf'
+    local curV="${(L)$(tuned --version)}"  # Convert to lowercase to be safe
+    local minV='tuned 2.23.0'
+    local versions="$minV"$'\n'"$curV"
+    local profile_dirs  # Default value
+
+    # (GNU version of `sort` is needed for this)
+    if [[ "$versions" != "$(sort --version-sort <<<"$versions")" ]]; then
+        profile_dirs='/usr/lib/tuned,/etc/tuned'
+    else
+        profile_dirs='/usr/lib/tuned/profiles,/etc/tuned/profiles'
+
+        # Find `profile_dirs` definition (only supported >=v2.23.0)
+        if [[ -f "$config_file" ]] && [[ -r "$config_file" ]]; then
+            parsed_dirs="$(grep -E '^profile_dirs\s*=\s*.*$' "$config_file")"
+
+            [[ -n "$parsed_dirs" ]] &&
+                profile_dirs="$(sed -En 's/profile_dirs\s*=\s*(.*)$/\1/p' <<<"${parsed_dirs##*$'\n'}")"
+        fi
+    fi
+
+    # Print list of profiles
+    local IFS=',;'
+    find "${=profile_dirs}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null
+    return 0
+}
+
+
 _tuned()
 {
     # local variables needed by _arguments
     local context state state_descr line
     typeset -A opt_args
-
-    local -a profiles=("${(f)$(find /usr/lib/tuned/profiles /etc/tuned/profiles -mindepth 1 -maxdepth 1 -type d -printf '%f\n')}")
 
     local -a global_args=('(-d --daemon)'{-d,--daemon}'[run in background]'
                           '(-D --debug)'{-D,--debug}'[show/log debugging messages]'
@@ -24,7 +52,7 @@ _tuned()
     _arguments -s -S "${global_args[@]}" && return 0
 
     case "$state" in
-        (profile) _values 'profile' "${profiles[@]}" ;;
+        (profile) _values 'profile' "${(f)$(_tuned_get-profiles)}" ;;
     esac
 
     return 0


### PR DESCRIPTION
Instead of only the old directories, `/usr/lib/tuned/profiles,/etc/tuned/profiles`, use the `profile_dir` option in the configuration file (the default being the old constant value) or `/usr/lib/tuned,/etc/tuned` if on a version of `tuned` that doesn't support it.

Fixes #881